### PR TITLE
Cosmetic: combined notice for multiple tools, lowercase 'using'

### DIFF
--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -161,13 +161,17 @@ pub fn user_transition(
                     let message_to_send = response.message.clone().or_else(|| {
                         (!response.tool_calls.is_empty() && env.announce_tool_use).then(|| {
                             // Discord subtext (`-# `) + italic so it reads as a small, greyed
-                            // status line, not a real bot message.
-                            response
+                            // status line, not a real bot message. One tool → singular; several →
+                            // a single combined line.
+                            let names: Vec<&str> = response
                                 .tool_calls
                                 .iter()
-                                .map(|tc| format!("-# *Using tool: {}*", tc.tool_type.wire_name()))
-                                .collect::<Vec<_>>()
-                                .join("\n")
+                                .map(|tc| tc.tool_type.wire_name())
+                                .collect();
+                            match names.as_slice() {
+                                [one] => format!("-# *using tool: {one}*"),
+                                many => format!("-# *using multiple tools: {}*", many.join(", ")),
+                            }
                         })
                     });
 


### PR DESCRIPTION
Tweaks the tool-use notice from #104:
- **Single tool:** `-# *using tool: get_weather*`
- **Multiple tools:** one combined line — `-# *using multiple tools: web_search, visit_url*` — instead of one subtext line per call.
- Lowercased `Using` → `using`.

Names are listed per call in `tool_calls` order (no dedup), no params. Cosmetic only — no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)