### PR TITLE
Make the state-machine entity a Conversation (channel-keyed), not a User (#115)

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -152,7 +152,7 @@ fn respond_blocking(
     let messages_json = serde_json::Value::Array(messages).to_string();
 
     let template = model.chat_template(None)?;
-    let tools_json = crate::types::user::ToolType::tools_json();
+    let tools_json = crate::types::conversation::ToolType::tools_json();
     let params = OpenAIChatTemplateParams {
         messages_json: &messages_json,
         tools_json: if allow_tools {

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -1,7 +1,7 @@
 use crate::{
-    types::user::{
+    types::conversation::{
         HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
-        ToolType, UserAction,
+        ToolType, ConversationAction,
     },
     services::llama_cpp::LlamaCppService,
     Env,
@@ -176,7 +176,7 @@ pub async fn get_llm_decision(
     maybe_recent_conversation: Option<RecentConversation>,
     tool_rounds: usize,
     max_tool_rounds: usize,
-) -> UserAction {
+) -> ConversationAction {
     // Budget spent → final call with tools off, so the model can't emit another tool call; the
     // matching synthesis directive on the last tool result (see `budget_note`) nudges it to answer
     // from what it already gathered.
@@ -197,7 +197,7 @@ pub async fn get_llm_decision(
     .await;
 
     match llama_cpp_result {
-        Ok(llama_cpp_response) => UserAction::LLMDecisionResult(Ok(llama_cpp_response)),
-        Err(err) => UserAction::LLMDecisionResult(Err(err.to_string())),
+        Ok(llama_cpp_response) => ConversationAction::LLMDecisionResult(Ok(llama_cpp_response)),
+        Err(err) => ConversationAction::LLMDecisionResult(Err(err.to_string())),
     }
 }

--- a/chatbot/src/externals/long_term_memory_external.rs
+++ b/chatbot/src/externals/long_term_memory_external.rs
@@ -1,5 +1,5 @@
 use crate::{
-    types::user::{HistoryEntry, LLMInput, LLMResponse, UserAction},
+    types::conversation::{HistoryEntry, LLMInput, LLMResponse, ConversationAction},
     services::lance_db::LanceService,
     Env,
 };
@@ -43,17 +43,17 @@ pub async fn ensure_embedding_index(table: &Table, column: &str) -> Result<(), S
 
 async fn commit(
     lance_service: Arc<LanceService>,
-    user_id: String,
+    conversation_id: String,
     history: Vec<HistoryEntry>,
 ) -> Result<(), String> {
     let schema = Arc::clone(&lance_service.history_schema);
 
-    let table = lance_service.table_for_user(&user_id).await;
+    let table = lance_service.table_for_conversation(&conversation_id).await;
 
     let filtered: Vec<String> = history
         .iter()
         .filter_map(|h| match h {
-            HistoryEntry::Input(LLMInput::UserMessage(msg)) => {
+            HistoryEntry::Input(LLMInput::IncomingUpdate(msg)) => {
                 Some(format!("USER MESSAGE: {}", msg.text))
             }
             HistoryEntry::Output(LLMResponse {
@@ -95,13 +95,13 @@ async fn commit(
     )
     .map_err(|e| e.to_string())?;
 
-    let user_ids: Vec<String> = vec![user_id.clone(); filtered.len()];
+    let conversation_ids: Vec<String> = vec![conversation_id.clone(); filtered.len()];
 
     // 4. Build RecordBatch (Ensure your schema matches these 3 columns)
     let batch = RecordBatch::try_new(
         Arc::clone(&schema),
         vec![
-            Arc::new(StringArray::from(user_ids)),
+            Arc::new(StringArray::from(conversation_ids)),
             Arc::new(StringArray::from(filtered)),
             Arc::new(vector_array), // The new vector column
         ],
@@ -123,8 +123,8 @@ async fn commit(
 
 pub async fn commit_to_memory(
     env: Arc<Env>,
-    user_id: String,
+    conversation_id: String,
     history: Vec<HistoryEntry>,
-) -> UserAction {
-    UserAction::CommitResult(commit(Arc::clone(&env.lance_service), user_id, history).await)
+) -> ConversationAction {
+    ConversationAction::CommitResult(commit(Arc::clone(&env.lance_service), conversation_id, history).await)
 }

--- a/chatbot/src/externals/message_external.rs
+++ b/chatbot/src/externals/message_external.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use crate::types::user::UserAction;
-use crate::types::user::UserChannel;
-use crate::{types::user::UserId, Env};
+use crate::{
+    types::conversation::{ConversationAction, Platform, ConversationId},
+    Env,
+};
 use serenity::all::CreateMessage;
 
 /// Discord rejects message content longer than 2000 characters.
@@ -38,42 +39,29 @@ fn split_for_discord(content: &str) -> Vec<String> {
     chunks
 }
 
-pub async fn send_message(env: Arc<Env>, user_id: UserId, message: String) -> UserAction {
-    let user_id_result = match user_id.0 {
-        UserChannel::Discord => {
-            let user_id_result = user_id.1.parse::<u64>();
-            match user_id_result {
-                Ok(user_id) => Ok(serenity::all::UserId::new(user_id)),
-                Err(err) => Err(err.to_string()),
-            }
-        }
-        _ => panic!("Telegram not yet implemented"),
-    };
-
-    match user_id_result {
-        Err(err) => UserAction::MessageSent(Err(err)),
-        Ok(user_id) => {
-            let dm_channel_result = match user_id.to_user(&env.discord_http).await {
-                Ok(user) => user.create_dm_channel(&env.discord_http).await,
-                Err(e) => Err(e),
+pub async fn send_message(env: Arc<Env>, conversation_id: ConversationId, message: String) -> ConversationAction {
+    match conversation_id.0 {
+        Platform::Discord => {
+            // The conversation id is an opaque string; on Discord it's the channel id (DM or server
+            // channel alike). Parse it back into a ChannelId and send straight there — no user
+            // lookup or DM-channel creation needed, since the id already names the channel.
+            let channel = match conversation_id.1.parse::<u64>() {
+                Ok(id) => serenity::all::ChannelId::new(id),
+                Err(err) => return ConversationAction::MessageSent(Err(err.to_string())),
             };
 
-            match dm_channel_result {
-                Ok(channel) => {
-                    // Chunk to Discord's 2000-char limit; send sequentially, bail on first error.
-                    for chunk in split_for_discord(&message) {
-                        if let Err(err) = channel
-                            .send_message(&env.discord_http, CreateMessage::new().content(&chunk))
-                            .await
-                        {
-                            eprintln!("Failed to send Discord message: {err}");
-                            return UserAction::MessageSent(Err(err.to_string()));
-                        }
-                    }
-                    UserAction::MessageSent(Ok(()))
+            // Chunk to Discord's 2000-char limit; send sequentially, bail on first error.
+            for chunk in split_for_discord(&message) {
+                if let Err(err) = channel
+                    .send_message(&env.discord_http, CreateMessage::new().content(&chunk))
+                    .await
+                {
+                    eprintln!("Failed to send Discord message: {err}");
+                    return ConversationAction::MessageSent(Err(err.to_string()));
                 }
-                Err(err) => UserAction::MessageSent(Err(err.to_string())),
             }
+            ConversationAction::MessageSent(Ok(()))
         }
+        _ => panic!("Telegram not yet implemented"),
     }
 }

--- a/chatbot/src/externals/recall_long_term_external.rs
+++ b/chatbot/src/externals/recall_long_term_external.rs
@@ -5,9 +5,9 @@ use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use lancedb::query::{ExecutableQuery, QueryBase};
 use serenity::futures::TryStreamExt;
 
-use crate::{types::user::ToolResultData, Env};
+use crate::{types::conversation::ToolResultData, Env};
 
-async fn recall(env: Arc<Env>, user_id: String, search_term: String) -> anyhow::Result<String> {
+async fn recall(env: Arc<Env>, conversation_id: String, search_term: String) -> anyhow::Result<String> {
     let mut options = InitOptions::default();
     options.show_download_progress = true;
     options.model_name = EmbeddingModel::BGESmallENV15;
@@ -17,7 +17,7 @@ async fn recall(env: Arc<Env>, user_id: String, search_term: String) -> anyhow::
 
     let query_embedding = model.embed(vec![search_term], None)?[0].clone();
 
-    let history_table = env.lance_service.table_for_user(&user_id).await;
+    let history_table = env.lance_service.table_for_conversation(&conversation_id).await;
 
     let mut res = history_table
         .query()
@@ -59,10 +59,10 @@ async fn recall(env: Arc<Env>, user_id: String, search_term: String) -> anyhow::
 
 pub async fn recall_long(
     env: Arc<Env>,
-    user_id: String,
+    conversation_id: String,
     search_term: String,
 ) -> anyhow::Result<ToolResultData> {
-    let recalled = recall(env, user_id, search_term).await?;
+    let recalled = recall(env, conversation_id, search_term).await?;
     let text = format!("LONG TERM RECALL:\n{recalled}\n");
     Ok(ToolResultData {
         actual: text.clone(),

--- a/chatbot/src/externals/recall_short_term_external.rs
+++ b/chatbot/src/externals/recall_short_term_external.rs
@@ -1,4 +1,4 @@
-use crate::types::user::{HistoryEntry, ToolResultData};
+use crate::types::conversation::{HistoryEntry, ToolResultData};
 
 pub fn recall_short(history: &[HistoryEntry]) -> ToolResultData {
     let start_index = history.len().saturating_sub(20);

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -1,8 +1,8 @@
 use crate::{
     configuration::client_tokens::{BRAVE_SEARCH_TOKEN, SEARXNG_URL},
     externals::{recall_long_term_external::recall_long, recall_short_term_external::recall_short},
-    types::user::{
-        HistoryEntry, MathOperation, ToolCall, ToolResultData, ToolType, UserAction,
+    types::conversation::{
+        HistoryEntry, MathOperation, ToolCall, ToolResultData, ToolType, ConversationAction,
         MAX_SEARCH_DESCRIPTION_LENGTH,
     },
     Env,
@@ -453,7 +453,7 @@ async fn fetch_url_content(url: &str) -> anyhow::Result<ToolResultData> {
 async fn run_tool(
     env: Arc<Env>,
     tool_type: ToolType,
-    user_id: String,
+    conversation_id: String,
     history: Vec<HistoryEntry>,
 ) -> Result<ToolResultData, String> {
     match tool_type {
@@ -463,7 +463,7 @@ async fn run_tool(
         ToolType::VisitUrl { url } => fetch_url_content(&url).await.map_err(|e| e.to_string()),
         ToolType::RecallShortTerm { .. } => Ok(recall_short(&history)),
         ToolType::RecallLongTerm { search_term } => {
-            recall_long(env, user_id, search_term).await.map_err(|e| e.to_string())
+            recall_long(env, conversation_id, search_term).await.map_err(|e| e.to_string())
         }
     }
 }
@@ -473,11 +473,11 @@ async fn run_tool(
 pub async fn execute_tool(
     env: Arc<Env>,
     tool_call: ToolCall,
-    user_id: String,
+    conversation_id: String,
     history: Vec<HistoryEntry>,
-) -> UserAction {
-    let result = run_tool(env, tool_call.tool_type, user_id, history).await;
-    UserAction::ToolResult {
+) -> ConversationAction {
+    let result = run_tool(env, tool_call.tool_type, conversation_id, history).await;
+    ConversationAction::ToolResult {
         id: tool_call.id,
         result,
     }

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -3,8 +3,8 @@ use regex::Regex;
 use serenity::{async_trait, model::channel::Message as DMessage, prelude::*};
 
 use crate::{
-    types::user::{UserAction, UserChannel, UserId},
-    state_machines::user_state_machine::USER_STATE_MACHINE,
+    types::conversation::{ConversationAction, Platform, ConversationId},
+    state_machines::conversation_state_machine::CONVERSATION_STATE_MACHINE,
 };
 
 pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Client> {
@@ -12,11 +12,11 @@ pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Clien
 
     let intents = GatewayIntents::DIRECT_MESSAGES;
 
-    let user_state_machine = USER_STATE_MACHINE.clone();
+    let conversation_state_machine = CONVERSATION_STATE_MACHINE.clone();
 
     // Create a new instance of the Client, logging in as a bot. This will
     let client = Client::builder(discord_token, intents)
-        .event_handler(Handler { user_state_machine })
+        .event_handler(Handler { conversation_state_machine })
         .await?;
 
     Ok(client)
@@ -29,7 +29,7 @@ pub async fn run_discord(mut client: Client) -> anyhow::Result<()> {
 }
 
 struct Handler {
-    user_state_machine: StateMachineHandle<UserId, UserAction>,
+    conversation_state_machine: StateMachineHandle<ConversationId, ConversationAction>,
 }
 
 #[async_trait]
@@ -39,12 +39,15 @@ impl EventHandler for Handler {
     async fn message(&self, ctx: Context, message: DMessage) {
         if !message.author.bot {
             if let Some((msg, start_conversation)) = filter(&message, &ctx).await {
-                let user_id = UserId(UserChannel::Discord, message.author.id.get().to_string());
-                let action = UserAction::NewMessage {
+                // Key the conversation by the channel the message arrived on (a DM channel is 1:1,
+                // a server channel is shared). The channel id is stored as the opaque conversation
+                // id string; only this Discord adapter knows it's a channel id.
+                let conversation_id = ConversationId(Platform::Discord, message.channel_id.get().to_string());
+                let action = ConversationAction::NewMessage {
                     start_conversation,
                     msg,
                 };
-                self.user_state_machine.act(user_id, action).await;
+                self.conversation_state_machine.act(conversation_id, action).await;
             }
         }
     }

--- a/chatbot/src/services/lance_db.rs
+++ b/chatbot/src/services/lance_db.rs
@@ -20,8 +20,8 @@ impl LanceService {
         }
     }
 
-    pub async fn table_for_user(&self, user_id: &str) -> Table {
-        let table_name = format!("history_{}", user_id);
+    pub async fn table_for_conversation(&self, conversation_id: &str) -> Table {
+        let table_name = format!("history_{}", conversation_id);
 
         match self.connection.open_table(&table_name).execute().await {
             Ok(t) => t,
@@ -45,7 +45,7 @@ async fn setup_table_and_schema() -> (Connection, Arc<Schema>) {
 
     let dim = 384;
     let schema = Arc::new(Schema::new(vec![
-        Field::new("user_id", DataType::Utf8, false),
+        Field::new("conversation_id", DataType::Utf8, false),
         Field::new("content", DataType::Utf8, false),
         Field::new(
             "embedding",

--- a/chatbot/src/state_machines.rs
+++ b/chatbot/src/state_machines.rs
@@ -1,2 +1,2 @@
 pub mod bot_state_machine;
-pub mod user_state_machine;
+pub mod conversation_state_machine;

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -3,11 +3,11 @@ use crate::externals::{
     llama_cpp_external::get_llm_decision, message_external::send_message,
     tool_call_external::execute_tool,
 };
-use crate::types::user::{LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
+use crate::types::conversation::{LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
 use crate::{
-    types::user::{
-        HistoryEntry, LLMInput, RecentConversation, User, UserAction, UserId, UserMessage,
-        UserState,
+    types::conversation::{
+        HistoryEntry, LLMInput, RecentConversation, Conversation, ConversationAction, ConversationId, IncomingUpdate,
+        ConversationState,
     },
     Env, ENV,
 };
@@ -21,24 +21,24 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-type UserTransitionResult = TransitionResult<User, UserAction>;
-type UserExternalOperation = ExternalOperation<UserAction>;
+type ConversationTransitionResult = TransitionResult<Conversation, ConversationAction>;
+type ConversationExternalOperation = ExternalOperation<ConversationAction>;
 
 fn handle_outcome(
     env: Arc<Env>,
-    user_id: &UserId,
+    conversation_id: &ConversationId,
     is_timeout: bool,
     response: LLMResponse,
     recent_conversation: RecentConversation,
-    pending: Vec<UserMessage>,
+    pending: Vec<IncomingUpdate>,
     tool_rounds: usize,
-) -> UserTransitionResult {
+) -> ConversationTransitionResult {
     // Any `message` was already sent on the way into SendingMessage; here we act on the tool calls.
     if response.tool_calls.is_empty() {
         // No tools to run — settle into Idle.
         Ok((
-            User {
-                state: UserState::Idle {
+            Conversation {
+                state: ConversationState::Idle {
                     recent_conversation: if is_timeout {
                         None
                     } else {
@@ -53,21 +53,21 @@ fn handle_outcome(
     } else {
         // Dispatch every call as its own external op and seed pending_tools, so each returning
         // result can be moved to completed_tools by id (one round per batch).
-        let mut external = Vec::<UserExternalOperation>::new();
+        let mut external = Vec::<ConversationExternalOperation>::new();
         let mut pending_tools = HashMap::new();
         for tool_call in response.tool_calls {
             external.push(Box::pin(execute_tool(
                 env.clone(),
                 tool_call.clone(),
-                user_id.to_string(),
+                conversation_id.to_string(),
                 recent_conversation.history.clone(),
             )));
             pending_tools.insert(tool_call.id.clone(), tool_call);
         }
 
         Ok((
-            User {
-                state: UserState::RunningTools {
+            Conversation {
+                state: ConversationState::RunningTools {
                     is_timeout,
                     recent_conversation,
                     tool_rounds: tool_rounds + 1,
@@ -82,32 +82,32 @@ fn handle_outcome(
     }
 }
 
-pub fn user_transition(
+pub fn conversation_transition(
     env: Arc<Env>,
-    user_id: UserId,
-    user: User,
-    action: &UserAction,
-) -> Pin<Box<dyn Future<Output = UserTransitionResult> + Send + '_>> {
+    conversation_id: ConversationId,
+    conversation: Conversation,
+    action: &ConversationAction,
+) -> Pin<Box<dyn Future<Output = ConversationTransitionResult> + Send + '_>> {
     Box::pin(async move {
-        let state = match (user.state, action) {
-            (_, UserAction::ForceReset) => Ok((
-                User {
+        let state = match (conversation.state, action) {
+            (_, ConversationAction::ForceReset) => Ok((
+                Conversation {
                     pending: Vec::new(),
-                    state: UserState::default(),
+                    state: ConversationState::default(),
                     last_transition: Utc::now(),
                 },
                 Vec::new(),
             )),
             (
                 user_state,
-                UserAction::NewMessage {
+                ConversationAction::NewMessage {
                     msg,
                     start_conversation,
                 },
             ) => {
                 let accept_message = match (&user_state, start_conversation) {
                     (
-                        UserState::Idle {
+                        ConversationState::Idle {
                             recent_conversation: None,
                         },
                         false,
@@ -116,36 +116,36 @@ pub fn user_transition(
                 };
 
                 let pending = if accept_message {
-                    let mut pending = user.pending;
+                    let mut pending = conversation.pending;
                     // Queued iff it arrived while the bot was busy (any non-Idle state) — i.e. it
                     // crossed an in-flight response. An Idle arrival drains immediately and isn't.
-                    let queued = !matches!(&user_state, UserState::Idle { .. });
-                    pending.push(UserMessage {
+                    let queued = !matches!(&user_state, ConversationState::Idle { .. });
+                    pending.push(IncomingUpdate {
                         text: msg.clone(),
                         queued,
                     });
                     pending
                 } else {
-                    user.pending
+                    conversation.pending
                 };
 
                 Ok((
-                    User {
+                    Conversation {
                         pending,
                         state: user_state,
-                        ..user
+                        ..conversation
                     },
                     Vec::new(),
                 ))
             }
             (
-                UserState::AwaitingLLMDecision {
+                ConversationState::AwaitingLLMDecision {
                     is_timeout,
                     history,
                     current_input,
                     tool_rounds,
                 },
-                UserAction::LLMDecisionResult(res),
+                ConversationAction::LLMDecisionResult(res),
             ) => match res {
                 Ok(response) => {
                     // Add the input and output to history. An empty decision (no message, no tool
@@ -184,75 +184,75 @@ pub fn user_transition(
                     match message_to_send {
                         Some(message) => {
                             // Transition to SendingMessage state and trigger message sending
-                            let mut external = Vec::<UserExternalOperation>::new();
+                            let mut external = Vec::<ConversationExternalOperation>::new();
                             external.push(Box::pin(send_message(
                                 env.clone(),
-                                user_id.clone(),
+                                conversation_id.clone(),
                                 message,
                             )));
 
                             Ok((
-                                User {
-                                    state: UserState::SendingMessage {
+                                Conversation {
+                                    state: ConversationState::SendingMessage {
                                         is_timeout,
                                         outcome: response.clone(),
                                         recent_conversation: updated_conversation,
                                         tool_rounds,
                                     },
                                     last_transition: Utc::now(),
-                                    ..user
+                                    ..conversation
                                 },
                                 external,
                             ))
                         }
                         None => handle_outcome(
                             env.clone(),
-                            &user_id,
+                            &conversation_id,
                             is_timeout,
                             response.clone(),
                             updated_conversation,
-                            user.pending,
+                            conversation.pending,
                             tool_rounds,
                         ),
                     }
                 }
                 Err(_) => Ok((
-                    User {
-                        state: UserState::Idle {
+                    Conversation {
+                        state: ConversationState::Idle {
                             recent_conversation: None,
                         },
                         last_transition: Utc::now(),
-                        ..user
+                        ..conversation
                     },
                     Vec::new(),
                 )),
             },
             (
-                UserState::SendingMessage {
+                ConversationState::SendingMessage {
                     is_timeout,
                     outcome,
                     recent_conversation,
                     tool_rounds,
                 },
-                UserAction::MessageSent(_res),
+                ConversationAction::MessageSent(_res),
             ) => handle_outcome(
                 env.clone(),
-                &user_id,
+                &conversation_id,
                 is_timeout,
                 outcome,
                 recent_conversation,
-                user.pending,
+                conversation.pending,
                 tool_rounds,
             ),
             (
-                UserState::RunningTools {
+                ConversationState::RunningTools {
                     recent_conversation,
                     is_timeout,
                     tool_rounds,
                     mut pending_tools,
                     mut completed_tools,
                 },
-                UserAction::ToolResult { id, result },
+                ConversationAction::ToolResult { id, result },
             ) => {
                 // Move this tool from pending to completed, folding any error into the result data.
                 if let Some(tool_call) = pending_tools.remove(id) {
@@ -285,11 +285,11 @@ pub fn user_transition(
                     // Fold any messages the user sent mid-tool-run into this same turn (after the
                     // results, per the OpenAI protocol). Clearing pending here is required — else
                     // post_transition drains it again at Idle and the message is sent twice.
-                    let mut pending = user.pending;
+                    let mut pending = conversation.pending;
                     let current_input = LLMInput::ToolResults(results, take_pending(&mut pending));
 
                     let history = recent_conversation.history();
-                    let mut external = Vec::<UserExternalOperation>::new();
+                    let mut external = Vec::<ConversationExternalOperation>::new();
                     external.push(Box::pin(get_llm_decision(
                         env.clone(),
                         current_input.clone(),
@@ -299,8 +299,8 @@ pub fn user_transition(
                     )));
 
                     Ok((
-                        User {
-                            state: UserState::AwaitingLLMDecision {
+                        Conversation {
+                            state: ConversationState::AwaitingLLMDecision {
                                 is_timeout,
                                 history,
                                 current_input,
@@ -314,8 +314,8 @@ pub fn user_transition(
                 } else {
                     // Still waiting on other tools in the batch — stay put, dispatch nothing new.
                     Ok((
-                        User {
-                            state: UserState::RunningTools {
+                        Conversation {
+                            state: ConversationState::RunningTools {
                                 is_timeout,
                                 recent_conversation,
                                 tool_rounds,
@@ -323,54 +323,54 @@ pub fn user_transition(
                                 completed_tools,
                             },
                             last_transition: Utc::now(),
-                            ..user
+                            ..conversation
                         },
                         Vec::new(),
                     ))
                 }
             }
             (
-                UserState::Idle {
+                ConversationState::Idle {
                     recent_conversation: Some((recent_conversation, _)),
                 },
-                UserAction::Timeout,
+                ConversationAction::Timeout,
             ) => {
                 println!("Timed Out");
 
-                let mut external = Vec::<UserExternalOperation>::new();
+                let mut external = Vec::<ConversationExternalOperation>::new();
 
                 external.push(Box::pin(commit_to_memory(
                     Arc::clone(&env),
-                    user_id.to_string(),
+                    conversation_id.to_string(),
                     recent_conversation.history.clone(),
                 )));
 
                 Ok((
-                    User {
-                        state: UserState::CommitingToMemory {
+                    Conversation {
+                        state: ConversationState::CommitingToMemory {
                             recent_conversation,
                         },
                         last_transition: Utc::now(),
-                        ..user
+                        ..conversation
                     },
                     external,
                 ))
             }
             (
-                UserState::CommitingToMemory {
+                ConversationState::CommitingToMemory {
                     recent_conversation,
                 },
-                UserAction::CommitResult(_),
+                ConversationAction::CommitResult(_),
             ) => {
                 println!("Commited to Memory");
 
                 let timeout_message = "User said goodbye, RESPOND WITH GOODBYE BUT MENTION RELEVANT THINGS ABOUT THE CONVERSATION".to_string();
-                let current_input = LLMInput::UserMessage(UserMessage {
+                let current_input = LLMInput::IncomingUpdate(IncomingUpdate {
                     text: timeout_message,
                     queued: false,
                 });
 
-                let mut external = Vec::<UserExternalOperation>::new();
+                let mut external = Vec::<ConversationExternalOperation>::new();
 
                 external.push(Box::pin(get_llm_decision(
                     env.clone(),
@@ -381,15 +381,15 @@ pub fn user_transition(
                 )));
 
                 Ok((
-                    User {
-                        state: UserState::AwaitingLLMDecision {
+                    Conversation {
+                        state: ConversationState::AwaitingLLMDecision {
                             is_timeout: true,
                             history: recent_conversation.history,
                             current_input,
                             tool_rounds: 0,
                         },
                         last_transition: Utc::now(),
-                        ..user
+                        ..conversation
                     },
                     external,
                 ))
@@ -397,14 +397,14 @@ pub fn user_transition(
             _ => Err(anyhow::anyhow!("Invalid state or action")),
         };
 
-        post_transition(env, user_id, state)
+        post_transition(env, conversation_id, state)
     })
 }
 
 /// Drain buffered user messages into a single newline-joined string, clearing `pending`. Returns
 /// `None` if there was nothing buffered. Single source of truth for both pending drain points (the
 /// Idle drain below and the mid-tool-loop fold in the RunningTools branch), so they stay identical.
-fn take_pending(pending: &mut Vec<UserMessage>) -> Option<UserMessage> {
+fn take_pending(pending: &mut Vec<IncomingUpdate>) -> Option<IncomingUpdate> {
     (!pending.is_empty()).then(|| {
         let drained = std::mem::take(pending);
         // Messages drained together are homogeneous (all queued during a busy turn, or a single
@@ -415,28 +415,28 @@ fn take_pending(pending: &mut Vec<UserMessage>) -> Option<UserMessage> {
             .map(|m| m.text)
             .collect::<Vec<_>>()
             .join("\n");
-        UserMessage { text, queued }
+        IncomingUpdate { text, queued }
     })
 }
 
 fn post_transition(
     env: Arc<Env>,
-    _user_id: UserId,
-    result: UserTransitionResult,
-) -> UserTransitionResult {
-    let (mut user, mut external) = result?;
+    _conversation_id: ConversationId,
+    result: ConversationTransitionResult,
+) -> ConversationTransitionResult {
+    let (mut conversation, mut external) = result?;
 
     // Never rest in Idle with buffered input: drain it into a fresh user turn. (Mirrors the
     // mid-tool-loop fold in the RunningTools branch, which folds into a tool-result turn instead.)
-    let recent_conversation = match &user.state {
-        UserState::Idle {
+    let recent_conversation = match &conversation.state {
+        ConversationState::Idle {
             recent_conversation,
         } => recent_conversation.clone(),
-        _ => return Ok((user, external)),
+        _ => return Ok((conversation, external)),
     };
 
-    let Some(msg) = take_pending(&mut user.pending) else {
-        return Ok((user, external));
+    let Some(msg) = take_pending(&mut conversation.pending) else {
+        return Ok((conversation, external));
     };
 
     let history = recent_conversation
@@ -444,7 +444,7 @@ fn post_transition(
         .map(|(rc, _)| rc.history())
         .unwrap_or_else(Vec::new);
 
-    let current_input = LLMInput::UserMessage(msg);
+    let current_input = LLMInput::IncomingUpdate(msg);
 
     external.push(Box::pin(get_llm_decision(
         env.clone(),
@@ -455,8 +455,8 @@ fn post_transition(
     )));
 
     Ok((
-        User {
-            state: UserState::AwaitingLLMDecision {
+        Conversation {
+            state: ConversationState::AwaitingLLMDecision {
                 is_timeout: false,
                 history,
                 current_input,
@@ -469,21 +469,21 @@ fn post_transition(
     ))
 }
 
-pub fn schedule(user: &User) -> Vec<Scheduled<UserAction>> {
+pub fn schedule(conversation: &Conversation) -> Vec<Scheduled<ConversationAction>> {
     let mut schedules = Vec::new();
-    match user.state {
-        UserState::Idle {
+    match conversation.state {
+        ConversationState::Idle {
             recent_conversation: Some((_, last_activity)),
         } => schedules.push(Scheduled {
             at: last_activity + ChronoDuration::milliseconds(900_000),
-            action: UserAction::Timeout,
+            action: ConversationAction::Timeout,
         }),
-        UserState::AwaitingLLMDecision { .. }
-        | UserState::SendingMessage { .. }
-        | UserState::CommitingToMemory { .. }
-        | UserState::RunningTools { .. } => schedules.push(Scheduled {
-            at: user.last_transition + ChronoDuration::milliseconds(600_000),
-            action: UserAction::ForceReset,
+        ConversationState::AwaitingLLMDecision { .. }
+        | ConversationState::SendingMessage { .. }
+        | ConversationState::CommitingToMemory { .. }
+        | ConversationState::RunningTools { .. } => schedules.push(Scheduled {
+            at: conversation.last_transition + ChronoDuration::milliseconds(600_000),
+            action: ConversationAction::ForceReset,
         }),
         _ => {}
     }
@@ -491,11 +491,11 @@ pub fn schedule(user: &User) -> Vec<Scheduled<UserAction>> {
     schedules
 }
 
-pub static USER_STATE_MACHINE: Lazy<framework::StateMachineHandle<UserId, UserAction>> =
+pub static CONVERSATION_STATE_MACHINE: Lazy<framework::StateMachineHandle<ConversationId, ConversationAction>> =
     Lazy::new(|| {
         new_state_machine(
             ENV.get().expect("ENV not initialized").clone(),
-            Transition(user_transition),
+            Transition(conversation_transition),
             Schedule(schedule),
         )
     });

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use strum::IntoEnumIterator;
 
-use crate::types::user::{ToolKind, ToolType};
+use crate::types::conversation::{ToolKind, ToolType};
 
 #[derive(Debug, Deserialize)]
 struct GetWeatherArgs {

--- a/chatbot/src/types.rs
+++ b/chatbot/src/types.rs
@@ -1,2 +1,2 @@
 pub mod bot;
-pub mod user;
+pub mod conversation;

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -15,32 +15,32 @@ pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 2000;
 pub const MAX_TOOL_ROUNDS: usize = 10;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub enum UserChannel {
+pub enum Platform {
     Telegram,
     Discord,
 }
-impl Display for UserChannel {
+impl Display for Platform {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UserChannel::Telegram => write!(f, "Telegram"),
-            UserChannel::Discord => write!(f, "Discord"),
+            Platform::Telegram => write!(f, "Telegram"),
+            Platform::Discord => write!(f, "Discord"),
         }
     }
 }
 
-impl UserChannel {
+impl Platform {
     fn to_string(&self) -> &'static str {
         match self {
-            UserChannel::Telegram => "Telegram",
-            UserChannel::Discord => "Discord",
+            Platform::Telegram => "Telegram",
+            Platform::Discord => "Discord",
         }
     }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
-pub struct UserId(pub UserChannel, pub String);
+pub struct ConversationId(pub Platform, pub String);
 
-impl Display for UserId {
+impl Display for ConversationId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}_{}", self.0.to_string(), self.1)
     }
@@ -58,7 +58,7 @@ impl RecentConversation {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum UserState {
+pub enum ConversationState {
     Idle {
         recent_conversation: Option<(RecentConversation, DateTime<Utc>)>,
     },
@@ -91,24 +91,26 @@ pub enum UserState {
         completed_tools: Vec<(ToolCall, ToolResultData)>,
     },
 }
-impl Default for UserState {
+impl Default for ConversationState {
     fn default() -> Self {
-        UserState::Idle {
+        ConversationState::Idle {
             recent_conversation: None,
         }
     }
 }
 
-/// A user message. `queued` is true when it was buffered into `pending` while the bot was busy
-/// (a non-Idle state), so it crossed an in-flight response. The flag is the persisted truth;
-/// the `[Followup]` tag is applied only at prompt-render time (see `to_content`).
+/// An inbound update from a conversation — today always a user's message (later may also carry
+/// non-message events: edits, reactions, joins). `queued` is true when it was buffered into
+/// `pending` while the bot was busy (a non-Idle state), so it crossed an in-flight response. The
+/// flag is the persisted truth; the `[Followup]` tag is applied only at prompt-render time (see
+/// `to_content`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserMessage {
+pub struct IncomingUpdate {
     pub text: String,
     pub queued: bool,
 }
 
-impl UserMessage {
+impl IncomingUpdate {
     /// Prompt content: the text, prefixed with `[Followup]` when it was queued mid-response so the
     /// model knows it may already be addressed. Render-time only — the stored `text` stays clean.
     pub fn to_content(&self) -> String {
@@ -120,21 +122,24 @@ impl UserMessage {
     }
 }
 
+/// The per-conversation entity the state machine drives: its current `state`, any `pending`
+/// updates buffered while busy, and when it last transitioned. Keyed by [`ConversationId`] (a
+/// channel/DM on some [`Platform`]) — one independent instance per conversation.
 #[derive(Clone, Default, Serialize, Deserialize)]
-pub struct User {
-    pub pending: Vec<UserMessage>,
-    pub state: UserState,
+pub struct Conversation {
+    pub pending: Vec<IncomingUpdate>,
+    pub state: ConversationState,
     pub last_transition: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
-    UserMessage(UserMessage),
+    IncomingUpdate(IncomingUpdate),
     /// One turn's batch of tool results (id order), each tagged with the call it answers.
-    /// The optional trailing `UserMessage` is input that arrived mid-tool-run, folded into this
+    /// The optional trailing `IncomingUpdate` is input that arrived mid-tool-run, folded into this
     /// same turn *after* the results — OpenAI requires tool responses to immediately follow the
     /// assistant's `tool_calls`, so the user message comes last.
-    ToolResults(Vec<ToolResult>, Option<UserMessage>),
+    ToolResults(Vec<ToolResult>, Option<IncomingUpdate>),
 }
 
 impl LLMInput {
@@ -142,7 +147,7 @@ impl LLMInput {
     /// message per result (the template groups them into a single tool-response turn).
     pub fn to_openai_messages(&self) -> Vec<Value> {
         match self {
-            LLMInput::UserMessage(msg) => vec![json!({ "role": "user", "content": msg.to_content() })],
+            LLMInput::IncomingUpdate(msg) => vec![json!({ "role": "user", "content": msg.to_content() })],
             LLMInput::ToolResults(results, user_msg) => {
                 let mut messages: Vec<Value> = results
                     .iter()
@@ -205,7 +210,7 @@ pub struct ToolResult {
 pub struct LLMResponse {
     /// Reasoning (`<think>`); kept for logging but never replayed into the next prompt.
     pub thoughts: String,
-    /// User-facing text, if the model produced any.
+    /// Conversation-facing text, if the model produced any.
     pub message: Option<String>,
     /// Tool calls to dispatch this turn; empty if none.
     pub tool_calls: Vec<ToolCall>,
@@ -255,7 +260,7 @@ impl HistoryEntry {
     pub fn format_simplified(&self) -> String {
         match self {
             HistoryEntry::Input(llm_input) => match llm_input {
-                LLMInput::UserMessage(m) => format!("User:\n{}", m.text),
+                LLMInput::IncomingUpdate(m) => format!("User:\n{}", m.text),
                 LLMInput::ToolResults(results, user_msg) => {
                     let joined = results
                         .iter()
@@ -286,7 +291,7 @@ impl HistoryEntry {
 }
 
 #[derive(Clone, Serialize)]
-pub enum UserAction {
+pub enum ConversationAction {
     ForceReset,
     NewMessage {
         msg: String,
@@ -309,16 +314,16 @@ pub struct ToolResultData {
     pub simplified: String,
 }
 
-impl std::fmt::Debug for UserAction {
+impl std::fmt::Debug for ConversationAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UserAction::ForceReset => write!(f, "ForceReset"),
-            UserAction::NewMessage { .. } => write!(f, "NewMessage"),
-            UserAction::Timeout => write!(f, "Timeout"),
-            UserAction::CommitResult(_) => write!(f, "CommitResult"),
-            UserAction::LLMDecisionResult(_) => write!(f, "LLMDecisionResult"),
-            UserAction::MessageSent(_) => write!(f, "MessageSent"),
-            UserAction::ToolResult { .. } => write!(f, "ToolResult"),
+            ConversationAction::ForceReset => write!(f, "ForceReset"),
+            ConversationAction::NewMessage { .. } => write!(f, "NewMessage"),
+            ConversationAction::Timeout => write!(f, "Timeout"),
+            ConversationAction::CommitResult(_) => write!(f, "CommitResult"),
+            ConversationAction::LLMDecisionResult(_) => write!(f, "LLMDecisionResult"),
+            ConversationAction::MessageSent(_) => write!(f, "MessageSent"),
+            ConversationAction::ToolResult { .. } => write!(f, "ToolResult"),
         }
     }
 }


### PR DESCRIPTION
Closes #115.

Re-keys the core state-machine entity from **User** (keyed by Discord author id, replies via DM) to **Conversation** (keyed by `channel_id`, replies in-channel), and renames `user → conversation` terminology throughout. **Behavior-preserving for today's DMs** (a DM channel is 1:1 and its id is stable, so per-channel ≡ per-user). Group chats stay blocked — intents and author attribution are out of scope.

## Part A — re-key identity by channel
- **[discord.rs](chatbot/src/services/discord.rs)**: key the entity by `message.channel_id` instead of `message.author.id`. The channel id is stored as the **opaque conversation-id string** — Discord terminology stays in the adapter.
- **[message_external.rs](chatbot/src/externals/message_external.rs)**: send via `ChannelId::send_message` (parsing the opaque id back to a `ChannelId` inside the `Platform::Discord` arm) instead of `to_user → create_dm_channel`. Chunking unchanged.
- **[lance_db.rs](chatbot/src/services/lance_db.rs)**: memory table becomes `history_{conversation_id}`. Existing `history_{author_id}` DM tables are orphaned (early/personal — starting fresh).

## Part B — rename user→conversation
`UserId→ConversationId`, `User→Conversation`, `UserState→ConversationState`, `UserAction→ConversationAction`, `UserChannel→Platform`, `UserMessage→IncomingUpdate`, `user_transition→conversation_transition`, `USER_STATE_MACHINE→CONVERSATION_STATE_MACHINE`, `table_for_user→table_for_conversation`, `user_id→conversation_id`. Files `types/user.rs→types/conversation.rs`, `state_machines/user_state_machine.rs→conversation_state_machine.rs`.

## Platform-agnostic by construction
`ConversationId(Platform, String)` — the `String` is **opaque**; only the platform adapter parses it back (Discord → `ChannelId`; Telegram arm still a `todo`). Verified: **no `channel_id`/`ChannelId` outside `discord.rs`/`message_external.rs`**, so no Discord terminology bleeds into the domain layer.

## Preserved (refer to the human/API, not the entity)
The `"User:"` transcript label, the `"User said goodbye"` timeout prompt, OpenAI `"role": "user"`, and prose/system-prompt text about the human user — all intentionally left untouched.

## Testing
- `cargo build` clean (pre-existing config warnings only).
- `cargo test`: relevant tests pass (`test_fetch_web_search`, `test_fetch_weather`). `test_fetch_url_content_real` fails environmentally — the sandbox network returned a 528-char stub for example.com, not the real page; that test is unchanged by this PR and lives on main from #114.
- Behavior-preserving for DMs — to confirm end-to-end, deploy and DM the bot (received under the channel-keyed id, replied in the same DM).

## Related
- #116 (framework "user" naming neutralized — done; framework stays generic, NOT "conversation").
- Follow-ups that unblock group chats: gateway intents (`GUILD_MESSAGES`/`MESSAGE_CONTENT`), in-channel author attribution.