### PR TITLE
Graded budget nudges + terse tool descriptions

### DIFF
--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -10,12 +10,14 @@ use serde_json::Value;
 
 use std::sync::Arc;
 
-/// A plain-text budget note for the most recent tool result, escalating with usage: a caution past
-/// the halfway mark, then a synthesis directive at the cap (where tools are turned off, so the model
-/// can't call another and this nudges it to answer from history rather than stall). `None` below the
-/// caution threshold. Relative thresholds track the cap if retuned. Not `<system-reminder>`: Qwen
-/// has no special handling for that tag, so a plain bracketed marker is used instead. Lives here in
-/// the message stream — never the system turn — to keep the cached system prefix stable.
+/// A plain-text budget note for the most recent tool result, escalating in three tiers so the model
+/// isn't scared into quitting early: at ~50% nudge it to vary its approach (NOT to stop — an early
+/// "wrap up" makes it bail prematurely), at ~80% tell it to start wrapping up, and at the cap a
+/// synthesis directive (where tools are turned off, so it can't call another and this nudges it to
+/// answer from history rather than stall). `None` below the halfway mark. Relative thresholds track
+/// the cap if retuned. Not `<system-reminder>`: Qwen has no special handling for that tag, so a
+/// plain bracketed marker is used instead. Lives here in the message stream — never the system turn
+/// — to keep the cached system prefix stable.
 fn budget_note(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
     if max_tool_rounds == 0 {
         None
@@ -26,9 +28,13 @@ fn budget_note(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
              not determine.]"
                 .to_string(),
         )
+    } else if tool_rounds * 5 >= max_tool_rounds * 4 {
+        Some(format!(
+            "[Tool budget: {tool_rounds}/{max_tool_rounds} used — you're running low. Either wrap up and answer with what you have, or make your remaining calls count: use them only if they'll meaningfully improve your answer.]"
+        ))
     } else if tool_rounds * 2 >= max_tool_rounds {
         Some(format!(
-            "[Tool budget: {tool_rounds}/{max_tool_rounds} used — start wrapping up and answer soon.]"
+            "[Tool budget: {tool_rounds}/{max_tool_rounds} used — if your current approach isn't working, try a different angle rather than repeating similar calls. You still have room to keep investigating.]"
         ))
     } else {
         None

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -43,7 +43,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Get the current weather for a city. Use when the user asks about weather, temperature, or conditions for a specific place. Don't re-request a city's weather you've already fetched this turn — reuse the result above.",
+                    "description": "Get the current weather for a city.",
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -57,7 +57,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Search the web for current or factual information. Returns a short list of results (title, URL, and a snippet) — not full pages. Usually step one of a two-step pattern: search to discover relevant URLs, then call visit_url on the most promising result to read its full content before answering. If the snippets already answer the question, you can skip visit_url. Don't issue near-identical or repeated queries: if a couple of searches don't surface the answer, stop searching and reply with what you found, noting what you couldn't determine.",
+                    "description": "Search the web. Returns short snippets — use visit_url to read a result in full.",
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -71,7 +71,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Fetch a web page and extract its readable text. Use this after web_search to open a result and read it in full, since search only returns short snippets. Also works on a URL the user gives you directly. Don't re-fetch a URL you've already visited this turn — its content is already in the conversation above.",
+                    "description": "Fetch a URL's readable text — usually a web_search result, or one the user gave you.",
                     "parameters": {
                         "type": "object",
                         "properties": {


### PR DESCRIPTION
Follow-up tuning on #87 after live testing.

## Why
The model **bailed at 5/10** — the single ~50% note said "start wrapping up and answer soon," so it did, far too early.

## Changes
- **Three-tier `budget_note`** (relative thresholds, still on the latest tool result):
  - **~50%** — nudge to *vary approach*, explicitly reassuring it has room left (no "wrap up").
  - **~80%** — "you're running low: either wrap up, or make your remaining calls count (use them only if they'll meaningfully improve the answer)."
  - **cap** — unchanged tools-off synthesis directive.
- **Trimmed tool descriptions** to one terse line each — the graded notes now carry the don't-repeat pressure, so the schemas no longer need the two-step-pattern / anti-repeat prose.

System prompt stays invariant; all dynamic budget content still rides the message stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)