### PR TITLE
Force-close runaway <think> blocks at a token budget

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -18,6 +18,20 @@ use tokio::task::spawn_blocking;
 
 use crate::{configuration::debug::DEBUG_LIVE_LLM_OUTPUT, services::llama_cpp::LlamaCppService};
 
+/// Safety cap on a single generation's reasoning: if the model hasn't closed its `<think>` block
+/// within this many generated tokens, we force it shut (see [`THINKING_FORCE_CLOSE`]) so it commits
+/// to an answer instead of looping. Generous on purpose — a net for runaway loops, not a routine
+/// limiter (the overall cap is `LlamaCppService::get_max_generation_tokens`).
+const MAX_THINKING_TOKENS: usize = 2048;
+
+/// Injected verbatim (tokenized, then fed through the decode loop) to force-close a runaway
+/// `<think>` block: a short first-person "stop and answer" stitch in the model's own voice, then the
+/// closing tag. Reading as the model's own decision to wrap up yields a cleaner answer than a bare
+/// `</think>`. It sits before `</think>`, so it lands in `reasoning_content` and the user never
+/// sees it.
+const THINKING_FORCE_CLOSE: &str =
+    "\n\nWait — I'm going in circles. I have enough to answer the user now, so I'll stop thinking and respond.\n</think>\n\n";
+
 fn run_generation(
     model: &LlamaModel,
     backend: &LlamaBackend,
@@ -60,7 +74,31 @@ fn run_generation(
     let mut out = String::new();
     let max_generation_tokens = LlamaCppService::get_max_generation_tokens();
 
-    for _ in 0..max_generation_tokens {
+    // Generation starts inside the <think> block (the template ends the prompt with
+    // `<|im_start|>assistant\n<think>`), so track whether the model closes it. If it hasn't by
+    // MAX_THINKING_TOKENS, force it shut to break reasoning loops.
+    let mut thinking_closed = false;
+
+    for i in 0..max_generation_tokens {
+        if !thinking_closed && i >= MAX_THINKING_TOKENS {
+            // Inject the "stop and answer" stitch + </think> token-by-token through the same decode
+            // path as sampled tokens, then resume sampling — the model now produces the answer.
+            for forced in model.str_to_token(THINKING_FORCE_CLOSE, AddBos::Never)? {
+                let piece = model.token_to_piece(forced, &mut decoder, true, None)?;
+                if DEBUG_LIVE_LLM_OUTPUT {
+                    print!("{piece}");
+                    let _ = io::stdout().flush();
+                }
+                out.push_str(&piece);
+                batch.clear();
+                batch.add(forced, n_cur, &[0], true)?;
+                ctx.decode(&mut batch)?;
+                n_cur += 1;
+                last_idx = batch.n_tokens() - 1;
+            }
+            thinking_closed = true;
+        }
+
         let token = sampler.sample(&ctx, last_idx);
         if model.is_eog_token(token) {
             break;
@@ -71,6 +109,9 @@ fn run_generation(
             let _ = io::stdout().flush();
         }
         out.push_str(&piece);
+        if !thinking_closed && out.contains("</think>") {
+            thinking_closed = true;
+        }
 
         batch.clear();
         batch.add(token, n_cur, &[0], true)?;


### PR DESCRIPTION
Addresses #92.

## What
If the model doesn't close its `<think>` block within `MAX_THINKING_TOKENS` generated tokens, inject a first-person "stop and answer" stitch + `</think>` through the same decode path as sampled tokens, then resume sampling so it commits to an answer instead of looping.

```rust
const MAX_THINKING_TOKENS: usize = 2048;   // generous safety net, well under the 8192 overall cap
const THINKING_FORCE_CLOSE: &str =
    "\n\nWait — I'm going in circles. I have enough to answer the user now, so I'll stop thinking and respond.\n</think>\n\n";
```

## Why it's safe / correct
- Generation starts **inside** `<think>` (template ends the prompt with `<|im_start|>assistant\n<think>`), so we watch for a natural `</think>` and only force one as a fallback.
- The stitch sits **before** `</think>` → lands in `reasoning_content`, never shown to the user.
- Closing the block guarantees a **non-empty `content`** answer instead of an all-reasoning blank reply (the failure mode when a loop never closes the tag).
- Constants are **generation-local** in `agents.rs`, not global.

## Verified locally
Temporarily set the budget to 200 and sent a trade-off + self-referential prompt ("postgres or mongodb, and how long will this answer be?"). The think block was cut mid-reasoning, the stitch fired verbatim, and the model produced a clean, complete answer to both parts (`content` non-empty, EOS reached, message sent). Restored to 2048 for this PR.

## Notes / follow-ups (still on #92)
- `presence_penalty` (Qwen3-recommended anti-repetition knob) not included here — separate, complementary.
- Optional loop-detection / per-turn `enable_thinking` toggle also deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)