### PR TITLE
Rich UserMessage { text, queued }; tag mid-response followups with [Followup]

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -217,7 +217,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. A user message prefixed with [Followup] was sent while you were still producing your previous response, so it crossed that reply and may already be addressed by it. Read it against what you just said: don't redundantly re-answer what you already covered, but do handle anything new it adds, and reprioritize or drop the original goal if it clearly changes what the user wants.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. A user message prefixed with [Followup] was sent while you were still producing your previous response or tools were running, so it crossed that reply and may already be addressed by it. Read it against what you just said: don't redundantly re-answer what you already covered, but do handle anything new it adds, and reprioritize or drop the original goal if it clearly changes what the user wants.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             Utc::now().format("%Y-%m-%d %H:%M")
         )

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -217,7 +217,7 @@ impl Agent {
 
     pub fn system_content(&self) -> String {
         format!(
-            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. If a user message appears immediately after tool results, the user sent it while the tool was running — treat it as additional input alongside the original request: it may add to, refine, or override that request. Don't forget the original goal either, unless it's obviously no longer relevant.\n\nCurrent date and time (UTC): {}",
+            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps. A user message prefixed with [Followup] was sent while you were still producing your previous response, so it crossed that reply and may already be addressed by it. Read it against what you just said: don't redundantly re-answer what you already covered, but do handle anything new it adds, and reprioritize or drop the original goal if it clearly changes what the user wants.\n\nCurrent date and time (UTC): {}",
             self.system_prompt,
             Utc::now().format("%Y-%m-%d %H:%M")
         )

--- a/chatbot/src/externals/long_term_memory_external.rs
+++ b/chatbot/src/externals/long_term_memory_external.rs
@@ -53,8 +53,8 @@ async fn commit(
     let filtered: Vec<String> = history
         .iter()
         .filter_map(|h| match h {
-            HistoryEntry::Input(LLMInput::UserMessage(text)) => {
-                Some(format!("USER MESSAGE: {text}"))
+            HistoryEntry::Input(LLMInput::UserMessage(msg)) => {
+                Some(format!("USER MESSAGE: {}", msg.text))
             }
             HistoryEntry::Output(LLMResponse {
                 message: Some(response),

--- a/chatbot/src/state_machines/user_state_machine.rs
+++ b/chatbot/src/state_machines/user_state_machine.rs
@@ -6,7 +6,7 @@ use crate::externals::{
 use crate::types::user::{LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
 use crate::{
     types::user::{
-        HistoryEntry, LLMInput, RecentConversation, User, UserAction, UserId,
+        HistoryEntry, LLMInput, RecentConversation, User, UserAction, UserId, UserMessage,
         UserState,
     },
     Env, ENV,
@@ -30,7 +30,7 @@ fn handle_outcome(
     is_timeout: bool,
     response: LLMResponse,
     recent_conversation: RecentConversation,
-    pending: Vec<String>,
+    pending: Vec<UserMessage>,
     tool_rounds: usize,
 ) -> UserTransitionResult {
     // Any `message` was already sent on the way into SendingMessage; here we act on the tool calls.
@@ -117,7 +117,13 @@ pub fn user_transition(
 
                 let pending = if accept_message {
                     let mut pending = user.pending;
-                    pending.push(msg.clone());
+                    // Queued iff it arrived while the bot was busy (any non-Idle state) — i.e. it
+                    // crossed an in-flight response. An Idle arrival drains immediately and isn't.
+                    let queued = !matches!(&user_state, UserState::Idle { .. });
+                    pending.push(UserMessage {
+                        text: msg.clone(),
+                        queued,
+                    });
                     pending
                 } else {
                     user.pending
@@ -359,7 +365,10 @@ pub fn user_transition(
                 println!("Commited to Memory");
 
                 let timeout_message = "User said goodbye, RESPOND WITH GOODBYE BUT MENTION RELEVANT THINGS ABOUT THE CONVERSATION".to_string();
-                let current_input = LLMInput::UserMessage(timeout_message);
+                let current_input = LLMInput::UserMessage(UserMessage {
+                    text: timeout_message,
+                    queued: false,
+                });
 
                 let mut external = Vec::<UserExternalOperation>::new();
 
@@ -395,8 +404,19 @@ pub fn user_transition(
 /// Drain buffered user messages into a single newline-joined string, clearing `pending`. Returns
 /// `None` if there was nothing buffered. Single source of truth for both pending drain points (the
 /// Idle drain below and the mid-tool-loop fold in the RunningTools branch), so they stay identical.
-fn take_pending(pending: &mut Vec<String>) -> Option<String> {
-    (!pending.is_empty()).then(|| std::mem::take(pending).join("\n"))
+fn take_pending(pending: &mut Vec<UserMessage>) -> Option<UserMessage> {
+    (!pending.is_empty()).then(|| {
+        let drained = std::mem::take(pending);
+        // Messages drained together are homogeneous (all queued during a busy turn, or a single
+        // Idle arrival); mark the merged message queued if any were.
+        let queued = drained.iter().any(|m| m.queued);
+        let text = drained
+            .into_iter()
+            .map(|m| m.text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        UserMessage { text, queued }
+    })
 }
 
 fn post_transition(

--- a/chatbot/src/types/user.rs
+++ b/chatbot/src/types/user.rs
@@ -96,21 +96,42 @@ impl Default for UserState {
     }
 }
 
+/// A user message. `queued` is true when it was buffered into `pending` while the bot was busy
+/// (a non-Idle state), so it crossed an in-flight response. The flag is the persisted truth;
+/// the `[Followup]` tag is applied only at prompt-render time (see `to_content`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserMessage {
+    pub text: String,
+    pub queued: bool,
+}
+
+impl UserMessage {
+    /// Prompt content: the text, prefixed with `[Followup]` when it was queued mid-response so the
+    /// model knows it may already be addressed. Render-time only — the stored `text` stays clean.
+    pub fn to_content(&self) -> String {
+        if self.queued {
+            format!("[Followup] {}", self.text)
+        } else {
+            self.text.clone()
+        }
+    }
+}
+
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct User {
-    pub pending: Vec<String>,
+    pub pending: Vec<UserMessage>,
     pub state: UserState,
     pub last_transition: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
-    UserMessage(String),
+    UserMessage(UserMessage),
     /// One turn's batch of tool results (id order), each tagged with the call it answers.
-    /// The optional trailing `String` is user message(s) that arrived mid-tool-run, folded into
-    /// this same turn *after* the results — OpenAI requires tool responses to immediately follow
-    /// the assistant's `tool_calls`, so the user message comes last.
-    ToolResults(Vec<ToolResult>, Option<String>),
+    /// The optional trailing `UserMessage` is input that arrived mid-tool-run, folded into this
+    /// same turn *after* the results — OpenAI requires tool responses to immediately follow the
+    /// assistant's `tool_calls`, so the user message comes last.
+    ToolResults(Vec<ToolResult>, Option<UserMessage>),
 }
 
 impl LLMInput {
@@ -118,7 +139,7 @@ impl LLMInput {
     /// message per result (the template groups them into a single tool-response turn).
     pub fn to_openai_messages(&self) -> Vec<Value> {
         match self {
-            LLMInput::UserMessage(msg) => vec![json!({ "role": "user", "content": msg })],
+            LLMInput::UserMessage(msg) => vec![json!({ "role": "user", "content": msg.to_content() })],
             LLMInput::ToolResults(results, user_msg) => {
                 let mut messages: Vec<Value> = results
                     .iter()
@@ -126,7 +147,7 @@ impl LLMInput {
                     .collect();
                 // A user interjection that arrived mid-tool-run trails the results (protocol order).
                 if let Some(msg) = user_msg {
-                    messages.push(json!({ "role": "user", "content": msg }));
+                    messages.push(json!({ "role": "user", "content": msg.to_content() }));
                 }
                 messages
             }
@@ -231,7 +252,7 @@ impl HistoryEntry {
     pub fn format_simplified(&self) -> String {
         match self {
             HistoryEntry::Input(llm_input) => match llm_input {
-                LLMInput::UserMessage(m) => format!("User:\n{m}"),
+                LLMInput::UserMessage(m) => format!("User:\n{}", m.text),
                 LLMInput::ToolResults(results, user_msg) => {
                     let joined = results
                         .iter()
@@ -241,7 +262,7 @@ impl HistoryEntry {
                     let assistant = format!("Assistant:\n{joined}");
                     // Surface the folded-in interjection so recall/memory text stays faithful.
                     match user_msg {
-                        Some(msg) => format!("{assistant}\nUser:\n{msg}"),
+                        Some(msg) => format!("{assistant}\nUser:\n{}", msg.text),
                         None => assistant,
                     }
                 }


### PR DESCRIPTION
Replaces bare `String` user messages with a `UserMessage { text, queued }` type, used in `pending` and `LLMInput`.

## Behavior
- `queued` is set at the **push** site: true iff the message arrived while the bot was in a non-Idle state (buffered into `pending` mid-response). An Idle arrival (drains immediately, incl. a conversation's first message) is `queued: false`. The flag persists through the drain into the turn, so it cleanly distinguishes a mid-response interjection from a normal message — fixing the ambiguity at the `post_transition` Idle drain (which serves both cases).
- At prompt-render time (`to_openai_messages`), a `queued` message is prefixed with **`[Followup]`** so the model knows it crossed an in-flight response and may already be addressed (the "you already answered this" UX wart).
- Covers **both** drain paths: the Idle drain and the tool-result fold (`take_pending` now yields a `UserMessage`; `ToolResults`' trailing slot is `Option<UserMessage>`).

## Principle alignment
The `queued` flag is the **persisted truth** in the state machine; the `[Followup]` text is **prompt-shaping applied only in the renderer**. Stored `text` stays clean — `format_simplified` and the long-term-memory filter use `.text` without the tag, so recall isn't polluted.

## Scope
`UserMessage` type + `to_content()` renderer (types/user.rs), `User.pending` / `LLMInput` variants, `handle_outcome` param, the push, `take_pending`, the timeout-goodbye construction, and the memory filter. `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)