### PR TITLE
Per-turn tool-iteration cap with tools-off synthesis

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -158,8 +158,9 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nCurrent date and time (UTC): {}",
+            "{}\n\nYou have up to {} tool calls per turn. Use them deliberately and prefer answering once you have gathered enough to respond.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
+            crate::models::user::MAX_TOOL_ROUNDS,
             Utc::now().format("%Y-%m-%d %H:%M")
         )
     }

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -89,8 +89,11 @@ fn respond_blocking(
     backend: Arc<LlamaBackend>,
     batch_chunk_size: usize,
     conversation: serde_json::Value,
+    allow_tools: bool,
 ) -> anyhow::Result<serde_json::Value> {
-    // Prepend the system turn (persona + current time), then render with the model's template.
+    // Prepend the system turn (persona + current time), then render with the model's template. At
+    // the budget cap, advertise no tools so the model physically cannot emit another tool call (the
+    // synthesis nudge itself rides the message stream, not this stable system turn).
     let mut messages = vec![serde_json::json!({
         "role": "system",
         "content": agent.system_content(),
@@ -104,7 +107,11 @@ fn respond_blocking(
     let tools_json = crate::models::user::ToolCall::tools_json();
     let params = OpenAIChatTemplateParams {
         messages_json: &messages_json,
-        tools_json: Some(tools_json.as_str()),
+        tools_json: if allow_tools {
+            Some(tools_json.as_str())
+        } else {
+            None
+        },
         tool_choice: None,
         json_schema: None,
         grammar: None,
@@ -172,9 +179,18 @@ impl Agent {
         backend: Arc<LlamaBackend>,
         batch_chunk_size: usize,
         conversation: serde_json::Value,
+        allow_tools: bool,
     ) -> anyhow::Result<serde_json::Value> {
         let task = spawn_blocking(move || {
-            respond_blocking(self, ctx_params, model, backend, batch_chunk_size, conversation)
+            respond_blocking(
+                self,
+                ctx_params,
+                model,
+                backend,
+                batch_chunk_size,
+                conversation,
+                allow_tools,
+            )
         });
 
         task.await?

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -10,12 +10,30 @@ use serde_json::Value;
 
 use std::sync::Arc;
 
+/// A plain-text budget reminder for the most recent tool result, or `None` below the caution
+/// threshold. Relative (halfway) so it tracks the cap if retuned; the hard cap itself needs no
+/// reminder — that's handled by the tools-off synthesis call. Not `<system-reminder>`: Qwen has no
+/// special handling for that tag, so a plain bracketed marker is used instead.
+fn budget_reminder(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
+    if max_tool_rounds > 0 && tool_rounds * 2 >= max_tool_rounds && tool_rounds < max_tool_rounds {
+        Some(format!(
+            "[Tool budget: {tool_rounds}/{max_tool_rounds} used — start wrapping up and answer soon.]"
+        ))
+    } else {
+        None
+    }
+}
+
 /// Build the conversation as an OpenAI-style messages JSON array (without the system turn — the
 /// agent prepends that). The `tool_call_id` is threaded from each assistant call to the result
-/// that follows it. Prior reasoning is not replayed (Qwen3 guidance).
+/// that follows it. Prior reasoning is not replayed (Qwen3 guidance). When the new input is a tool
+/// result, the running budget reminder is appended to it at render time (never persisted, so old
+/// turns don't accumulate stale counts).
 fn build_conversation(
     new_input: &LLMInput,
     maybe_recent_conversation: Option<RecentConversation>,
+    tool_rounds: usize,
+    max_tool_rounds: usize,
 ) -> Value {
     let history = maybe_recent_conversation
         .map(|rc| rc.history)
@@ -38,7 +56,16 @@ fn build_conversation(
             }
         }
     }
-    messages.push(new_input.to_openai_message(last_tool_call_id.as_deref()));
+
+    let mut new_message = new_input.to_openai_message(last_tool_call_id.as_deref());
+    if matches!(new_input, LLMInput::ToolResult(_)) {
+        if let Some(reminder) = budget_reminder(tool_rounds, max_tool_rounds) {
+            if let Some(content) = new_message.get("content").and_then(|c| c.as_str()) {
+                new_message["content"] = Value::String(format!("{content}\n\n{reminder}"));
+            }
+        }
+    }
+    messages.push(new_message);
 
     Value::Array(messages)
 }
@@ -81,8 +108,15 @@ async fn get_response_from_llm(
     llama_cpp: &LlamaCppService,
     current_input: &LLMInput,
     maybe_recent_conversation: Option<RecentConversation>,
+    tool_rounds: usize,
+    max_tool_rounds: usize,
 ) -> anyhow::Result<LLMResponse> {
-    let conversation = build_conversation(current_input, maybe_recent_conversation);
+    let conversation = build_conversation(
+        current_input,
+        maybe_recent_conversation,
+        tool_rounds,
+        max_tool_rounds,
+    );
 
     println!("\n\n------------------------ NEW ITERATION ------------------------\n\n");
     println!(
@@ -133,6 +167,8 @@ pub async fn get_llm_decision(
         env.llama_cpp.as_ref(),
         &current_input,
         maybe_recent_conversation,
+        tool_rounds,
+        max_tool_rounds,
     )
     .await;
 

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -10,12 +10,23 @@ use serde_json::Value;
 
 use std::sync::Arc;
 
-/// A plain-text budget reminder for the most recent tool result, or `None` below the caution
-/// threshold. Relative (halfway) so it tracks the cap if retuned; the hard cap itself needs no
-/// reminder — that's handled by the tools-off synthesis call. Not `<system-reminder>`: Qwen has no
-/// special handling for that tag, so a plain bracketed marker is used instead.
-fn budget_reminder(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
-    if max_tool_rounds > 0 && tool_rounds * 2 >= max_tool_rounds && tool_rounds < max_tool_rounds {
+/// A plain-text budget note for the most recent tool result, escalating with usage: a caution past
+/// the halfway mark, then a synthesis directive at the cap (where tools are turned off, so the model
+/// can't call another and this nudges it to answer from history rather than stall). `None` below the
+/// caution threshold. Relative thresholds track the cap if retuned. Not `<system-reminder>`: Qwen
+/// has no special handling for that tag, so a plain bracketed marker is used instead. Lives here in
+/// the message stream — never the system turn — to keep the cached system prefix stable.
+fn budget_note(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
+    if max_tool_rounds == 0 {
+        None
+    } else if tool_rounds >= max_tool_rounds {
+        Some(
+            "[Tool budget exhausted — no more tools are available this turn. Answer the user now \
+             using the information already gathered above, and clearly state anything you could \
+             not determine.]"
+                .to_string(),
+        )
+    } else if tool_rounds * 2 >= max_tool_rounds {
         Some(format!(
             "[Tool budget: {tool_rounds}/{max_tool_rounds} used — start wrapping up and answer soon.]"
         ))
@@ -59,9 +70,9 @@ fn build_conversation(
 
     let mut new_message = new_input.to_openai_message(last_tool_call_id.as_deref());
     if matches!(new_input, LLMInput::ToolResult(_)) {
-        if let Some(reminder) = budget_reminder(tool_rounds, max_tool_rounds) {
+        if let Some(note) = budget_note(tool_rounds, max_tool_rounds) {
             if let Some(content) = new_message.get("content").and_then(|c| c.as_str()) {
-                new_message["content"] = Value::String(format!("{content}\n\n{reminder}"));
+                new_message["content"] = Value::String(format!("{content}\n\n{note}"));
             }
         }
     }
@@ -110,6 +121,7 @@ async fn get_response_from_llm(
     maybe_recent_conversation: Option<RecentConversation>,
     tool_rounds: usize,
     max_tool_rounds: usize,
+    allow_tools: bool,
 ) -> anyhow::Result<LLMResponse> {
     let conversation = build_conversation(
         current_input,
@@ -124,7 +136,9 @@ async fn get_response_from_llm(
         serde_json::to_string_pretty(&conversation).unwrap_or_default()
     );
 
-    let parsed = llama_cpp.get_primary_response(conversation).await?;
+    let parsed = llama_cpp
+        .get_primary_response(conversation, allow_tools)
+        .await?;
 
     let thoughts = parsed
         .get("reasoning_content")
@@ -161,7 +175,14 @@ pub async fn get_llm_decision(
     tool_rounds: usize,
     max_tool_rounds: usize,
 ) -> UserAction {
-    println!("[tool budget] {tool_rounds}/{max_tool_rounds} tool calls this turn");
+    // Budget spent → final call with tools off, so the model can't emit another tool call; the
+    // matching synthesis directive on the last tool result (see `budget_note`) nudges it to answer
+    // from what it already gathered.
+    let allow_tools = tool_rounds < max_tool_rounds;
+    println!(
+        "[tool budget] {tool_rounds}/{max_tool_rounds} tool calls this turn (tools {})",
+        if allow_tools { "on" } else { "off — synthesizing" }
+    );
 
     let llama_cpp_result = get_response_from_llm(
         env.llama_cpp.as_ref(),
@@ -169,6 +190,7 @@ pub async fn get_llm_decision(
         maybe_recent_conversation,
         tool_rounds,
         max_tool_rounds,
+        allow_tools,
     )
     .await;
 

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -124,7 +124,11 @@ pub async fn get_llm_decision(
     env: Arc<Env>,
     current_input: LLMInput,
     maybe_recent_conversation: Option<RecentConversation>,
+    tool_rounds: usize,
+    max_tool_rounds: usize,
 ) -> UserAction {
+    println!("[tool budget] {tool_rounds}/{max_tool_rounds} tool calls this turn");
+
     let llama_cpp_result = get_response_from_llm(
         env.llama_cpp.as_ref(),
         &current_input,

--- a/chatbot/src/models/user.rs
+++ b/chatbot/src/models/user.rs
@@ -61,6 +61,8 @@ pub enum UserState {
         is_timeout: bool,
         history: Vec<HistoryEntry>,
         current_input: LLMInput,
+        /// Tool calls made so far in this turn (resets to 0 on a new user turn).
+        tool_rounds: usize,
     },
     SendingMessage {
         is_timeout: bool,
@@ -70,6 +72,7 @@ pub enum UserState {
     RunningTool {
         is_timeout: bool,
         recent_conversation: RecentConversation,
+        tool_rounds: usize,
     },
 }
 impl Default for UserState {

--- a/chatbot/src/models/user.rs
+++ b/chatbot/src/models/user.rs
@@ -6,6 +6,10 @@ use strum::{EnumDiscriminants, EnumIter};
 
 pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 20;
 
+/// Max tool calls the model may make in a single user turn before the loop is cut short. Single
+/// source of truth: the state machine enforces it; the system prompt discloses it.
+pub const MAX_TOOL_ROUNDS: usize = 10;
+
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum UserChannel {
     Telegram,

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -83,6 +83,7 @@ impl LlamaCppService {
     pub async fn get_primary_response(
         &self,
         conversation: serde_json::Value,
+        allow_tools: bool,
     ) -> anyhow::Result<serde_json::Value> {
         self.primary_agent
             .respond(
@@ -91,6 +92,7 @@ impl LlamaCppService {
                 Arc::clone(&self.backend),
                 Self::BATCH_CHUNK_SIZE,
                 conversation,
+                allow_tools,
             )
             .await
     }

--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -23,6 +23,9 @@ use std::sync::Arc;
 type UserTransitionResult = TransitionResult<User, UserAction>;
 type UserExternalOperation = ExternalOperation<UserAction>;
 
+/// Max tool calls the model may make in a single turn before the loop is cut short.
+const MAX_TOOL_ROUNDS: usize = 10;
+
 fn handle_outcome(
     env: Arc<Env>,
     user_id: &UserId,
@@ -30,6 +33,7 @@ fn handle_outcome(
     response: LLMResponse,
     recent_conversation: RecentConversation,
     pending: Vec<String>,
+    tool_rounds: usize,
 ) -> UserTransitionResult {
     match response.output {
         LLMDecisionType::MessageUser { .. } => Ok((
@@ -60,6 +64,7 @@ fn handle_outcome(
                     state: UserState::RunningTool {
                         is_timeout,
                         recent_conversation,
+                        tool_rounds: tool_rounds + 1,
                     },
                     last_transition: Utc::now(),
                     pending,
@@ -125,6 +130,7 @@ pub fn user_transition(
                     is_timeout,
                     history,
                     current_input,
+                    tool_rounds,
                 },
                 UserAction::LLMDecisionResult(res),
             ) => match res {
@@ -175,6 +181,7 @@ pub fn user_transition(
                             response.clone(),
                             updated_conversation,
                             user.pending,
+                            tool_rounds,
                         ),
                     }
                 }
@@ -203,11 +210,13 @@ pub fn user_transition(
                 outcome,
                 recent_conversation,
                 user.pending,
+                0,
             ),
             (
                 UserState::RunningTool {
                     recent_conversation,
                     is_timeout,
+                    tool_rounds,
                 },
                 UserAction::ToolResult(res),
             ) => {
@@ -221,6 +230,8 @@ pub fn user_transition(
                             env.clone(),
                             current_input.clone(),
                             Some(recent_conversation),
+                            tool_rounds,
+                            MAX_TOOL_ROUNDS,
                         )));
 
                         Ok((
@@ -229,6 +240,7 @@ pub fn user_transition(
                                     is_timeout,
                                     history,
                                     current_input,
+                                    tool_rounds,
                                 },
                                 last_transition: Utc::now(),
                                 ..user
@@ -251,6 +263,8 @@ pub fn user_transition(
                             env.clone(),
                             current_input.clone(),
                             Some(recent_conversation),
+                            tool_rounds,
+                            MAX_TOOL_ROUNDS,
                         )));
 
                         Ok((
@@ -259,6 +273,7 @@ pub fn user_transition(
                                     is_timeout,
                                     history,
                                     current_input,
+                                    tool_rounds,
                                 },
                                 last_transition: Utc::now(),
                                 ..user
@@ -312,6 +327,8 @@ pub fn user_transition(
                     env.clone(),
                     current_input.clone(),
                     Some(recent_conversation.clone()),
+                    0,
+                    MAX_TOOL_ROUNDS,
                 )));
 
                 Ok((
@@ -320,6 +337,7 @@ pub fn user_transition(
                             is_timeout: true,
                             history: recent_conversation.history,
                             current_input,
+                            tool_rounds: 0,
                         },
                         last_transition: Utc::now(),
                         ..user
@@ -361,6 +379,8 @@ fn post_transition(
                 env.clone(),
                 current_input.clone(),
                 recent_conversation.as_ref().map(|(rc, _)| rc.clone()),
+                0,
+                MAX_TOOL_ROUNDS,
             )));
 
             let user = User {
@@ -368,6 +388,7 @@ fn post_transition(
                     is_timeout: false,
                     history,
                     current_input: LLMInput::UserMessage(msg.clone()),
+                    tool_rounds: 0,
                 },
                 last_transition: Utc::now(),
                 pending: Vec::new(),

--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -3,7 +3,7 @@ use crate::externals::{
     llama_cpp_external::get_llm_decision, message_external::send_message,
     tool_call_external::execute_tool,
 };
-use crate::models::user::{LLMResponse, ToolResultData};
+use crate::models::user::{LLMResponse, ToolResultData, MAX_TOOL_ROUNDS};
 use crate::{
     models::user::{
         HistoryEntry, LLMDecisionType, LLMInput, RecentConversation, User, UserAction, UserId,
@@ -22,9 +22,6 @@ use std::sync::Arc;
 
 type UserTransitionResult = TransitionResult<User, UserAction>;
 type UserExternalOperation = ExternalOperation<UserAction>;
-
-/// Max tool calls the model may make in a single turn before the loop is cut short.
-const MAX_TOOL_ROUNDS: usize = 10;
 
 fn handle_outcome(
     env: Arc<Env>,

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -43,7 +43,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Get the current weather for a city. Use when the user asks about weather, temperature, or conditions for a specific place.",
+                    "description": "Get the current weather for a city. Use when the user asks about weather, temperature, or conditions for a specific place. Don't re-request a city's weather you've already fetched this turn — reuse the result above.",
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -57,7 +57,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Search the web for current or factual information. Returns a short list of results (title, URL, and a snippet) — not full pages. Usually step one of a two-step pattern: search to discover relevant URLs, then call visit_url on the most promising result to read its full content before answering. If the snippets already answer the question, you can skip visit_url.",
+                    "description": "Search the web for current or factual information. Returns a short list of results (title, URL, and a snippet) — not full pages. Usually step one of a two-step pattern: search to discover relevant URLs, then call visit_url on the most promising result to read its full content before answering. If the snippets already answer the question, you can skip visit_url. Don't issue near-identical or repeated queries: if a couple of searches don't surface the answer, stop searching and reply with what you found, noting what you couldn't determine.",
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -71,7 +71,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Fetch a web page and extract its readable text. Use this after web_search to open a result and read it in full, since search only returns short snippets. Also works on a URL the user gives you directly.",
+                    "description": "Fetch a web page and extract its readable text. Use this after web_search to open a result and read it in full, since search only returns short snippets. Also works on a URL the user gives you directly. Don't re-fetch a URL you've already visited this turn — its content is already in the conversation above.",
                     "parameters": {
                         "type": "object",
                         "properties": {


### PR DESCRIPTION
## Problem

The native agent loop had no per-turn tool cap, so the model could call tools indefinitely. Observed live: a single question produced **68 `web_search` + 25 `visit_url` calls** over ~5 minutes, never answering. The 10-minute `ForceReset` doesn't catch this — it's keyed off `last_transition`, which resets every tool round, so a *busy* loop never trips it.

Closes #86.

## Approach

A layered design — soft prevention plus a hard guarantee:

1. **Anti-repeat nudges on tool descriptions** (`tools.rs`) — discourage re-searching/re-visiting the same thing.
2. **Per-turn round counter** owned by the state machine (`tool_rounds` on `AwaitingLLMDecision`/`RunningTool`, `MAX_TOOL_ROUNDS` as the single source of truth in `models::user`). Resets to 0 each new user turn. Threaded into `get_llm_decision` (value passed down — the constant isn't read outside its owner).
3. **Static budget disclosure** in the system prompt (persona policy — stable, never mutates per call).
4. **Dynamic budget note** appended to the *most recent tool result* at render time (never persisted): caution past ~50%, then a synthesis directive at the cap. Plain bracketed text, not `<system-reminder>` (Qwen has no special handling for that tag).
5. **Hard cut at the cap** — the final call renders with `tools_json: None` (`allow_tools=false`), so the model physically cannot emit another tool call; the loop is guaranteed to terminate with a user message, and the synthesis note nudges it to answer from gathered context rather than stall.

Key invariant: the **system prompt stays identical across every call** — all dynamic budget content rides the message stream.

## Verified

- `cargo build` clean (only pre-existing dead-code warnings).
- Live verification of the cap behavior to follow on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)