### PR TITLE
Neutralize "user" naming in the generic framework crate

### DIFF
--- a/framework/src/bee_handle.rs
+++ b/framework/src/bee_handle.rs
@@ -36,7 +36,7 @@ pub fn new_entity<
 >(
     env: Arc<Env>,
     id: Id,
-    user_state_machine_handle: StateMachineHandle<Id, Action>,
+    handle: StateMachineHandle<Id, Action>,
     transition: Transition<Id, State, Action, Env>,
     schedule: Schedule<State, Action>,
 ) -> Handle<Action> {
@@ -45,7 +45,7 @@ pub fn new_entity<
         env,
         id,
         receiver,
-        user_state_machine_handle,
+        handle,
         transition,
         schedule,
         sender.clone(),

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -85,14 +85,14 @@ async fn run_entity<
         match activity {
             Activity::StateMachineAction(action) => {
                 match transition.0(env.clone(), id.clone(), state.clone(), &action).await {
-                    Ok((updated_user, external)) => {
+                    Ok((updated_state, external)) => {
                         match &maybe_scheduled {
                             Some(scheduled) => {
                                 scheduled.abort();
                             }
                             None => {}
                         }
-                        let mut scheduled = schedule.0(&updated_user);
+                        let mut scheduled = schedule.0(&updated_state);
 
                         scheduled.sort_by_key(|scheduled| scheduled.at);
 
@@ -131,13 +131,13 @@ async fn run_entity<
 
                         external.into_iter().for_each(|f| {
                             let handle: StateMachineHandle<Id, Action> = handle.clone();
-                            let user_id = id.clone();
+                            let id = id.clone();
                             tokio::spawn(async move {
                                 let action = f.await;
-                                handle.act(user_id, action).await;
+                                handle.act(id, action).await;
                             });
                         });
-                        state = updated_user;
+                        state = updated_state;
                     }
                     Err(_) => (),
                 }

--- a/framework/src/state_machine_handle.rs
+++ b/framework/src/state_machine_handle.rs
@@ -20,10 +20,10 @@ where
     Id: PersistedStateMachineItem + Ord + 'static,
     Action: PersistedStateMachineItem + 'static,
 {
-    pub async fn act(&self, user_id: Id, user_action: Action) {
+    pub async fn act(&self, id: Id, action: Action) {
         let _ = self
             .sender
-            .send((user_id, user_action))
+            .send((id, action))
             .await
             .expect("Send failed");
     }
@@ -40,13 +40,13 @@ pub fn new_state_machine<
     schedule: Schedule<State, Action>,
 ) -> StateMachineHandle<Id, Action> {
     let (sender, receiver) = mpsc::channel(8);
-    let user_state_machine_handle = StateMachineHandle { sender };
+    let handle = StateMachineHandle { sender };
     tokio::spawn(start_state_machine(
         env,
-        user_state_machine_handle.clone(),
+        handle.clone(),
         receiver,
         transition,
         schedule,
     ));
-    user_state_machine_handle
+    handle
 }


### PR DESCRIPTION
The `framework` crate is a domain-agnostic actor runtime (generic over `Id`/`Action`), but its locals and one struct field were named after the chatbot's "user" concept. This renames them to neutral terms so the crate reads as the generic runtime it is — and removes the last "user" references from `framework/src/`.

## Renames
| Was | Now |
|---|---|
| `user_state_machine_handle` (field + locals) | `handle` |
| `user_id` (incl. `act` param + the `run_entity` self-shadow) | `id` |
| `user_action` (`act` param) | `action` |
| `updated_user` | `updated_state` |

Touches `bee_handle.rs`, `state_machine_handle.rs`, `lib.rs` — 12 sites, all that `grep -rniE user framework/src/` found.

## Non-breaking
Every change is a private local/field or a **parameter name** (positional, not part of the call contract), so the chatbot crate is unaffected. Verified: `grep` shows zero `user` left in the framework, and the **whole workspace builds clean**.

## Relationship to #115
Separate and complementary. #115 renames the chatbot's domain entity `User → Conversation`; this one keeps the framework *neutral* (explicitly NOT "conversation" — the runtime doesn't know about conversations). #115 calls this cleanup out as out-of-scope-but-optional; this PR does it independently.