### PR TITLE
Allow parallel_tool_calls so multi-call turns don't crash

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -169,7 +169,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nYou have up to {} tool calls per turn. Use them deliberately and prefer answering once you have gathered enough to respond.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nYou have up to {} tool calls per turn. Use them deliberately and prefer answering once you have gathered enough to respond. Call only one tool at a time — if you emit multiple tool calls in one turn, only the first runs and the rest are dropped.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             crate::models::user::MAX_TOOL_ROUNDS,
             Utc::now().format("%Y-%m-%d %H:%M")

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -119,7 +119,11 @@ fn respond_blocking(
         chat_template_kwargs: None,
         add_generation_prompt: true,
         use_jinja: true,
-        parallel_tool_calls: false,
+        // The model may emit multiple <tool_call> blocks in one turn regardless; with this set to
+        // false, parse_response_oaicompat hard-fails (`ffi error -3`) on such output and the turn
+        // dies silently (see #89). Allow it so parsing succeeds; we still run only the first call
+        // (first_tool_call warns on extras) until multi-tool execution lands.
+        parallel_tool_calls: true,
         enable_thinking: true,
         add_bos: false,
         add_eos: false,


### PR DESCRIPTION
Fixes the freeze from #89 (mitigation A).

## Cause
The model sometimes emits two `<tool_call>` blocks in one turn. With `parallel_tool_calls: false`, `parse_response_oaicompat` hard-fails with `ffi error -3`; the error `?`-propagates to `LLMDecisionResult(Err)` and the state machine's `Err(_) => Idle` arm silently drops the conversation → permanent freeze. Reproduced in the `probe` crate (single call OK; two calls → `ffi error -3` under `false`, OK under `true`).

## Fix
Set `parallel_tool_calls: true` so the parser accepts the calls. We still execute only the first call this turn (`first_tool_call` warns on extras) — proper multi-tool execution (C) and surfacing the swallowed error (B) remain open on #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)