### PR TITLE
Drop the tool-budget number from the system prompt

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -169,9 +169,8 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nOn each turn you either answer the user or make a SINGLE tool call (if you emit more than one tool call in a turn, only the first runs and the rest are dropped). You may take up to {} consecutive tool-call turns to gather what you need before you answer the user, so use them deliberately and answer as soon as you have enough.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nOn each turn you either answer the user or make a SINGLE tool call (if you emit more than one tool call in a turn, only the first runs and the rest are dropped). Use tools deliberately and answer once you've gathered enough.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
-            crate::models::user::MAX_TOOL_ROUNDS,
             Utc::now().format("%Y-%m-%d %H:%M")
         )
     }


### PR DESCRIPTION
Keep only the one-tool-per-turn rule in the system prompt; let the model discover the ceiling from the dynamic budget notes appended to tool results.

The static "up to N tool calls" line was inviting the model to reason about (and argue with) the limit before doing any work — including the live case where it refused a task on the false premise that the limit was unreachable. The cap is still enforced (state machine + tools-off synthesis); it's just no longer announced up front.

Follow-up on the thinking-loop side tracked in #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)