### PR TITLE
Chunk Discord messages to the 2000-char limit

### DIFF
--- a/chatbot/src/externals/message_external.rs
+++ b/chatbot/src/externals/message_external.rs
@@ -5,6 +5,39 @@ use crate::models::user::UserChannel;
 use crate::{models::user::UserId, Env};
 use serenity::all::CreateMessage;
 
+/// Discord rejects message content longer than 2000 characters.
+const DISCORD_MESSAGE_LIMIT: usize = 2000;
+
+/// Split `content` into chunks of at most `DISCORD_MESSAGE_LIMIT` characters, preferring to break
+/// at a newline so we don't cut mid-line. Empty/whitespace-only chunks are dropped (Discord also
+/// rejects empty content).
+fn split_for_discord(content: &str) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut remaining = content;
+
+    while remaining.chars().count() > DISCORD_MESSAGE_LIMIT {
+        // Byte index of the character at the limit (a valid char boundary).
+        let hard = remaining
+            .char_indices()
+            .nth(DISCORD_MESSAGE_LIMIT)
+            .map(|(i, _)| i)
+            .unwrap_or(remaining.len());
+        // Break at the last newline within the window, else hard-cut at the limit.
+        let split_at = remaining[..hard].rfind('\n').map(|i| i + 1).unwrap_or(hard);
+
+        let (chunk, rest) = remaining.split_at(split_at);
+        if !chunk.trim().is_empty() {
+            chunks.push(chunk.to_string());
+        }
+        remaining = rest;
+    }
+
+    if !remaining.trim().is_empty() {
+        chunks.push(remaining.to_string());
+    }
+    chunks
+}
+
 pub async fn send_message(env: Arc<Env>, user_id: UserId, message: String) -> UserAction {
     let user_id_result = match user_id.0 {
         UserChannel::Discord => {
@@ -27,14 +60,17 @@ pub async fn send_message(env: Arc<Env>, user_id: UserId, message: String) -> Us
 
             match dm_channel_result {
                 Ok(channel) => {
-                    let res = channel
-                        .send_message(&env.discord_http, CreateMessage::new().content(&message))
-                        .await;
-
-                    match res {
-                        Ok(_) => UserAction::MessageSent(Ok(())),
-                        Err(err) => UserAction::MessageSent(Err(err.to_string())),
+                    // Chunk to Discord's 2000-char limit; send sequentially, bail on first error.
+                    for chunk in split_for_discord(&message) {
+                        if let Err(err) = channel
+                            .send_message(&env.discord_http, CreateMessage::new().content(&chunk))
+                            .await
+                        {
+                            eprintln!("Failed to send Discord message: {err}");
+                            return UserAction::MessageSent(Err(err.to_string()));
+                        }
                     }
+                    UserAction::MessageSent(Ok(()))
                 }
                 Err(err) => UserAction::MessageSent(Err(err.to_string())),
             }


### PR DESCRIPTION
Long replies from the native chat loop exceeded Discord's **2000-char** per-message limit and were silently dropped — the send returned an error, but the state machine matches `MessageSent(_res)` and ignores it, so it transitioned as if delivered.

**Fix:** `send_message` now splits the reply into ≤2000-char chunks (breaking on newline boundaries so lines aren't cut mid-way), sends them sequentially, drops empty/whitespace-only chunks, and **logs + returns an error** on the first failed send.

Known follow-ups (not in this PR):
- The state machine still ignores the `MessageSent` result (no retry / user-facing surfacing) — now at least logged via `eprintln`.
- A long fenced code block can be split across messages (breaking the ``` fence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)