### PR TITLE
Triple the idle timeout (5min -> 15min)

### DIFF
--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -455,7 +455,7 @@ pub fn schedule(user: &User) -> Vec<Scheduled<UserAction>> {
         UserState::Idle {
             recent_conversation: Some((_, last_activity)),
         } => schedules.push(Scheduled {
-            at: last_activity + ChronoDuration::milliseconds(300_000),
+            at: last_activity + ChronoDuration::milliseconds(900_000),
             action: UserAction::Timeout,
         }),
         UserState::AwaitingLLMDecision { .. }


### PR DESCRIPTION
Bumps the idle `Timeout` schedule from 300_000ms (5 min) to 900_000ms (15 min), so idle conversations stay alive ~3× longer before the timeout/goodbye flow fires. Busy-state `ForceReset` (600s) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)