### PR TITLE
Add probe dev CLI; document Qwen native format + llama-cpp-2 findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,6 +5176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "probe"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "llama-cpp-2",
+ "serde_json",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-    "chatbot", "framework",
+    "chatbot", "framework", "probe",
 ]
 resolver = "3"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Rust-based Discord chatbot powered by a local Large Language Model, featuring 
 This is a multi-component project that provides a sophisticated AI chatbot experience:
 
 - **Discord Integration**: Responds to direct messages and mentions
-- **Local LLM**: Uses Qwen2.5-14B-Instruct running locally via llama.cpp
+- **Local LLM**: Uses Qwen3.6-27B running locally via llama.cpp
 - **Tool Calling**: Supports multi-turn tool execution (weather, web search, etc.)
 - **Memory Systems**: Short-term and long-term memory via LanceDB with embeddings
 - **Type-Safe Architecture**: Built on a custom Rust state machine framework
@@ -18,23 +18,25 @@ This is a multi-component project that provides a sophisticated AI chatbot exper
 bot/
 ├── chatbot/                 # Main Discord chatbot application
 │   ├── src/
-│   │   ├── agents/         # Thinking and executor agents
+│   │   ├── agents/         # Primary agent (single model, structured output)
 │   │   ├── externals/       # External operations (LLM, tools, memory)
 │   │   ├── models/         # Data models
 │   │   ├── services/       # External service integrations
 │   │   ├── state_machines/ # User and bot state machines
-│   │   ├── agents.rs       # Agent traits and implementation
+│   │   ├── agents.rs       # Agent abstraction + inference
 │   │   ├── main.rs         # Entry point
 │   │   └── configuration.rs
 │   ├── grammars/           # GBNF grammars for structured output
 │   ├── models/             # GGUF model files
+│   ├── model_reference/    # Per-family prompt/tool-calling notes (e.g. qwen.md)
 │   ├── resources/          # Session caches and resources
 │   ├── Dockerfile          # Multi-stage build
 │   ├── Dockerfile.base     # Base image with Rust + llama.cpp
 │   ├── Cargo.toml          # Workspace member
 │   └── Justfile            # Build automation
 │
-└── framework/              # Reusable state machine library
+├── framework/              # Reusable state machine library
+└── probe/                  # Minimal local CLI to visualize raw model behavior (dev tool)
 ```
 
 ## Components
@@ -46,8 +48,8 @@ The main application that orchestrates:
 - **DiscordService**: Handles WebSocket events and HTTP via `serenity`
 - **LlamaCppService**: Manages local LLM inference with session caching
 - **LanceService**: Vector database for memory/embedding storage
-- **Thinking Agent**: Decision-making based on conversation context
-- **Executor Agent**: Tool execution and response formatting
+- **Primary Agent**: Single model that decides and emits the structured tool call directly
+  (the former separate "executor" translation agent has been removed)
 
 #### Available Tools
 
@@ -73,19 +75,19 @@ A reusable Rust library providing:
 ### Agent Flow
 
 ```
-User Message → DiscordService → UserStateMachine → ThinkingAgent
+User Message → DiscordService → UserStateMachine → PrimaryAgent
                                                     ↓
                               ┌─────────────────────┼─────────────────────┐
                               ↓                     ↓                     ↓
                       message-user            Tool Call            Recall Memory
                               ↓                     ↓                     ↓
-                      DiscordService         ExecutorAgent         LanceService
+                      DiscordService         (execute tool)        LanceService
                               ↓                     ↓                     ↓
                               └─────────────────────┼─────────────────────┘
                                                     ↓
-                                              Final Response
+                                            back to PrimaryAgent
                                                     ↓
