### PR TITLE
Clarify tool-budget wording (turn = one step, up to 10 tool turns)

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -169,7 +169,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nYou have up to {} tool calls per turn. Use them deliberately and prefer answering once you have gathered enough to respond. Call only one tool at a time — if you emit multiple tool calls in one turn, only the first runs and the rest are dropped.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nOn each turn you either answer the user or make a SINGLE tool call (if you emit more than one tool call in a turn, only the first runs and the rest are dropped). You may take up to {} consecutive tool-call turns to gather what you need before you answer the user, so use them deliberately and answer as soon as you have enough.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             crate::models::user::MAX_TOOL_ROUNDS,
             Utc::now().format("%Y-%m-%d %H:%M")

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -23,9 +23,9 @@ fn budget_note(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
         None
     } else if tool_rounds >= max_tool_rounds {
         Some(
-            "[Tool budget exhausted — no more tools are available this turn. Answer the user now \
-             using the information already gathered above, and clearly state anything you could \
-             not determine.]"
+            "[Tool budget exhausted — you've used all your tool-call turns and no more are \
+             available. Answer the user now using the information already gathered above, and \
+             clearly state anything you could not determine.]"
                 .to_string(),
         )
     } else if tool_rounds * 5 >= max_tool_rounds * 4 {


### PR DESCRIPTION
Live, the model conflated "10 tool calls per turn" with "one tool per turn" and reasoned itself into a strict 1-call-per-turn limit ("I physically cannot exceed the 10-call limit in a single turn").

Reframe so "turn" consistently means a single model step:
- **System prompt:** "On each turn you either answer the user or make a SINGLE tool call (… only the first runs …). You may take up to N consecutive tool-call turns to gather what you need before you answer."
- **Cap note:** "you've used all your tool-call turns and no more are available" (was "no more tools are available this turn").

🤖 Generated with [Claude Code](https://claude.com/claude-code)