### PR TITLE
Fold mid-tool-run user messages into the tool-result turn

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -217,7 +217,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. If a user message appears immediately after tool results, this means the user sent something while the tool was running — incorporate the new instructions into your decision making for the next step.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. If a user message appears immediately after tool results, the user sent it while the tool was running — treat it as additional input alongside the original request: it may add to, refine, or override that request, so keep serving the original goal unless the new message clearly replaces it.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             Utc::now().format("%Y-%m-%d %H:%M")
         )

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -217,7 +217,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. If a user message appears immediately after tool results, this means the user sent something while the tool was running — incorporate the new instructions into your decision making for the next step.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             Utc::now().format("%Y-%m-%d %H:%M")
         )

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -217,7 +217,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. If a user message appears immediately after tool results, the user sent it while the tool was running — treat it as additional input alongside the original request: it may add to, refine, or override that request, so keep serving the original goal unless the new message clearly replaces it.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. If a user message appears immediately after tool results, the user sent it while the tool was running — treat it as additional input alongside the original request: it may add to, refine, or override that request. Don't forget the original goal either, unless it's obviously no longer relevant.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             Utc::now().format("%Y-%m-%d %H:%M")
         )

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -66,12 +66,18 @@ fn build_conversation(
     }
 
     let mut new_messages = new_input.to_openai_messages();