-                                              DiscordService
+                                              Final Response → DiscordService
 ```
 
 ### State Machine Framework
@@ -121,7 +123,7 @@ just deploy_local
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MODEL_PATH` | Path to GGUF model | `models/Llama-3.3-70B-Instruct-Q4_K_M.gguf` |
+| `PRIMARY_MODEL_PATH` | Path to GGUF model | `models/Qwen3.6-27B-Q4_K_M.gguf` |
 | `RUST_LOG` | Log level | `info` |
 
 ## Dependencies

--- a/chatbot/model_reference/qwen.md
+++ b/chatbot/model_reference/qwen.md
@@ -88,9 +88,9 @@ Reminder:
   </tool_response><|im_end|>
   ```
 
-> **Parsing is the harness's job.** llama.cpp's *server* parses `<tool_call>` for you; the
-> embedded library (what `llama-cpp-2` wraps) does not — we parse the `<function=…><parameter=…>`
-> blocks ourselves in Rust.
+> **The binding parses for us.** `llama-cpp-2` 0.1.146 exposes `parse_response_oaicompat`, which
+> turns the raw `<tool_call>` output into structured `tool_calls` JSON — no hand-written XML parser
+> needed. (See the "Driving it via llama-cpp-2" section below.)
 
 ---
 
@@ -173,6 +173,58 @@ loop:
 
 ---
 
+## Driving it via `llama-cpp-2` (v0.1.146) — confirmed working
+
+The Rust binding wraps llama.cpp's `common_chat` machinery, so we do NOT hand-render ChatML or
+hand-parse tool calls. Verified end-to-end with the `probe/` crate.
+
+**Render** — get the embedded template, then render with tools:
+- `model.chat_template(None)` → `LlamaChatTemplate` (the model's own template).
+- `model.apply_chat_template_with_tools_oaicompat(tmpl, &[LlamaChatMessage], tools_json, json_schema, add_gen)`
+  — simple path; messages are role+content; **no** `reasoning_format`.
+- `model.apply_chat_template_oaicompat(tmpl, &OpenAIChatTemplateParams { messages_json, tools_json,
+  reasoning_format, enable_thinking, use_jinja, add_generation_prompt, parse_tool_calls, … })`
+  — params path; messages are an OpenAI-style **JSON array string**; supports `reasoning_format`
+  ("auto" | "deepseek" | "deepseek-legacy" | "none").
+
+Both return `ChatTemplateResult { prompt, grammar, grammar_lazy, grammar_triggers, parser,
+chat_format, generation_prompt, parse_tool_calls, … }`:
+- `prompt` — rendered ChatML to feed the model.
+- `grammar` (+ `grammar_lazy`, `grammar_triggers`) — auto-generated tool-call grammar, lazily
+  triggered by `<tool_call>`: free text flows + stops on EOS, grammar constrains only tool-call
+  args. Optional — Qwen emits valid calls without it; apply it to *enforce* well-formed calls.
+- `parser` / `chat_format` — consumed by the response parser.
+
+**Parse** — the binding does it: `rendered.parse_response_oaicompat(raw_output, is_partial)` →
+an OpenAI-style message JSON:
+```json
+{"role":"assistant","reasoning_content":"…","content":"","tool_calls":[
+  {"type":"function","id":"…","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]}
+```
+- `tool_calls[].function.arguments` is a JSON **string** (parse again for the object).
+- `reasoning_content` is populated ONLY when `reasoning_format` was set during render; otherwise the
+  `<think>` block leaks into `content`.
+- It is a method on the **`ChatTemplateResult`** (NOT `LlamaModel`) — it needs the `chat_format` /
+  `parser` produced during rendering.
+
+## Empirical behavior (probed against Qwen3.6-27B)
+
+- **No BOS** — tokenize with `AddBos::Never`; the prompt starts at `<|im_start|>` (id 248045);
+  `<|im_end|>` is id 248046. Special tokens are single ids, not literal characters.
+- **Tool-call turns carry NO user-facing message.** Even when explicitly told "tell me what tool you
+  called," the model emits *only* the tool call and defers the message to the turn AFTER the tool
+  result. With `reasoning_format` set, `content` is **empty** on a tool-call turn (just
+  `reasoning_content` + `tool_calls`). The schema allows content + tool_calls together; this model
+  doesn't do it in practice → **branch the loop on "are there tool_calls?", not on content.**
+- **Pronouns resolve from history** — asked weather "there" after answering "Paris" → it called
+  `get_weather(city="Paris")`.
+- **Thinking is verbose** and can be mildly degenerate (repeats "Done./Proceeds./✅") even for trivial
+  routing. Real latency/token cost per turn — consider `enable_thinking:false` for simple turns.
+- **Sampler / system prompt:** LM Studio preset = temp 0.6, top_k 20, top_p 0.95, min_p off,
+  **repeat_penalty OFF**, and **no default system prompt**.
+
+---
+
 ## How to re-extract the embedded template
 
 The Jinja chat template is stored in GGUF metadata under `tokenizer.chat_template`
@@ -200,7 +252,9 @@ print(buf[pos:pos+slen].decode("utf-8"))
 - **Tool results:** use the `tool` role (`<tool_response>`), fixing the current
   "labeled as Assistant:" problem.
 - **Thoughts:** the `<think>` channel replaces the hand-rolled `thoughts:` field, hidden from user.
-- **Tool calls:** parse XML `<function=…>`, not the current `{"GetWeather":"..."}` JSON.
-- **Open question:** does `llama-cpp-2` expose `llama_chat_apply_template`? If not, hand-render
-  the ChatML above (structure is simple). Tool-call parsing is ours either way.
+- **Tool calls:** the model emits XML `<function=…>`, but `parse_response_oaicompat` hands us
+  structured `tool_calls` — no XML parsing on our side.
+- **Rendering + parsing: RESOLVED** — `llama-cpp-2` 0.1.146 renders (with tools + reasoning_format)
+  and parses tool calls for us via `apply_chat_template_oaicompat` + `parse_response_oaicompat`.
+  No hand-rolled ChatML or XML parser. See "Driving it via llama-cpp-2" above.
 ```

--- a/probe/Cargo.toml
+++ b/probe/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "probe"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0.102"
+llama-cpp-2 = { version = "0.1.146", features = ["vulkan"] }
+serde_json = "1.0.150"

--- a/probe/README.md
+++ b/probe/README.md
@@ -1,0 +1,48 @@
+# probe
+
+A tiny, throwaway CLI for poking at the local model and **visualizing raw behavior**. It's
+deliberately minimal (one `main.rs`, everything hardcoded) — edit the constants/conversation,
+rebuild, run. Not part of the bot; it's a developer scratchpad for the chat-harness overhaul.
+
+## What it does
+
+Loads the GGUF onto the GPU, drives it with the model's **native chat template** (+ a hardcoded
+fake tool), and prints four things:
+
+1. **`RAW PROMPT`** — the full rendered ChatML string sent to the model (tools injected).
+2. **`RAW OUTPUT`** — streamed live as the model generates, stops on `<|im_end|>` (EOS).
+3. **`OAICOMPAT JSON`** — `parse_response_oaicompat` output: the binding's structured parse with
+   `reasoning_content` / `content` / `tool_calls` already separated.
+
+(It renders via `apply_chat_template_oaicompat` with `reasoning_format` set, so `<think>` lands in
+`reasoning_content` instead of leaking into `content`.)
+
+## Run it
+
+```bash
+cargo run -p probe          # or: ./target/debug/probe  (release: cargo run -p probe --release)
+```
+
+Edit the hardcoded bits at the top of [`src/main.rs`](src/main.rs):
+- `MODEL` — path to the GGUF (defaults to the chatbot's Qwen3.6-27B).
+- `TOOLS` — the fake tool definition (OpenAI-compatible JSON array).
+- `REASONING_FORMAT` — `"auto"` | `"deepseek"` | `"deepseek-legacy"` | `"none"`.
+- the `messages_json` conversation.
+
+## Build dependencies (local)
+
+The `vulkan` feature compiles llama.cpp from source, so the host needs (Debian/Ubuntu):
+
+```bash
+sudo apt-get install -y glslc libvulkan-dev libclang-dev
+```
+
+- `glslc` — compiles the Vulkan shaders.
+- `libvulkan-dev` — Vulkan headers + loader dev symlink (CMake `FindVulkan`).
+- `libclang-dev` — bindgen's clang builtin headers (else `stdbool.h not found`).
+
+(`cmake`, a C/C++ compiler, and the Vulkan driver are also required but usually already present.)
+GPU offload is forced via `with_n_gpu_layers(999)`.
+
+> If a build fails on stale CMake state (`gmake: Makefile: No such file`), run
+> `cargo clean -p llama-cpp-sys-2` and rebuild.

--- a/probe/src/main.rs
+++ b/probe/src/main.rs
@@ -1,0 +1,117 @@
+// Minimal local probe: drive the model with its NATIVE chat template (+ a fake tool) and dump the
+// full prompt, the tokens, the raw output, and the OAICompat JSON. Renders via the params path with
+// `reasoning_format` set, so the parser splits reasoning_content from content. (Run: `cargo run -p probe`.)
+use llama_cpp_2::{
+    context::params::LlamaContextParams,
+    llama_backend::LlamaBackend,
+    llama_batch::LlamaBatch,
+    model::{params::LlamaModelParams, AddBos, LlamaModel, Special},
+    openai::OpenAIChatTemplateParams,
+    sampling::LlamaSampler,
+    send_logs_to_tracing, LogOptions,
+};
+use std::{io::Write, num::NonZero};
+
+const MODEL: &str = "/home/zireael9797/Repos/bot/chatbot/models/Qwen3.6-27B-Q4_K_M.gguf";
+const N_CTX: u32 = 8192;
+const MAX_TOKENS: usize = 1024;
+
+// ---- hardcoded fake tool, OpenAI-compatible JSON array ----
+const TOOLS: &str = r#"[{"type":"function","function":{
+  "name":"get_weather",
+  "description":"Get the current weather for a city",
+  "parameters":{"type":"object","properties":{
+    "city":{"type":"string","description":"City name, e.g. Paris"}},
+    "required":["city"]}}}]"#;
+
+// reasoning extraction format: "auto" | "deepseek" | "deepseek-legacy" | "none"
+const REASONING_FORMAT: &str = "auto";
+
+fn main() -> anyhow::Result<()> {
+    send_logs_to_tracing(LogOptions::default().with_logs_enabled(false)); // silence llama.cpp/ggml logs
+    let backend = LlamaBackend::init()?;
+    let model = LlamaModel::load_from_file(
+        &backend,
+        MODEL,
+        &LlamaModelParams::default().with_n_gpu_layers(999), // offload everything to GPU (Vulkan)
+    )?;
+
+    // ---- hardcode the conversation: simulate being on the 2nd question, so "there" => Paris ----
+    let messages_json = serde_json::json!([
+        {"role": "user", "content": "What is the capital of France"},
+        {"role": "assistant", "content": "It's Paris"},
+        {"role": "user", "content": "What's the weather there? Even if you call a tool, tell me what tool you called"}
+    ])
+    .to_string();
+
+    // Render via the params path so we can set reasoning_format (splits <think> into reasoning_content).
+    let template = model.chat_template(None)?;
+    let params = OpenAIChatTemplateParams {
+        messages_json: &messages_json,
+        tools_json: Some(TOOLS),
+        tool_choice: None,
+        json_schema: None,
+        grammar: None,
+        reasoning_format: Some(REASONING_FORMAT),
+        chat_template_kwargs: None,
+        add_generation_prompt: true,
+        use_jinja: true,
+        parallel_tool_calls: false,
+        enable_thinking: true,
+        add_bos: false,
+        add_eos: false,
+        parse_tool_calls: true,
+    };
+    let rendered = model.apply_chat_template_oaicompat(&template, &params)?;
+    let prompt = &rendered.prompt;
+
+    println!("\n========== RAW PROMPT ==========\n{prompt}");
+
+    let mut ctx = model.new_context(
+        &backend,
+        LlamaContextParams::default().with_n_ctx(Some(NonZero::new(N_CTX).unwrap())),
+    )?;
+
+    let tokens = model.str_to_token(prompt, AddBos::Never)?;
+
+    let mut batch = LlamaBatch::new(N_CTX as usize, 1);
+    let last = tokens.len() - 1;
+    for (i, t) in tokens.iter().enumerate() {
+        batch.add(*t, i as i32, &[0], i == last)?;
+    }
+    ctx.decode(&mut batch)?;
+
+    // Qwen's recommended sampler (per LM Studio): temp 0.6 / top_k 20 / top_p 0.95, no repeat penalty.
+    let mut sampler = LlamaSampler::chain_simple([
+        LlamaSampler::temp(0.6),
+        LlamaSampler::top_k(20),
+        LlamaSampler::top_p(0.95, 1),
+        LlamaSampler::dist(0),
+    ]);
+
+    println!("\n========== RAW OUTPUT ==========");
+    let mut out = String::new();
+    let mut n_cur = tokens.len() as i32;
+    let mut last_idx = batch.n_tokens() - 1;
+    for _ in 0..MAX_TOKENS {
+        let tok = sampler.sample(&ctx, last_idx);
+        if model.is_eog_token(tok) {
+            break;
+        }
+        let piece = model.token_to_str(tok, Special::Tokenize)?;
+        print!("{piece}");
+        std::io::stdout().flush()?;
+        out.push_str(&piece);
+        batch.clear();
+        batch.add(tok, n_cur, &[0], true)?;
+        ctx.decode(&mut batch)?;
+        n_cur += 1;
+        last_idx = batch.n_tokens() - 1;
+    }
+
+    // The binding's parser: raw stream -> OpenAI-style JSON. With reasoning_format set above, this
+    // now separates reasoning_content (the <think> block) from content and tool_calls.
+    let parsed = rendered.parse_response_oaicompat(&out, false)?;
+    println!("\n\n========== OAICOMPAT JSON (parse_response_oaicompat) ==========\n{parsed}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Tooling + docs from the Phase 2 research spike (no changes to the running bot).

- **New `probe/` workspace crate** — a minimal local CLI to visualize raw model behavior. Loads the GGUF on GPU, drives it with the model's native chat template plus a hardcoded fake tool, and prints **RAW PROMPT → RAW OUTPUT → OAICOMPAT JSON**. Renders via `apply_chat_template_oaicompat` with `reasoning_format` set, so the parser splits `reasoning_content` from `content`. Dev tool only.
- **`chatbot/model_reference/qwen.md`** (moved into `chatbot/`, expanded) — confirmed `llama-cpp-2` 0.1.146 integration (`chat_template` / `apply_chat_template_oaicompat` / `parse_response_oaicompat` / `ChatTemplateResult`) and **empirical behavior** probed against Qwen3.6-27B: no BOS, tool-call turns carry no user-facing message (deferred to post-tool-result turn), verbose/degenerate thinking, recommended sampler + empty default system prompt. Corrected the earlier "we must hand-parse tool calls" note — the binding parses for us.
- **`probe/README.md`** — usage + local build deps (`glslc`, `libvulkan-dev`, `libclang-dev`).
- **Root README** — Qwen3.6-27B, single Primary Agent (executor removed), `probe/` + `model_reference/` in the tree, `PRIMARY_MODEL_PATH`.

## Notes
- No `.gguf` committed (gitignored). `probe` shares the workspace target.
- Docs/tooling only — the chatbot binary is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)