### PR TITLE
Replace Brave Search with self-hosted SearxNG (#113)

### DIFF
--- a/chatbot/Justfile
+++ b/chatbot/Justfile
@@ -26,8 +26,12 @@ run_local tag="latest":
     docker stop bot 2>/dev/null || true
     docker rm bot 2>/dev/null || true
     # Run with AMD GPU support (ROCm)
+    # Host networking: the bot shares the host's network stack (no bridge/NAT), so it reaches
+    # host-published services like the SearxNG instance at http://localhost:8080 directly — see
+    # SEARXNG_URL. The bot has no inbound listener (Discord gateway is outbound), so no port clash.
     docker run -d \
         --name bot \
+        --network host \
         --device=/dev/kfd \
         --device=/dev/dri \
         --group-add video \

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -83,20 +83,46 @@ To improve startup performance, the bot pre-evaluates the static base prompt (sy
 
 The `web_search` tool queries a [SearxNG](https://github.com/searxng/searxng) instance — a self-hosted metasearch engine — instead of a metered third-party API, so there's no external rate limit to trip.
 
-The bot only needs a reachable instance with **JSON output enabled**:
+The bot only needs **a reachable instance with JSON output enabled**:
 
 - Point `SEARXNG_URL` (in `src/configuration.rs`) at the instance's base URL. The bot runs with host networking (`--network host`), so `localhost` is the host machine — the default `http://localhost:8080` reaches a SearxNG published on the host's port 8080. A remote instance works too (e.g. `https://search.example.com`).
-- The instance **must** have JSON format enabled, off by default. In its `settings.yml`:
-  ```yaml
-  search:
-    formats:
-      - html
-      - json
-  ```
-- Verify with: `curl "$SEARXNG_URL/search?q=test&format=json"` — it should return JSON with a `results` array.
+- The instance **must** have JSON format enabled (it's off by default — see the `settings.yml` below).
 
 > [!NOTE]
-> How you run SearxNG (Docker, bare metal, hosted) is out of scope here — see the [upstream SearxNG docs](https://docs.searxng.org/). A quick local container is `docker run -d --name searxng -p 8080:8080 -v <config-dir>:/etc/searxng searxng/searxng`, with the JSON format and a `server.secret_key` set in the mounted `settings.yml`.
+> **Running** SearxNG (Docker, bare metal, hosted) is out of scope here — see the [upstream docs](https://docs.searxng.org/). The steps below are just a convenience for a quick local instance.
+
+A minimal local container:
+
+1. **Create a config dir and `settings.yml`** that overrides only what we need on top of the image defaults:
+   ```yaml
+   # <config-dir>/settings.yml
+   use_default_settings: true
+   server:
+     # Required: SearxNG won't start without one. Generate via `openssl rand -hex 32`.
+     secret_key: "<random-hex>"
+     # Listen on all interfaces inside the container so the published port works.
+     bind_address: "0.0.0.0"
+   search:
+     # JSON is off by default; the bot's web_search calls the JSON endpoint, so enable it.
+     formats:
+       - html
+       - json
+   ```
+
+2. **Run the container**, mounting that config and publishing port 8080 on the host:
+   ```bash
+   docker run -d --name searxng --restart unless-stopped \
+     -p 8080:8080 \
+     -v <config-dir>:/etc/searxng \
+     searxng/searxng
+   ```
+   The bot runs with `--network host`, so the host's `:8080` is reachable at the default `SEARXNG_URL=http://localhost:8080`.
+
+3. **Verify JSON output works:**
+   ```bash
+   curl "http://localhost:8080/search?q=test&format=json"   # → JSON with a "results" array
+   ```
+   A `403`/HTML response usually means JSON isn't enabled (check `search.formats`) or the limiter is blocking direct API calls (set `server.limiter: false` for a private instance).
 
 ## Architecture
 

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -79,6 +79,25 @@ To improve startup performance, the bot pre-evaluates the static base prompt (sy
 - On startup, if the session file exists, it's loaded to skip re-evaluation.
 - If missing or invalid, it falls back to full evaluation and regenerates the file.
 
+### Web Search (SearxNG)
+
+The `web_search` tool queries a [SearxNG](https://github.com/searxng/searxng) instance — a self-hosted metasearch engine — instead of a metered third-party API, so there's no external rate limit to trip.
+
+The bot only needs a reachable instance with **JSON output enabled**:
+
+- Point `SEARXNG_URL` (in `src/configuration.rs`) at the instance's base URL. The bot runs with host networking (`--network host`), so `localhost` is the host machine — the default `http://localhost:8080` reaches a SearxNG published on the host's port 8080. A remote instance works too (e.g. `https://search.example.com`).
+- The instance **must** have JSON format enabled, off by default. In its `settings.yml`:
+  ```yaml
+  search:
+    formats:
+      - html
+      - json
+  ```
+- Verify with: `curl "$SEARXNG_URL/search?q=test&format=json"` — it should return JSON with a `results` array.
+
+> [!NOTE]
+> How you run SearxNG (Docker, bare metal, hosted) is out of scope here — see the [upstream SearxNG docs](https://docs.searxng.org/). A quick local container is `docker run -d --name searxng -p 8080:8080 -v <config-dir>:/etc/searxng searxng/searxng`, with the JSON format and a `server.secret_key` set in the mounted `settings.yml`.
+
 ## Architecture
 
 ### Directory Structure

--- a/chatbot/src/configuration.rs.template
+++ b/chatbot/src/configuration.rs.template
@@ -2,7 +2,10 @@ pub const MONGODB_AUTH: &str = "FOO";
 pub mod client_tokens {
     pub const TELEGRAM_TOKEN: &str = "FOO";
     pub const DISCORD_TOKEN: &str = "FOO";
-    pub const BRAVE_SEARCH_TOKEN: &str = "FOO";
+    /// Base URL of the SearxNG instance backing `web_search` (JSON format must be enabled on it).
+    /// The bot runs with host networking, so `localhost` is the host — point a SearxNG at the
+    /// host's :8080, or set this to a remote instance's URL.
+    pub const SEARXNG_URL: &str = "http://localhost:8080";
 }
 pub mod debug {
     pub const DEBUG_LIVE_LLM_OUTPUT: bool = false;

--- a/chatbot/src/configuration.rs.template
+++ b/chatbot/src/configuration.rs.template
@@ -6,6 +6,10 @@ pub mod client_tokens {
     /// The bot runs with host networking, so `localhost` is the host — point a SearxNG at the
     /// host's :8080, or set this to a remote instance's URL.
     pub const SEARXNG_URL: &str = "http://localhost:8080";
+    /// Dormant fallback: token for the legacy Brave Search path (`fetch_web_search_brave`), kept
+    /// intact but not wired into the active SearxNG `web_search`. See tool_call_external.rs.
+    #[allow(dead_code)]
+    pub const BRAVE_SEARCH_TOKEN: &str = "FOO";
 }
 pub mod debug {
     pub const DEBUG_LIVE_LLM_OUTPUT: bool = false;

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -126,12 +126,33 @@ async fn fetch_weather(location: &str) -> anyhow::Result<ToolResultData> {
     })
 }
 
-/// SearxNG `/search?format=json` response. We only read `query` (echoed back) and `results`; the
-/// many other top-level fields (suggestions, infoboxes, …) are ignored.
+/// SearxNG `/search?format=json` response. Beyond the ranked `results`, SearxNG aggregates an
+/// instant `answers` summary and structured `infoboxes` (entity cards) — these are often a direct
+/// answer to the query, so we surface them ahead of the links. Other top-level fields
+/// (suggestions, corrections, …) are ignored.
 #[derive(Deserialize)]
 struct SearxngResponse {
     query: String,
+    #[serde(default)]
+    answers: Vec<SearxngAnswer>,
+    #[serde(default)]
+    infoboxes: Vec<SearxngInfobox>,
     results: Vec<SearxngResult>,
+}
+
+#[derive(Deserialize)]
+struct SearxngAnswer {
+    #[serde(default)]
+    answer: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SearxngInfobox {
+    /// The infobox heading (entity name), e.g. "Rust (programming language)".
+    #[serde(default)]
+    infobox: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -143,7 +164,16 @@ struct SearxngResult {
     /// SearxNG's result snippet (mapped to our "Description" line).
     #[serde(default)]
     content: Option<String>,
+    /// Publication date, when the engine reports one (news/articles); absent for most pages.
+    #[serde(default, rename = "publishedDate")]
+    published_date: Option<String>,
 }
+
+/// Search results formatted for the model. The 32k-token context affords plenty of room; the old
+/// cap of 3 was tuned for a much smaller, less capable setup.
+const MAX_SEARCH_RESULTS: usize = 8;
+/// Of those, how many also go into the `simplified` (recall/memory) text.
+const SIMPLIFIED_SEARCH_RESULTS: usize = 3;
 
 async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
     let search_url = format!(
@@ -182,10 +212,29 @@ async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
         })?;
 
     let original_query = search_response.query;
+
+    // High-signal lead: instant answers and the first infobox, when present — often a direct
+    // answer to the query, placed ahead of the ranked links. Shared by both simplified and actual.
+    let mut lead = String::new();
+    for answer in search_response
+        .answers
+        .iter()
+        .filter_map(|a| a.answer.as_deref())
+        .filter(|s| !s.is_empty())
+    {
+        lead.push_str(&format!("Instant answer: {answer}\n\n"));
+    }
+    if let Some(infobox) = search_response.infoboxes.first() {
+        if let Some(content) = infobox.content.as_deref().filter(|s| !s.is_empty()) {
+            let title = infobox.infobox.as_deref().unwrap_or("Info");
+            lead.push_str(&format!("{title}: {content}\n\n"));
+        }
+    }
+
     let formatted_results: Vec<String> = search_response
         .results
         .into_iter()
-        .take(3)
+        .take(MAX_SEARCH_RESULTS)
         .map(|result| {
             let title = result.title.as_deref().unwrap_or("null");
             let url = result.url.as_deref().unwrap_or("null");
@@ -193,19 +242,24 @@ async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
 
             let safe_len = description.floor_char_boundary(MAX_SEARCH_DESCRIPTION_LENGTH);
             let description = &description[..safe_len];
-            format!("Title: {title}\nURL to visit: {url}\nDescription: {description}\n\n",)
+            // Surface the publication date when the engine provides one (recency cue).
+            let published = result
+                .published_date
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(|d| format!("Published: {d}\n"))
+                .unwrap_or_default();
+            format!("Title: {title}\nURL to visit: {url}\n{published}Description: {description}\n\n")
         })
         .collect();
 
-    let simplified_partition = 1;
-    let (primary, secondary) = match formatted_results.len() > simplified_partition {
-        true => formatted_results.split_at(simplified_partition),
-        false => (formatted_results.as_slice(), &[][..]),
-    };
+    // `simplified` (recall/memory) keeps the lead plus the top few results; `actual` (fed to the
+    // model live) keeps the lead plus every result.
+    let split = SIMPLIFIED_SEARCH_RESULTS.min(formatted_results.len());
+    let (primary, secondary) = formatted_results.split_at(split);
 
     let simplified = format!(
-        "Search results for \"{}\":\n{}",
-        original_query,
+        "{lead}Search results for \"{original_query}\":\n{}",
         primary.join("\n")
     );
 
@@ -267,22 +321,22 @@ async fn fetch_page(url: &str) -> anyhow::Result<ExtractedPage> {
 }
 
 async fn fetch_url_content(url: &str) -> anyhow::Result<ToolResultData> {
-    pub const MAX_ACTUAL_WEB_CONTENT_LENGTH: usize = 10000;
-    pub const MAX_SIMPLIFIED_WEB_CONTENT_LENGTH: usize = 300;
+    // Generous caps for the 32k-token context: `actual` is the full read fed to the model,
+    // `simplified` a longer preview for recall/memory (were 10000 / 300).
+    pub const MAX_ACTUAL_WEB_CONTENT_LENGTH: usize = 50000;
+    pub const MAX_SIMPLIFIED_WEB_CONTENT_LENGTH: usize = 2000;
 
     let extracted = fetch_page(url).await?;
 
-    let actual_content = if extracted.content.len() > MAX_ACTUAL_WEB_CONTENT_LENGTH {
-        &extracted.content[..MAX_ACTUAL_WEB_CONTENT_LENGTH]
-    } else {
-        &extracted.content
-    };
+    // `floor_char_boundary` clamps to the string length and never splits a multi-byte char, so a
+    // raw byte-index slice here can't panic on a UTF-8 boundary (the old `[..N]` could).
+    let actual_end = extracted.content.floor_char_boundary(MAX_ACTUAL_WEB_CONTENT_LENGTH);
+    let actual_content = &extracted.content[..actual_end];
 
-    let simplified_content = if extracted.content.len() > MAX_SIMPLIFIED_WEB_CONTENT_LENGTH {
-        &extracted.content[..MAX_SIMPLIFIED_WEB_CONTENT_LENGTH]
-    } else {
-        &extracted.content
-    };
+    let simplified_end = extracted
+        .content
+        .floor_char_boundary(MAX_SIMPLIFIED_WEB_CONTENT_LENGTH);
+    let simplified_content = &extracted.content[..simplified_end];
 
     let actual = format!("Content of {url}:\n{actual_content}");
     let simplified = format!("Content of {url}:\n{simplified_content}");

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -1,5 +1,5 @@
 use crate::{
-    configuration::client_tokens::BRAVE_SEARCH_TOKEN,
+    configuration::client_tokens::SEARXNG_URL,
     externals::{recall_long_term_external::recall_long, recall_short_term_external::recall_short},
     types::user::{
         HistoryEntry, MathOperation, ToolCall, ToolResultData, ToolType, UserAction,
@@ -126,35 +126,29 @@ async fn fetch_weather(location: &str) -> anyhow::Result<ToolResultData> {
     })
 }
 
+/// SearxNG `/search?format=json` response. We only read `query` (echoed back) and `results`; the
+/// many other top-level fields (suggestions, infoboxes, …) are ignored.
 #[derive(Deserialize)]
-struct BraveSearchResponse {
-    query: BraveSearchQuery,
-    web: BraveWebResults,
+struct SearxngResponse {
+    query: String,
+    results: Vec<SearxngResult>,
 }
 
 #[derive(Deserialize)]
-struct BraveSearchQuery {
-    original: String,
-}
-
-#[derive(Deserialize)]
-struct BraveWebResults {
-    results: Vec<BraveSearchResult>,
-}
-
-#[derive(Deserialize)]
-struct BraveSearchResult {
+struct SearxngResult {
     #[serde(default)]
     title: Option<String>,
     #[serde(default)]
     url: Option<String>,
+    /// SearxNG's result snippet (mapped to our "Description" line).
     #[serde(default)]
-    description: Option<String>,
+    content: Option<String>,
 }
 
 async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
     let search_url = format!(
-        "https://api.search.brave.com/res/v1/web/search?q={}",
+        "{}/search?q={}&format=json",
+        SEARXNG_URL.trim_end_matches('/'),
         urlencoding::encode(query)
     );
 
@@ -165,10 +159,9 @@ async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
     let response = client
         .get(&search_url)
         .header("Accept", "application/json")
-        .header("X-Subscription-Token", BRAVE_SEARCH_TOKEN)
         .send()
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to connect to Brave Search API: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to connect to SearxNG at {SEARXNG_URL}: {e}"))?;
 
     let status = response.status();
     if !status.is_success() {
@@ -177,29 +170,26 @@ async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
             .await
             .unwrap_or_else(|_| "Unknown error".to_string());
         return Err(anyhow::anyhow!(
-            "Brave Search API returned error status {}: {}",
-            status,
-            error_text
+            "SearxNG returned error status {status}: {error_text}"
         ));
     }
 
     let search_response = response
-        .json::<BraveSearchResponse>()
+        .json::<SearxngResponse>()
         .await
         .map_err(|e| {
-            anyhow::anyhow!("Failed to parse Brave Search response: {}. Make sure BRAVE_SEARCH_TOKEN is set correctly.", e)
+            anyhow::anyhow!("Failed to parse SearxNG response: {e}. Ensure SEARXNG_URL points at a SearxNG instance with JSON format enabled (search.formats includes json).")
         })?;
 
-    let original_query = search_response.query.original;
+    let original_query = search_response.query;
     let formatted_results: Vec<String> = search_response
-        .web
         .results
         .into_iter()
         .take(3)
         .map(|result| {
             let title = result.title.as_deref().unwrap_or("null");
             let url = result.url.as_deref().unwrap_or("null");
-            let description = result.description.as_deref().unwrap_or("null");
+            let description = result.content.as_deref().unwrap_or("null");
 
             let safe_len = description.floor_char_boundary(MAX_SEARCH_DESCRIPTION_LENGTH);
             let description = &description[..safe_len];
@@ -347,10 +337,12 @@ mod tests {
         assert!(weather.actual.contains("Wind Speed"));
     }
 
+    // Integration test: hits the SearxNG instance at SEARXNG_URL (reachable as localhost:8080 from
+    // the host). Requires a running instance with JSON format enabled.
     #[tokio::test]
     async fn test_fetch_web_search() {
         let search_results = fetch_web_search("Rust programming").await.unwrap();
-        assert!(search_results.actual.contains("Search Results for"));
+        assert!(search_results.actual.contains("Search results for"));
         assert!(search_results.actual.contains("Rust programming"));
     }
 

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -1,5 +1,5 @@
 use crate::{
-    configuration::client_tokens::SEARXNG_URL,
+    configuration::client_tokens::{BRAVE_SEARCH_TOKEN, SEARXNG_URL},
     externals::{recall_long_term_external::recall_long, recall_short_term_external::recall_short},
     types::user::{
         HistoryEntry, MathOperation, ToolCall, ToolResultData, ToolType, UserAction,
@@ -260,6 +260,110 @@ async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
 
     let simplified = format!(
         "{lead}Search results for \"{original_query}\":\n{}",
+        primary.join("\n")
+    );
+
+    let actual = format!("{simplified}\n{}", secondary.join("\n"));
+
+    Ok(ToolResultData { actual, simplified })
+}
+
+// ---------------------------------------------------------------------------------------------
+// Dormant fallback: the legacy Brave Search path, kept intact but NOT wired into `web_search`
+// (the active tool uses `fetch_web_search` / SearxNG above). Left in place so we can fall back by
+// swapping the call in `run_tool`. Remove once SearxNG is proven out. See #113 / closed #112.
+// ---------------------------------------------------------------------------------------------
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct BraveSearchResponse {
+    query: BraveSearchQuery,
+    web: BraveWebResults,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct BraveSearchQuery {
+    original: String,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct BraveWebResults {
+    results: Vec<BraveSearchResult>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct BraveSearchResult {
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[allow(dead_code)]
+async fn fetch_web_search_brave(query: &str) -> anyhow::Result<ToolResultData> {
+    let search_url = format!(
+        "https://api.search.brave.com/res/v1/web/search?q={}",
+        urlencoding::encode(query)
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+
+    let response = client
+        .get(&search_url)
+        .header("Accept", "application/json")
+        .header("X-Subscription-Token", BRAVE_SEARCH_TOKEN)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to Brave Search API: {}", e))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(anyhow::anyhow!(
+            "Brave Search API returned error status {}: {}",
+            status,
+            error_text
+        ));
+    }
+
+    let search_response = response
+        .json::<BraveSearchResponse>()
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("Failed to parse Brave Search response: {}. Make sure BRAVE_SEARCH_TOKEN is set correctly.", e)
+        })?;
+
+    let original_query = search_response.query.original;
+    let formatted_results: Vec<String> = search_response
+        .web
+        .results
+        .into_iter()
+        .take(MAX_SEARCH_RESULTS)
+        .map(|result| {
+            let title = result.title.as_deref().unwrap_or("null");
+            let url = result.url.as_deref().unwrap_or("null");
+            let description = result.description.as_deref().unwrap_or("null");
+
+            let safe_len = description.floor_char_boundary(MAX_SEARCH_DESCRIPTION_LENGTH);
+            let description = &description[..safe_len];
+            format!("Title: {title}\nURL to visit: {url}\nDescription: {description}\n\n")
+        })
+        .collect();
+
+    let split = SIMPLIFIED_SEARCH_RESULTS.min(formatted_results.len());
+    let (primary, secondary) = formatted_results.split_at(split);
+
+    let simplified = format!(
+        "Search results for \"{original_query}\":\n{}",
         primary.join("\n")
     );
 

--- a/chatbot/src/types/user.rs
+++ b/chatbot/src/types/user.rs
@@ -5,7 +5,10 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use strum::{EnumDiscriminants, EnumIter};
 
-pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 20;
+/// Per-result snippet cap in web search output. Generous — SearxNG snippets rarely exceed a few
+/// hundred chars, so this is effectively "don't truncate" with a safety net (was 20, far too tight
+/// for the current model/context).
+pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 2000;
 
 /// Max tool calls the model may make in a single user turn before the loop is cut short. Single
 /// source of truth: the state machine enforces it; the system prompt discloses it.


### PR DESCRIPTION
Closes #113.

`web_search` now queries a self-hosted [SearxNG](https://github.com/searxng/searxng) instance over its JSON endpoint instead of the Brave Search API — removing the global per-token rate limit that prompted #112 (closed: a client-side throttle can't fix a global external quota; the real fix is owning the search backend).

## 1. Brave → SearxNG swap
- **`fetch_web_search`** ([tool_call_external.rs](chatbot/src/externals/tool_call_external.rs)): `GET {SEARXNG_URL}/search?q=...&format=json`, parse SearxNG's response into the existing `ToolResultData`.
- **Config**: `SEARXNG_URL` added to `configuration.rs` and the checked-in `configuration.rs.template` (default `http://localhost:8080`).
- **Docs** ([README](chatbot/README.md)): how to point the bot at an instance + the JSON-format requirement. *Running* SearxNG is out of scope per #113 (links upstream).

## 2. Networking — `--network host`
[Justfile](chatbot/Justfile) `run_local` runs the bot with host networking. The bot is outbound-only (Discord gateway websocket; verified no inbound listener), so it shares the host stack and reaches a host-published SearxNG at plain `localhost:8080` — no bridge/NAT, no container-to-container coupling. Swap to a remote instance later = change only `SEARXNG_URL`.

## 3. Loosened truncation + richer data
The old caps were tuned for a much smaller setup; the 32k-token context has ample headroom.
- **Snippets** 20 → 2000 chars (effectively full); **results** 3 → 8; **simplified/recall** 1 → 3 results.
- Surface SearxNG's **instant `answers`** and first **`infobox`** as a high-signal lead (often a direct answer); include each result's **`publishedDate`** when present.
- **`visit_url`**: actual 10k → 50k chars, simplified 300 → 2k. Mechanism unchanged (SearxNG has no page-fetch endpoint — confirmed; `visit_url` stays our `reqwest` + `rs_trafilatura` extraction).
- **Bug fix**: `visit_url` previously sliced page content at a raw byte index (`&content[..N]`) — a UTF-8 boundary panic waiting to happen; now uses `floor_char_boundary` like the search path.

## 4. Brave kept as a dormant fallback
The Brave token, response structs, and search fn (renamed `fetch_web_search_brave`) are restored as self-contained `#[allow(dead_code)]` — **not** wired into `run_tool`. Reconnect via a one-line call swap if SearxNG misbehaves; remove once proven out.

## Testing
- `cargo build` clean (only pre-existing config warnings).
- `test_fetch_web_search` passes against a live local SearxNG (`localhost:8080` reachable from host). Also fixed its `"Search Results for"` assertion (capital R) that never matched the lowercase output.
- **Deployed locally** with `--network host`; container up, SearxNG reachable end-to-end, smoke-tested through Discord.