### PR TITLE
Embed build SHA in commit.txt + log model-load completion

### DIFF
--- a/chatbot/Dockerfile
+++ b/chatbot/Dockerfile
@@ -30,8 +30,8 @@ COPY .git ./.git
 
 RUN cargo build --release --package chatbot
 
-# Capture git commit message
-RUN git log -1 --pretty=%B > /app/commit.txt || echo "unknown" > /app/commit.txt
+# Capture the build's commit: short SHA on the first line, then the message.
+RUN (git rev-parse --short HEAD && echo && git log -1 --pretty=%B) > /app/commit.txt || echo "unknown" > /app/commit.txt
 
 FROM zireael9797/bot-base:latest
 

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -33,11 +33,9 @@ impl LlamaCppService {
             .unwrap_or_else(|_| "./models/Qwen3.6-27B-Q4_K_M.gguf".to_string());
         println!("Loading primary model from: {}", primary_model_path);
 
-        Ok(LlamaModel::load_from_file(
-            backend,
-            &primary_model_path,
-            model_params,
-        )?)
+        let model = LlamaModel::load_from_file(backend, &primary_model_path, model_params)?;
+        println!("Loaded primary model from: {}", primary_model_path);
+        Ok(model)
     }
 
     pub async fn new() -> anyhow::Result<Self> {


### PR DESCRIPTION
Two small housekeeping items.

1. **Build SHA in `commit.txt`** — the file now leads with the short git SHA, then the commit message. Verify a running container's build at a glance: `docker exec bot head -1 /app/commit.txt`.
2. **Model-load completion log** — we logged "Loading primary model from: …" but never logged completion, so a slow/hung load looked identical to a finished one. Added "Loaded primary model from: …" after `load_from_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)