### PR TITLE
Run all tool calls in a turn (parallel tools)

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -168,10 +168,9 @@ fn respond_blocking(
         chat_template_kwargs: None,
         add_generation_prompt: true,
         use_jinja: true,
-        // The model may emit multiple <tool_call> blocks in one turn regardless; with this set to
-        // false, parse_response_oaicompat hard-fails (`ffi error -3`) on such output and the turn
-        // dies silently (see #89). Allow it so parsing succeeds; we still run only the first call
-        // (first_tool_call warns on extras) until multi-tool execution lands.
+        // The model may emit multiple <tool_call> blocks in one turn; with this set to false,
+        // parse_response_oaicompat hard-fails (`ffi error -3`) on such output (#89). We allow it and
+        // run every call (#98) — the state machine fans them out and collects the results.
         parallel_tool_calls: true,
         enable_thinking: true,
         add_bos: false,
@@ -218,7 +217,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nOn each turn you either answer the user or make a SINGLE tool call (if you emit more than one tool call in a turn, only the first runs and the rest are dropped). Use tools deliberately and answer once you've gathered enough.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             Utc::now().format("%Y-%m-%d %H:%M")
         )

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -153,7 +153,7 @@ fn respond_blocking(
     let messages_json = serde_json::Value::Array(messages).to_string();
 
     let template = model.chat_template(None)?;
-    let tools_json = crate::models::user::ToolCall::tools_json();
+    let tools_json = crate::models::user::ToolType::tools_json();
     let params = OpenAIChatTemplateParams {
         messages_json: &messages_json,
         tools_json: if allow_tools {

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -60,56 +60,51 @@ fn build_conversation(
 
     for entry in &history {
         match entry {
-            HistoryEntry::Input(input) => messages.push(input.to_openai_message()),
+            HistoryEntry::Input(input) => messages.extend(input.to_openai_messages()),
             HistoryEntry::Output(response) => messages.push(response.to_openai_message()),
         }
     }
 
-    let mut new_message = new_input.to_openai_message();
-    if matches!(new_input, LLMInput::ToolResult { .. }) {
+    let mut new_messages = new_input.to_openai_messages();
+    // Append the budget note to the last tool-result message of the batch (nearest the generation).
+    if matches!(new_input, LLMInput::ToolResults(_)) {
         if let Some(note) = budget_note(tool_rounds, max_tool_rounds) {
-            if let Some(content) = new_message.get("content").and_then(|c| c.as_str()) {
-                new_message["content"] = Value::String(format!("{content}\n\n{note}"));
+            if let Some(last) = new_messages.last_mut() {
+                if let Some(content) = last.get("content").and_then(|c| c.as_str()) {
+                    last["content"] = Value::String(format!("{content}\n\n{note}"));
+                }
             }
         }
     }
-    messages.push(new_message);
+    messages.extend(new_messages);
 
     Value::Array(messages)
 }
 
-/// First tool call from a parsed assistant message, as `(id, name, arguments_json_string)`.
-///
-/// Single-call by design: the state machine runs one tool per turn (`parallel_tool_calls: false`).
-/// Multi-tool is deferred to the state machine — if the model batches calls we take the first and
-/// warn rather than drop the rest silently.
-fn first_tool_call(parsed: &Value) -> Option<(String, String, String)> {
-    let calls = parsed.get("tool_calls").and_then(|v| v.as_array())?;
+/// Every tool call from a parsed assistant message, as `(id, name, arguments_json_string)` each.
+/// The model may batch several calls in one turn; we run them all.
+fn all_tool_calls(parsed: &Value) -> Vec<(String, String, String)> {
+    let Some(calls) = parsed.get("tool_calls").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
 
-    if calls.len() > 1 {
-        println!(
-            "[warn] model emitted {} tool calls; running only the first (multi-tool not yet supported)",
-            calls.len()
-        );
-    }
-
-    let call = calls.first()?;
-    let id = call
-        .get("id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("call_0")
-        .to_string();
-    let name = call
-        .pointer("/function/name")
-        .and_then(|v| v.as_str())?
-        .to_string();
-    let arguments = call
-        .pointer("/function/arguments")
-        .and_then(|v| v.as_str())
-        .unwrap_or("{}")
-        .to_string();
-
-    Some((id, name, arguments))
+    calls
+        .iter()
+        .filter_map(|call| {
+            let id = call
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("call_0")
+                .to_string();
+            let name = call.pointer("/function/name").and_then(|v| v.as_str())?.to_string();
+            let arguments = call
+                .pointer("/function/arguments")
+                .and_then(|v| v.as_str())
+                .unwrap_or("{}")
+                .to_string();
+            Some((id, name, arguments))
+        })
+        .collect()
 }
 
 async fn get_response_from_llm(
@@ -143,14 +138,20 @@ async fn get_response_from_llm(
         .unwrap_or("")
         .to_string();
 
-    // A tool call takes precedence over text; binding failures surface as a failed decision.
-    if let Some((id, name, arguments)) = first_tool_call(&parsed) {
-        let tool_type = ToolType::bind(&name, &arguments)?;
+    // Tool calls take precedence over text; binding failures surface as a failed decision. Sort by
+    // id so the assistant calls and (later) their results share one canonical order in history,
+    // keeping the positional render aligned.
+    let calls = all_tool_calls(&parsed);
+    if !calls.is_empty() {
+        let mut tool_calls = Vec::with_capacity(calls.len());
+        for (id, name, arguments) in calls {
+            let tool_type = ToolType::bind(&name, &arguments)?;
+            tool_calls.push(ToolCall { id, tool_type });
+        }
+        tool_calls.sort_by(|a, b| a.id.cmp(&b.id));
         return Ok(LLMResponse {
             thoughts,
-            output: LLMDecisionType::IntermediateToolCall {
-                tool_call: ToolCall { id, tool_type },
-            },
+            output: LLMDecisionType::IntermediateToolCall { tool_calls },
         });
     }
 

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -1,7 +1,7 @@
 use crate::{
     models::user::{
         HistoryEntry, LLMDecisionType, LLMInput, LLMResponse, RecentConversation, ToolCall,
-        UserAction,
+        ToolType, UserAction,
     },
     services::llama_cpp::LlamaCppService,
     Env,
@@ -42,10 +42,10 @@ fn budget_note(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
 }
 
 /// Build the conversation as an OpenAI-style messages JSON array (without the system turn — the
-/// agent prepends that). The `tool_call_id` is threaded from each assistant call to the result
-/// that follows it. Prior reasoning is not replayed (Qwen3 guidance). When the new input is a tool
-/// result, the running budget reminder is appended to it at render time (never persisted, so old
-/// turns don't accumulate stale counts).
+/// agent prepends that). Each tool result carries its own `tool_call_id` (from the call it answers),
+/// so no positional threading is needed. Prior reasoning is not replayed (Qwen3 guidance). When the
+/// new input is a tool result, the running budget reminder is appended to it at render time (never
+/// persisted, so old turns don't accumulate stale counts).
 fn build_conversation(
     new_input: &LLMInput,
     maybe_recent_conversation: Option<RecentConversation>,
@@ -57,25 +57,16 @@ fn build_conversation(
         .unwrap_or_default();
 
     let mut messages: Vec<Value> = Vec::new();
-    let mut last_tool_call_id: Option<String> = None;
 
     for entry in &history {
         match entry {
-            HistoryEntry::Input(input) => {
-                messages.push(input.to_openai_message(last_tool_call_id.as_deref()))
-            }
-            HistoryEntry::Output(response) => {
-                messages.push(response.to_openai_message());
-                last_tool_call_id = match &response.output {
-                    LLMDecisionType::IntermediateToolCall { id, .. } => Some(id.clone()),
-                    _ => None,
-                };
-            }
+            HistoryEntry::Input(input) => messages.push(input.to_openai_message()),
+            HistoryEntry::Output(response) => messages.push(response.to_openai_message()),
         }
     }
 
-    let mut new_message = new_input.to_openai_message(last_tool_call_id.as_deref());
-    if matches!(new_input, LLMInput::ToolResult(_)) {
+    let mut new_message = new_input.to_openai_message();
+    if matches!(new_input, LLMInput::ToolResult { .. }) {
         if let Some(note) = budget_note(tool_rounds, max_tool_rounds) {
             if let Some(content) = new_message.get("content").and_then(|c| c.as_str()) {
                 new_message["content"] = Value::String(format!("{content}\n\n{note}"));
@@ -154,10 +145,12 @@ async fn get_response_from_llm(
 
     // A tool call takes precedence over text; binding failures surface as a failed decision.
     if let Some((id, name, arguments)) = first_tool_call(&parsed) {
-        let tool_call = ToolCall::bind(&name, &arguments)?;
+        let tool_type = ToolType::bind(&name, &arguments)?;
         return Ok(LLMResponse {
             thoughts,
-            output: LLMDecisionType::IntermediateToolCall { tool_call, id },
+            output: LLMDecisionType::IntermediateToolCall {
+                tool_call: ToolCall { id, tool_type },
+            },
         });
     }
 

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -2,7 +2,7 @@ use crate::{
     configuration::client_tokens::BRAVE_SEARCH_TOKEN,
     externals::{recall_long_term_external::recall_long, recall_short_term_external::recall_short},
     models::user::{
-        HistoryEntry, MathOperation, ToolCall, ToolResultData, UserAction,
+        HistoryEntry, MathOperation, ToolResultData, ToolType, UserAction,
         MAX_SEARCH_DESCRIPTION_LENGTH,
     },
     Env,
@@ -302,28 +302,28 @@ async fn fetch_url_content(url: &str) -> anyhow::Result<ToolResultData> {
 
 pub async fn execute_tool(
     env: Arc<Env>,
-    tool_call: ToolCall,
+    tool_type: ToolType,
     user_id: String,
     history: Vec<HistoryEntry>,
 ) -> UserAction {
-    match tool_call {
-        ToolCall::GetWeather { location } => match fetch_weather(&location).await {
+    match tool_type {
+        ToolType::GetWeather { location } => match fetch_weather(&location).await {
             Ok(weather_info) => UserAction::ToolResult(Ok(weather_info)),
             Err(e) => UserAction::ToolResult(Err(e.to_string())),
         },
-        ToolCall::MathCalculation { operations } => {
+        ToolType::MathCalculation { operations } => {
             UserAction::ToolResult(Ok(execute_math(operations).await))
         }
-        ToolCall::WebSearch { query } => match fetch_web_search(&query).await {
+        ToolType::WebSearch { query } => match fetch_web_search(&query).await {
             Ok(search_results) => UserAction::ToolResult(Ok(search_results)),
             Err(e) => UserAction::ToolResult(Err(e.to_string())),
         },
-        ToolCall::VisitUrl { url } => match fetch_url_content(&url).await {
+        ToolType::VisitUrl { url } => match fetch_url_content(&url).await {
             Ok(content) => UserAction::ToolResult(Ok(content)),
             Err(e) => UserAction::ToolResult(Err(e.to_string())),
         },
-        ToolCall::RecallShortTerm { .. } => UserAction::ToolResult(Ok(recall_short(&history))),
-        ToolCall::RecallLongTerm { search_term } => {
+        ToolType::RecallShortTerm { .. } => UserAction::ToolResult(Ok(recall_short(&history))),
+        ToolType::RecallLongTerm { search_term } => {
             match recall_long(env, user_id, search_term).await {
                 Ok(data) => UserAction::ToolResult(Ok(data)),
                 Err(e) => UserAction::ToolResult(Err(e.to_string())),

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -2,7 +2,7 @@ use crate::{
     configuration::client_tokens::BRAVE_SEARCH_TOKEN,
     externals::{recall_long_term_external::recall_long, recall_short_term_external::recall_short},
     models::user::{
-        HistoryEntry, MathOperation, ToolResultData, ToolType, UserAction,
+        HistoryEntry, MathOperation, ToolCall, ToolResultData, ToolType, UserAction,
         MAX_SEARCH_DESCRIPTION_LENGTH,
     },
     Env,
@@ -300,35 +300,38 @@ async fn fetch_url_content(url: &str) -> anyhow::Result<ToolResultData> {
     Ok(ToolResultData { actual, simplified })
 }
 
-pub async fn execute_tool(
+/// Run one tool to its result. Errors are returned as `Err(String)`; the state machine folds them
+/// into a `ToolResultData` when moving the call to `completed_tools`.
+async fn run_tool(
     env: Arc<Env>,
     tool_type: ToolType,
     user_id: String,
     history: Vec<HistoryEntry>,
-) -> UserAction {
+) -> Result<ToolResultData, String> {
     match tool_type {
-        ToolType::GetWeather { location } => match fetch_weather(&location).await {
-            Ok(weather_info) => UserAction::ToolResult(Ok(weather_info)),
-            Err(e) => UserAction::ToolResult(Err(e.to_string())),
-        },
-        ToolType::MathCalculation { operations } => {
-            UserAction::ToolResult(Ok(execute_math(operations).await))
-        }
-        ToolType::WebSearch { query } => match fetch_web_search(&query).await {
-            Ok(search_results) => UserAction::ToolResult(Ok(search_results)),
-            Err(e) => UserAction::ToolResult(Err(e.to_string())),
-        },
-        ToolType::VisitUrl { url } => match fetch_url_content(&url).await {
-            Ok(content) => UserAction::ToolResult(Ok(content)),
-            Err(e) => UserAction::ToolResult(Err(e.to_string())),
-        },
-        ToolType::RecallShortTerm { .. } => UserAction::ToolResult(Ok(recall_short(&history))),
+        ToolType::GetWeather { location } => fetch_weather(&location).await.map_err(|e| e.to_string()),
+        ToolType::MathCalculation { operations } => Ok(execute_math(operations).await),
+        ToolType::WebSearch { query } => fetch_web_search(&query).await.map_err(|e| e.to_string()),
+        ToolType::VisitUrl { url } => fetch_url_content(&url).await.map_err(|e| e.to_string()),
+        ToolType::RecallShortTerm { .. } => Ok(recall_short(&history)),
         ToolType::RecallLongTerm { search_term } => {
-            match recall_long(env, user_id, search_term).await {
-                Ok(data) => UserAction::ToolResult(Ok(data)),
-                Err(e) => UserAction::ToolResult(Err(e.to_string())),
-            }
+            recall_long(env, user_id, search_term).await.map_err(|e| e.to_string())
         }
+    }
+}
+
+/// Execute a single tool call as its own external op, tagging the result action with the call's id
+/// so the state machine can move it from `pending_tools` to `completed_tools`.
+pub async fn execute_tool(
+    env: Arc<Env>,
+    tool_call: ToolCall,
+    user_id: String,
+    history: Vec<HistoryEntry>,
+) -> UserAction {
+    let result = run_tool(env, tool_call.tool_type, user_id, history).await;
+    UserAction::ToolResult {
+        id: tool_call.id,
+        result,
     }
 }
 

--- a/chatbot/src/models/user.rs
+++ b/chatbot/src/models/user.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::fmt::Display;
 use strum::{EnumDiscriminants, EnumIter};
 
@@ -73,12 +74,14 @@ pub enum UserState {
         outcome: LLMResponse,
         recent_conversation: RecentConversation,
     },
-    RunningTool {
+    RunningTools {
         is_timeout: bool,
         recent_conversation: RecentConversation,
         tool_rounds: usize,
-        /// The in-flight call, kept so the returning result can be tagged with its id positionally.
-        tool_call: ToolCall,
+        /// Calls still in flight this batch, keyed by id (id duplicated as the key).
+        pending_tools: HashMap<String, ToolCall>,
+        /// Calls that have returned, paired with their (error-folded) result.
+        completed_tools: Vec<(ToolCall, ToolResultData)>,
     },
 }
 impl Default for UserState {
@@ -99,17 +102,20 @@ pub struct User {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
     UserMessage(String),
-    /// A tool result tagged with the id of the call it answers (from the in-flight `ToolCall`).
-    ToolResult { id: String, data: ToolResultData },
+    /// One turn's batch of tool results (id order), each tagged with the call it answers.
+    ToolResults(Vec<ToolResult>),
 }
 
 impl LLMInput {
-    pub fn to_openai_message(&self) -> Value {
+    /// Render to OpenAI messages: a user message is one message; a tool-result batch is one `tool`
+    /// message per result (the template groups them into a single tool-response turn).
+    pub fn to_openai_messages(&self) -> Vec<Value> {
         match self {
-            LLMInput::UserMessage(msg) => json!({ "role": "user", "content": msg }),
-            LLMInput::ToolResult { id, data } => {
-                json!({ "role": "tool", "tool_call_id": id, "content": data.actual })
-            }
+            LLMInput::UserMessage(msg) => vec![json!({ "role": "user", "content": msg })],
+            LLMInput::ToolResults(results) => results
+                .iter()
+                .map(|r| json!({ "role": "tool", "tool_call_id": r.id, "content": r.data.actual }))
+                .collect(),
         }
     }
 }
@@ -147,9 +153,17 @@ pub struct ToolCall {
     pub tool_type: ToolType,
 }
 
+/// A concrete tool result: the data tagged with the id of the call it answers (symmetric to
+/// [`ToolCall`]). One per call in a batch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub id: String,
+    pub data: ToolResultData,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMDecisionType {
-    IntermediateToolCall { tool_call: ToolCall },
+    IntermediateToolCall { tool_calls: Vec<ToolCall> },
     MessageUser { response: String },
 }
 
@@ -166,19 +180,22 @@ impl LLMResponse {
             LLMDecisionType::MessageUser { response } => {
                 json!({ "role": "assistant", "content": response })
             }
-            // Tool-call turns carry empty content + a native tool_calls array. name/arguments are
-            // derived back from the bound ToolType (the inverse of `ToolType::bind`).
-            LLMDecisionType::IntermediateToolCall { tool_call } => json!({
+            // Tool-call turns carry empty content + a native tool_calls array (one entry per call).
+            // name/arguments are derived back from each bound ToolType (the inverse of `bind`).
+            LLMDecisionType::IntermediateToolCall { tool_calls } => json!({
                 "role": "assistant",
                 "content": "",
-                "tool_calls": [{
-                    "id": tool_call.id,
-                    "type": "function",
-                    "function": {
-                        "name": tool_call.tool_type.wire_name(),
-                        "arguments": tool_call.tool_type.wire_arguments()
-                    }
-                }]
+                "tool_calls": tool_calls
+                    .iter()
+                    .map(|tc| json!({
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.tool_type.wire_name(),
+                            "arguments": tc.tool_type.wire_arguments()
+                        }
+                    }))
+                    .collect::<Vec<_>>()
             }),
         }
     }
@@ -195,18 +212,20 @@ impl HistoryEntry {
         match self {
             HistoryEntry::Input(llm_input) => match llm_input {
                 LLMInput::UserMessage(m) => format!("User:\n{m}"),
-                LLMInput::ToolResult {
-                    data: ToolResultData { simplified, .. },
-                    ..
-                } => {
-                    format!("Assistant:\n{simplified}")
+                LLMInput::ToolResults(results) => {
+                    let joined = results
+                        .iter()
+                        .map(|r| r.data.simplified.clone())
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    format!("Assistant:\n{joined}")
                 }
             },
             HistoryEntry::Output(LLMResponse { output, .. }) => {
                 let text = match output {
                     LLMDecisionType::MessageUser { response } => response.clone(),
-                    LLMDecisionType::IntermediateToolCall { tool_call } => {
-                        format!("{tool_call:?}")
+                    LLMDecisionType::IntermediateToolCall { tool_calls } => {
+                        format!("{tool_calls:?}")
                     }
                 };
                 format!("Assistant:\n{text}")
@@ -226,7 +245,11 @@ pub enum UserAction {
     CommitResult(Result<(), String>),
     LLMDecisionResult(Result<LLMResponse, String>),
     MessageSent(Result<(), String>),
-    ToolResult(Result<ToolResultData, String>),
+    /// One tool's result, tagged with the id of the call it answers (one action per dispatched call).
+    ToolResult {
+        id: String,
+        result: Result<ToolResultData, String>,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -244,7 +267,7 @@ impl std::fmt::Debug for UserAction {
             UserAction::CommitResult(_) => write!(f, "CommitResult"),
             UserAction::LLMDecisionResult(_) => write!(f, "LLMDecisionResult"),
             UserAction::MessageSent(_) => write!(f, "MessageSent"),
-            UserAction::ToolResult(_) => write!(f, "ToolResult"),
+            UserAction::ToolResult { .. } => write!(f, "ToolResult"),
         }
     }
 }

--- a/chatbot/src/models/user.rs
+++ b/chatbot/src/models/user.rs
@@ -77,6 +77,8 @@ pub enum UserState {
         is_timeout: bool,
         recent_conversation: RecentConversation,
         tool_rounds: usize,
+        /// The in-flight call, kept so the returning result can be tagged with its id positionally.
+        tool_call: ToolCall,
     },
 }
 impl Default for UserState {
@@ -97,16 +99,16 @@ pub struct User {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
     UserMessage(String),
-    ToolResult(ToolResultData),
+    /// A tool result tagged with the id of the call it answers (from the in-flight `ToolCall`).
+    ToolResult { id: String, data: ToolResultData },
 }
 
 impl LLMInput {
-    pub fn to_openai_message(&self, last_tool_call_id: Option<&str>) -> Value {
+    pub fn to_openai_message(&self) -> Value {
         match self {
             LLMInput::UserMessage(msg) => json!({ "role": "user", "content": msg }),
-            LLMInput::ToolResult(ToolResultData { actual, .. }) => {
-                let id = last_tool_call_id.unwrap_or("call_0");
-                json!({ "role": "tool", "tool_call_id": id, "content": actual })
+            LLMInput::ToolResult { id, data } => {
+                json!({ "role": "tool", "tool_call_id": id, "content": data.actual })
             }
         }
     }
@@ -121,13 +123,14 @@ pub enum MathOperation {
     Exp(f32, f32),
 }
 
-/// Every executable tool. `ToolKind` (via `EnumDiscriminants`) is the fieldless companion used to
-/// build the advertised registry and look tools up by wire name — see `crate::tools`.
+/// A tool and its arguments. `ToolKind` (via `EnumDiscriminants`) is the fieldless companion used
+/// to build the advertised registry and look tools up by wire name — see `crate::tools`. Pair it
+/// with the parser-assigned id via [`ToolCall`] for a concrete invocation.
 #[derive(Debug, Clone, Serialize, Deserialize, EnumDiscriminants)]
 #[strum_discriminants(name(ToolKind))]
 #[strum_discriminants(derive(EnumIter))]
 #[strum_discriminants(vis(pub))]
-pub enum ToolCall {
+pub enum ToolType {
     GetWeather { location: String },
     MathCalculation { operations: Vec<MathOperation> },
     WebSearch { query: String },
@@ -136,9 +139,17 @@ pub enum ToolCall {
     RecallLongTerm { search_term: String },
 }
 
+/// A concrete tool invocation: a [`ToolType`] tagged with the id the parser assigned, so a result
+/// can be paired back to the call that produced it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub tool_type: ToolType,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMDecisionType {
-    IntermediateToolCall { tool_call: ToolCall, id: String },
+    IntermediateToolCall { tool_call: ToolCall },
     MessageUser { response: String },
 }
 
@@ -156,16 +167,16 @@ impl LLMResponse {
                 json!({ "role": "assistant", "content": response })
             }
             // Tool-call turns carry empty content + a native tool_calls array. name/arguments are
-            // derived back from the bound ToolCall (the inverse of `ToolCall::bind`).
-            LLMDecisionType::IntermediateToolCall { tool_call, id } => json!({
+            // derived back from the bound ToolType (the inverse of `ToolType::bind`).
+            LLMDecisionType::IntermediateToolCall { tool_call } => json!({
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [{
-                    "id": id,
+                    "id": tool_call.id,
                     "type": "function",
                     "function": {
-                        "name": tool_call.wire_name(),
-                        "arguments": tool_call.wire_arguments()
+                        "name": tool_call.tool_type.wire_name(),
+                        "arguments": tool_call.tool_type.wire_arguments()
                     }
                 }]
             }),
@@ -184,14 +195,17 @@ impl HistoryEntry {
         match self {
             HistoryEntry::Input(llm_input) => match llm_input {
                 LLMInput::UserMessage(m) => format!("User:\n{m}"),
-                LLMInput::ToolResult(ToolResultData { simplified, .. }) => {
+                LLMInput::ToolResult {
+                    data: ToolResultData { simplified, .. },
+                    ..
+                } => {
                     format!("Assistant:\n{simplified}")
                 }
             },
             HistoryEntry::Output(LLMResponse { output, .. }) => {
                 let text = match output {
                     LLMDecisionType::MessageUser { response } => response.clone(),
-                    LLMDecisionType::IntermediateToolCall { tool_call, .. } => {
+                    LLMDecisionType::IntermediateToolCall { tool_call } => {
                         format!("{tool_call:?}")
                     }
                 };

--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -3,7 +3,7 @@ use crate::externals::{
     llama_cpp_external::get_llm_decision, message_external::send_message,
     tool_call_external::execute_tool,
 };
-use crate::models::user::{LLMResponse, ToolResultData, MAX_TOOL_ROUNDS};
+use crate::models::user::{LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
 use crate::{
     models::user::{
         HistoryEntry, LLMDecisionType, LLMInput, RecentConversation, User, UserAction, UserId,
@@ -16,6 +16,7 @@ use framework::{
     new_state_machine, ExternalOperation, Schedule, Scheduled, Transition, TransitionResult,
 };
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -47,22 +48,29 @@ fn handle_outcome(
             },
             Vec::new(),
         )),
-        LLMDecisionType::IntermediateToolCall { tool_call } => {
+        LLMDecisionType::IntermediateToolCall { tool_calls } => {
+            // Dispatch every call as its own external op and seed pending_tools, so each returning
+            // result can be moved to completed_tools by id (one round per batch).
             let mut external = Vec::<UserExternalOperation>::new();
-            external.push(Box::pin(execute_tool(
-                env,
-                tool_call.tool_type.clone(),
-                user_id.to_string(),
-                recent_conversation.history.clone(),
-            )));
+            let mut pending_tools = HashMap::new();
+            for tool_call in tool_calls {
+                external.push(Box::pin(execute_tool(
+                    env.clone(),
+                    tool_call.clone(),
+                    user_id.to_string(),
+                    recent_conversation.history.clone(),
+                )));
+                pending_tools.insert(tool_call.id.clone(), tool_call);
+            }
 
             Ok((
                 User {
-                    state: UserState::RunningTool {
+                    state: UserState::RunningTools {
                         is_timeout,
                         recent_conversation,
                         tool_rounds: tool_rounds + 1,
-                        tool_call,
+                        pending_tools,
+                        completed_tools: Vec::new(),
                     },
                     last_transition: Utc::now(),
                     pending,
@@ -211,81 +219,84 @@ pub fn user_transition(
                 0,
             ),
             (
-                UserState::RunningTool {
+                UserState::RunningTools {
                     recent_conversation,
                     is_timeout,
                     tool_rounds,
-                    tool_call,
+                    mut pending_tools,
+                    mut completed_tools,
                 },
-                UserAction::ToolResult(res),
+                UserAction::ToolResult { id, result },
             ) => {
-                match res {
-                    Ok(tool_result) => {
-                        let current_input = LLMInput::ToolResult {
-                            id: tool_call.id.clone(),
-                            data: tool_result.clone(),
-                        };
+                // Move this tool from pending to completed, folding any error into the result data.
+                if let Some(tool_call) = pending_tools.remove(id) {
+                    let data = match result {
+                        Ok(data) => data.clone(),
+                        Err(error_msg) => {
+                            let msg = format!("Tool execution failed: {error_msg}");
+                            ToolResultData {
+                                actual: msg.clone(),
+                                simplified: msg,
+                            }
+                        }
+                    };
+                    completed_tools.push((tool_call, data));
+                } else {
+                    eprintln!("[warn] tool result for unknown id {id}; ignoring");
+                }
 
-                        let history = recent_conversation.history();
-                        let mut external = Vec::<UserExternalOperation>::new();
-                        external.push(Box::pin(get_llm_decision(
-                            env.clone(),
-                            current_input.clone(),
-                            Some(recent_conversation),
-                            tool_rounds,
-                            MAX_TOOL_ROUNDS,
-                        )));
+                if pending_tools.is_empty() {
+                    // Whole batch done: sort by id so calls and results align positionally, then
+                    // hand the results back to the model as one tool-result turn.
+                    completed_tools.sort_by(|(a, _), (b, _)| a.id.cmp(&b.id));
+                    let results = completed_tools
+                        .into_iter()
+                        .map(|(tool_call, data)| ToolResult {
+                            id: tool_call.id,
+                            data,
+                        })
+                        .collect();
+                    let current_input = LLMInput::ToolResults(results);
 
-                        Ok((
-                            User {
-                                state: UserState::AwaitingLLMDecision {
-                                    is_timeout,
-                                    history,
-                                    current_input,
-                                    tool_rounds,
-                                },
-                                last_transition: Utc::now(),
-                                ..user
+                    let history = recent_conversation.history();
+                    let mut external = Vec::<UserExternalOperation>::new();
+                    external.push(Box::pin(get_llm_decision(
+                        env.clone(),
+                        current_input.clone(),
+                        Some(recent_conversation),
+                        tool_rounds,
+                        MAX_TOOL_ROUNDS,
+                    )));
+
+                    Ok((
+                        User {
+                            state: UserState::AwaitingLLMDecision {
+                                is_timeout,
+                                history,
+                                current_input,
+                                tool_rounds,
                             },
-                            external,
-                        ))
-                    }
-                    Err(error_msg) => {
-                        let error_result = format!("Tool execution failed: {}", error_msg);
-                        let current_input = LLMInput::ToolResult {
-                            id: tool_call.id.clone(),
-                            data: ToolResultData {
-                                actual: error_result.clone(),
-                                simplified: error_result,
+                            last_transition: Utc::now(),
+                            ..user
+                        },
+                        external,
+                    ))
+                } else {
+                    // Still waiting on other tools in the batch — stay put, dispatch nothing new.
+                    Ok((
+                        User {
+                            state: UserState::RunningTools {
+                                is_timeout,
+                                recent_conversation,
+                                tool_rounds,
+                                pending_tools,
+                                completed_tools,
                             },
-                        };
-
-                        let history = recent_conversation.history();
-
-                        // Let LLM handle the error and inform the user
-                        let mut external = Vec::<UserExternalOperation>::new();
-                        external.push(Box::pin(get_llm_decision(
-                            env.clone(),
-                            current_input.clone(),
-                            Some(recent_conversation),
-                            tool_rounds,
-                            MAX_TOOL_ROUNDS,
-                        )));
-
-                        Ok((
-                            User {
-                                state: UserState::AwaitingLLMDecision {
-                                    is_timeout,
-                                    history,
-                                    current_input,
-                                    tool_rounds,
-                                },
-                                last_transition: Utc::now(),
-                                ..user
-                            },
-                            external,
-                        ))
-                    }
+                            last_transition: Utc::now(),
+                            ..user
+                        },
+                        Vec::new(),
+                    ))
                 }
             }
             (
@@ -417,7 +428,7 @@ pub fn schedule(user: &User) -> Vec<Scheduled<UserAction>> {
         UserState::AwaitingLLMDecision { .. }
         | UserState::SendingMessage { .. }
         | UserState::CommitingToMemory { .. }
-        | UserState::RunningTool { .. } => schedules.push(Scheduled {
+        | UserState::RunningTools { .. } => schedules.push(Scheduled {
             at: user.last_transition + ChronoDuration::milliseconds(600_000),
             action: UserAction::ForceReset,
         }),

--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -47,11 +47,11 @@ fn handle_outcome(
             },
             Vec::new(),
         )),
-        LLMDecisionType::IntermediateToolCall { tool_call, .. } => {
+        LLMDecisionType::IntermediateToolCall { tool_call } => {
             let mut external = Vec::<UserExternalOperation>::new();
             external.push(Box::pin(execute_tool(
                 env,
-                tool_call,
+                tool_call.tool_type.clone(),
                 user_id.to_string(),
                 recent_conversation.history.clone(),
             )));
@@ -62,6 +62,7 @@ fn handle_outcome(
                         is_timeout,
                         recent_conversation,
                         tool_rounds: tool_rounds + 1,
+                        tool_call,
                     },
                     last_transition: Utc::now(),
                     pending,
@@ -214,12 +215,16 @@ pub fn user_transition(
                     recent_conversation,
                     is_timeout,
                     tool_rounds,
+                    tool_call,
                 },
                 UserAction::ToolResult(res),
             ) => {
                 match res {
                     Ok(tool_result) => {
-                        let current_input = LLMInput::ToolResult(tool_result.clone());
+                        let current_input = LLMInput::ToolResult {
+                            id: tool_call.id.clone(),
+                            data: tool_result.clone(),
+                        };
 
                         let history = recent_conversation.history();
                         let mut external = Vec::<UserExternalOperation>::new();
@@ -247,10 +252,13 @@ pub fn user_transition(
                     }
                     Err(error_msg) => {
                         let error_result = format!("Tool execution failed: {}", error_msg);
-                        let current_input = LLMInput::ToolResult(ToolResultData {
-                            actual: error_result.clone(),
-                            simplified: error_result,
-                        });
+                        let current_input = LLMInput::ToolResult {
+                            id: tool_call.id.clone(),
+                            data: ToolResultData {
+                                actual: error_result.clone(),
+                                simplified: error_result,
+                            },
+                        };
 
                         let history = recent_conversation.history();
 

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use strum::IntoEnumIterator;
 
-use crate::models::user::{ToolCall, ToolKind};
+use crate::models::user::{ToolKind, ToolType};
 
 #[derive(Debug, Deserialize)]
 struct GetWeatherArgs {
@@ -86,7 +86,7 @@ impl ToolKind {
     }
 }
 
-impl ToolCall {
+impl ToolType {
     pub fn tools_json() -> String {
         let entries: Vec<Value> = ToolKind::iter().filter_map(|k| k.definition()).collect();
         Value::Array(entries).to_string()
@@ -99,32 +99,32 @@ impl ToolCall {
     /// JSON arguments to replay this call into history — the inverse of `bind`.
     pub fn wire_arguments(&self) -> String {
         match self {
-            ToolCall::GetWeather { location } => json!({ "city": location }),
-            ToolCall::MathCalculation { operations } => json!({ "operations": operations }),
-            ToolCall::WebSearch { query } => json!({ "query": query }),
-            ToolCall::VisitUrl { url } => json!({ "url": url }),
-            ToolCall::RecallShortTerm { reason } => json!({ "reason": reason }),
-            ToolCall::RecallLongTerm { search_term } => json!({ "search_term": search_term }),
+            ToolType::GetWeather { location } => json!({ "city": location }),
+            ToolType::MathCalculation { operations } => json!({ "operations": operations }),
+            ToolType::WebSearch { query } => json!({ "query": query }),
+            ToolType::VisitUrl { url } => json!({ "url": url }),
+            ToolType::RecallShortTerm { reason } => json!({ "reason": reason }),
+            ToolType::RecallLongTerm { search_term } => json!({ "search_term": search_term }),
         }
         .to_string()
     }
 
-    /// Bind a model-emitted call (name + raw JSON arguments) to a `ToolCall`. Unknown name or
+    /// Bind a model-emitted call (name + raw JSON arguments) to a `ToolType`. Unknown name or
     /// unbindable tool → runtime error; the per-variant match is exhaustive so new variants must
     /// be handled here.
-    pub fn bind(name: &str, arguments: &str) -> anyhow::Result<ToolCall> {
+    pub fn bind(name: &str, arguments: &str) -> anyhow::Result<ToolType> {
         let kind = ToolKind::iter()
             .find(|k| k.wire_name() == name)
             .ok_or_else(|| anyhow::anyhow!("model called an unknown tool: {name}"))?;
 
         match kind {
-            ToolKind::GetWeather => Ok(ToolCall::GetWeather {
+            ToolKind::GetWeather => Ok(ToolType::GetWeather {
                 location: parse_args::<GetWeatherArgs>(name, arguments)?.city,
             }),
-            ToolKind::WebSearch => Ok(ToolCall::WebSearch {
+            ToolKind::WebSearch => Ok(ToolType::WebSearch {
                 query: parse_args::<WebSearchArgs>(name, arguments)?.query,
             }),
-            ToolKind::VisitUrl => Ok(ToolCall::VisitUrl {
+            ToolKind::VisitUrl => Ok(ToolType::VisitUrl {
                 url: parse_args::<VisitUrlArgs>(name, arguments)?.url,
             }),
             ToolKind::MathCalculation | ToolKind::RecallShortTerm | ToolKind::RecallLongTerm => {


### PR DESCRIPTION
Closes #98. Implemented in two phases (see commits).

## Phase 1 — wrap tool calls with their id
- Rename the tool enum `ToolCall` → `ToolType` (the call + arguments); `tools_json`/`wire_name`/`wire_arguments`/`bind` move onto it.
- Add `ToolCall { id, tool_type }`; `IntermediateToolCall { tool_call }` folds the id into the wrapper.
- `LLMInput::ToolResult { id, data }` — the result self-describes the call it answers, so `build_conversation` no longer threads `last_tool_call_id` positionally.
- `RunningTool` carries the in-flight `ToolCall`.

## Phase 2 — run every call (fan-out / collect)
- `RunningTool` → `RunningTools { pending_tools: HashMap<id, ToolCall>, completed_tools: Vec<(ToolCall, ToolResultData)> }`.
- `IntermediateToolCall { tool_calls: Vec<ToolCall> }`; `LLMInput::ToolResults(Vec<ToolResult>)`; `to_openai_messages` renders the batch as N `tool` messages.
- `UserAction::ToolResult { id, result }`; `execute_tool` tags the action with the call id. `handle_outcome` dispatches **one external op per call** (one budget round per batch); each result moves `pending → completed` by id, and when `pending` empties we **sort by id** and hand the batch back to the model.
- `all_tool_calls` (was `first_tool_call`) keeps every call. Calls and results are **both id-sorted**, so the positional Qwen render (which strips ids) aligns. Errors are **per-call isolated** (one failed tool ≠ turn failure). Dropped the one-tool-per-turn system-prompt line.

## Why id-ordering (not call order)
The model's chat template strips `tool_call_id` and pairs result↔call **positionally** (verified in the probe — the binding does not reorder by id). Sorting both calls and results by id gives one canonical order on both sides, so the render always aligns. Re-sorting vs the model's emission order is cosmetic and harmless (the model doesn't depend on its own ordering).

## Verified live (build `389d54d`)
Two parallel round-trips in one conversation, then a followup:
- weather Berlin+Moscow (both calls failed → each surfaced its own folded error result, ids matched);
- visit `docs.rs` + `raiyan.bd` (both fetched, results paired correctly by id order);
- followup "what's docs.rs for?" answered from context with no new tool call.
History entries are well-formed: one assistant turn with N id-sorted `tool_calls` + N `tool` messages in the same order; positional alignment confirmed in the rendered ChatML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)