-    // Append the budget note to the last tool-result message of the batch (nearest the generation).
-    if matches!(new_input, LLMInput::ToolResults(_)) {
+    // Append the budget note to the last tool-result message of the batch. A user interjection
+    // folded into the turn trails the results, so target the last `tool` message specifically
+    // rather than the last message overall (which would land the note on the user's words).
+    if matches!(new_input, LLMInput::ToolResults(..)) {
         if let Some(note) = budget_note(tool_rounds, max_tool_rounds) {
-            if let Some(last) = new_messages.last_mut() {
-                if let Some(content) = last.get("content").and_then(|c| c.as_str()) {
-                    last["content"] = Value::String(format!("{content}\n\n{note}"));
+            if let Some(last_tool) = new_messages
+                .iter_mut()
+                .rev()
+                .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("tool"))
+            {
+                if let Some(content) = last_tool.get("content").and_then(|c| c.as_str()) {
+                    last_tool["content"] = Value::String(format!("{content}\n\n{note}"));
                 }
             }
         }

--- a/chatbot/src/models/user.rs
+++ b/chatbot/src/models/user.rs
@@ -103,7 +103,10 @@ pub struct User {
 pub enum LLMInput {
     UserMessage(String),
     /// One turn's batch of tool results (id order), each tagged with the call it answers.
-    ToolResults(Vec<ToolResult>),
+    /// The optional trailing `String` is user message(s) that arrived mid-tool-run, folded into
+    /// this same turn *after* the results — OpenAI requires tool responses to immediately follow
+    /// the assistant's `tool_calls`, so the user message comes last.
+    ToolResults(Vec<ToolResult>, Option<String>),
 }
 
 impl LLMInput {
@@ -112,10 +115,17 @@ impl LLMInput {
     pub fn to_openai_messages(&self) -> Vec<Value> {
         match self {
             LLMInput::UserMessage(msg) => vec![json!({ "role": "user", "content": msg })],
-            LLMInput::ToolResults(results) => results
-                .iter()
-                .map(|r| json!({ "role": "tool", "tool_call_id": r.id, "content": r.data.actual }))
-                .collect(),
+            LLMInput::ToolResults(results, user_msg) => {
+                let mut messages: Vec<Value> = results
+                    .iter()
+                    .map(|r| json!({ "role": "tool", "tool_call_id": r.id, "content": r.data.actual }))
+                    .collect();
+                // A user interjection that arrived mid-tool-run trails the results (protocol order).
+                if let Some(msg) = user_msg {
+                    messages.push(json!({ "role": "user", "content": msg }));
+                }
+                messages
+            }
         }
     }
 }
@@ -212,13 +222,18 @@ impl HistoryEntry {
         match self {
             HistoryEntry::Input(llm_input) => match llm_input {
                 LLMInput::UserMessage(m) => format!("User:\n{m}"),
-                LLMInput::ToolResults(results) => {
+                LLMInput::ToolResults(results, user_msg) => {
                     let joined = results
                         .iter()
                         .map(|r| r.data.simplified.clone())
                         .collect::<Vec<_>>()
                         .join("\n");
-                    format!("Assistant:\n{joined}")
+                    let assistant = format!("Assistant:\n{joined}");
+                    // Surface the folded-in interjection so recall/memory text stays faithful.
+                    match user_msg {
+                        Some(msg) => format!("{assistant}\nUser:\n{msg}"),
+                        None => assistant,
+                    }
                 }
             },
             HistoryEntry::Output(LLMResponse { output, .. }) => {

--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -376,11 +376,7 @@ pub fn user_transition(
 /// `None` if there was nothing buffered. Single source of truth for both pending drain points (the
 /// Idle drain below and the mid-tool-loop fold in the RunningTools branch), so they stay identical.
 fn take_pending(pending: &mut Vec<String>) -> Option<String> {
-    if pending.is_empty() {
-        None
-    } else {
-        Some(std::mem::take(pending).join("\n"))
-    }
+    (!pending.is_empty()).then(|| std::mem::take(pending).join("\n"))
 }
 
 fn post_transition(

--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -256,7 +256,11 @@ pub fn user_transition(
                             data,
                         })
                         .collect();
-                    let current_input = LLMInput::ToolResults(results);
+                    // Fold any messages the user sent mid-tool-run into this same turn (after the
+                    // results, per the OpenAI protocol). Clearing pending here is required — else
+                    // post_transition drains it again at Idle and the message is sent twice.
+                    let mut pending = user.pending;
+                    let current_input = LLMInput::ToolResults(results, take_pending(&mut pending));
 
                     let history = recent_conversation.history();
                     let mut external = Vec::<UserExternalOperation>::new();
@@ -277,7 +281,7 @@ pub fn user_transition(
                                 tool_rounds,
                             },
                             last_transition: Utc::now(),
-                            ..user
+                            pending,
                         },
                         external,
                     ))
@@ -368,52 +372,65 @@ pub fn user_transition(
     })
 }
 
+/// Drain buffered user messages into a single newline-joined string, clearing `pending`. Returns
+/// `None` if there was nothing buffered. Single source of truth for both pending drain points (the
+/// Idle drain below and the mid-tool-loop fold in the RunningTools branch), so they stay identical.
+fn take_pending(pending: &mut Vec<String>) -> Option<String> {
+    if pending.is_empty() {
+        None
+    } else {
+        Some(std::mem::take(pending).join("\n"))
+    }
+}
+
 fn post_transition(
     env: Arc<Env>,
     _user_id: UserId,
     result: UserTransitionResult,
 ) -> UserTransitionResult {
-    let (user, mut external) = result?;
+    let (mut user, mut external) = result?;
 
-    match (&user.state, user.pending.len() > 0) {
-        (
-            UserState::Idle {
-                recent_conversation,
+    // Never rest in Idle with buffered input: drain it into a fresh user turn. (Mirrors the
+    // mid-tool-loop fold in the RunningTools branch, which folds into a tool-result turn instead.)
+    let recent_conversation = match &user.state {
+        UserState::Idle {
+            recent_conversation,
+        } => recent_conversation.clone(),
+        _ => return Ok((user, external)),
+    };
+
+    let Some(msg) = take_pending(&mut user.pending) else {
+        return Ok((user, external));
+    };
+
+    let history = recent_conversation
+        .as_ref()
+        .map(|(rc, _)| rc.history())
+        .unwrap_or_else(Vec::new);
+
+    let current_input = LLMInput::UserMessage(msg);
+
+    external.push(Box::pin(get_llm_decision(
+        env.clone(),
+        current_input.clone(),
+        recent_conversation.map(|(rc, _)| rc),
+        0,
+        MAX_TOOL_ROUNDS,
+    )));
+
+    Ok((
+        User {
+            state: UserState::AwaitingLLMDecision {
+                is_timeout: false,
+                history,
+                current_input,
+                tool_rounds: 0,
             },
-            true,
-        ) => {
-            let msg = user.pending.join("\n");
-
-            let current_input = LLMInput::UserMessage(msg.clone());
-
-            let history = recent_conversation
-                .as_ref()
-                .map(|(rc, _)| rc.history())
-                .unwrap_or_else(|| Vec::new());
-
-            external.push(Box::pin(get_llm_decision(
-                env.clone(),
-                current_input.clone(),
-                recent_conversation.as_ref().map(|(rc, _)| rc.clone()),
-                0,
-                MAX_TOOL_ROUNDS,
-            )));
-
-            let user = User {
-                state: UserState::AwaitingLLMDecision {
-                    is_timeout: false,
-                    history,
-                    current_input: LLMInput::UserMessage(msg.clone()),
-                    tool_rounds: 0,
-                },
-                last_transition: Utc::now(),
-                pending: Vec::new(),
-            };
-
-            Ok((user, external))
-        }
-        _ => Ok((user, external)),
-    }
+            last_transition: Utc::now(),
+            pending: Vec::new(),
+        },
+        external,
+    ))
 }
 
 pub fn schedule(user: &User) -> Vec<Scheduled<UserAction>> {


### PR DESCRIPTION
Closes #101.

## What
When a user messages mid-turn, the message is buffered in `User.pending` and was previously only drained when the machine returned to `Idle`. If the turn routed through a tool loop, the interjection waited for the **entire** turn (all tool rounds + final reply) before the model ever saw it.

This adds a **second drain point** at the `RunningTools → AwaitingLLMDecision` transition: when a tool batch completes, any buffered user messages are folded into that same LLM turn, *after* the tool results — so the model reacts to the interjection a turn sooner.

## How
- `LLMInput::ToolResults(Vec<ToolResult>)` → `ToolResults(Vec<ToolResult>, Option<String>)`. The optional trailing string is the folded interjection.
  - `to_openai_messages` renders the `tool` messages first, then a trailing `user` message — preserving the OpenAI rule that tool responses must immediately follow the assistant's `tool_calls`.
  - `format_simplified` appends a `User:` line so recall/memory text stays faithful.
- New `take_pending(&mut Vec<String>) -> Option<String>` helper (newline-join + clear) is the single source of truth for both drain points: the existing `Idle` drain in `post_transition` and the new mid-tool-loop fold.
- The batch-complete branch clears `pending` when folding — required, else `post_transition` drains it again at `Idle` and the message is sent twice.
- The budget note in `llama_cpp_external` now targets the last `tool` message specifically, so a folded interjection never gets the note appended to it.

## Invariants / decisions (per #101)
- **History timing:** the folded message rides inside `current_input` and only enters history once the LLM has seen it and replied (history is appended at `LLMDecisionResult` time, never at dispatch). Holds by construction.
- **`tool_rounds`:** a mid-loop interjection does **not** reset the budget — folded into the ongoing turn.
- **Error path:** if the LLM call errors, the folded message is discarded — same loss that already exists for the `Idle`-drain path. Accepted.
- **AwaitingLLMDecision path unchanged:** messages arriving there still buffer and drain via `Idle` exactly as before; this change is purely additive.

## Testing
`cargo check -p chatbot` passes (only pre-existing dead-code warnings). No automated tests exist for the state machine; behavior reasoned through per the state transitions. Not yet run live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)