### PR TITLE
Enable group chats: intents, is_group, author attribution, group prompt (#118)

### DIFF
--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -14,7 +14,7 @@ The bot uses **Qwen3.6-27B** (quantized Q4_K_M) running locally via `llama-cpp-2
 - **Conversation Context**: Maintains conversation summaries for multi-turn conversations.
 - **Structured Output**: Uses GBNF grammar to ensure valid JSON responses.
 - **Type-Safe State Machine**: Built on `framework` framework for compile-time safety.
-- **DMs and group chats**: Works in 1:1 DMs and in server channels. Each conversation is keyed by its channel; in a group the model sees every message (prefixed with the sender's name) and decides for itself whether to reply, staying silent by returning an empty response.
+- **DMs and group chats**: Works in 1:1 DMs and in server channels. Each conversation is keyed by its channel; in a group the model sees every message (prefixed with the sender's name) and decides for itself whether to reply, staying silent by replying with the marker `<empty>`.
 
 ## Quick Start
 

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -14,7 +14,7 @@ The bot uses **Qwen3.6-27B** (quantized Q4_K_M) running locally via `llama-cpp-2
 - **Conversation Context**: Maintains conversation summaries for multi-turn conversations.
 - **Structured Output**: Uses GBNF grammar to ensure valid JSON responses.
 - **Type-Safe State Machine**: Built on `framework` framework for compile-time safety.
-- **DM-Only Bot**: Responds only to direct messages or when mentioned.
+- **DMs and group chats**: Works in 1:1 DMs and in server channels. Each conversation is keyed by its channel; in a group the model sees every message (prefixed with the sender's name) and decides for itself whether to reply, staying silent by returning an empty response.
 
 ## Quick Start
 
@@ -22,6 +22,7 @@ The bot uses **Qwen3.6-27B** (quantized Q4_K_M) running locally via `llama-cpp-2
 
 1.  **Docker** with buildx installed (Docker Desktop or Docker 19.03+).
 2.  **Discord Token**: You need a Discord bot token.
+3.  **Message Content Intent**: Enable the privileged **Message Content** intent for the bot in the Discord Developer Portal (Bot → Privileged Gateway Intents). Without it the bot can't read the text of group-channel messages that don't mention it.
 
 ### Installation & Build
 

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -139,13 +139,14 @@ fn respond_blocking(
     conversation: serde_json::Value,
     allow_tools: bool,
     is_group: bool,
+    bot_name: String,
 ) -> anyhow::Result<serde_json::Value> {
     // Prepend the system turn (persona + DM/group guidance), then render with the model's template.
     // At the budget cap, advertise no tools so the model physically cannot emit another tool call
     // (the synthesis nudge itself rides the message stream, not this stable system turn).
     let mut messages = vec![serde_json::json!({
         "role": "system",
-        "content": agent.system_content(is_group),
+        "content": agent.system_content(is_group, &bot_name),
     })];
     if let Some(arr) = conversation.as_array() {
         messages.extend(arr.iter().cloned());
@@ -215,14 +216,15 @@ impl Agent {
         self.temperature
     }
 
-    /// The system turn. `is_group` selects a DM vs group-chat variant; both are static per kind so
-    /// the cached system prefix stays stable. The group variant tells the model it's one participant
-    /// among many and that it may stay silent by replying with an empty string.
-    pub fn system_content(&self, is_group: bool) -> String {
+    /// The system turn. `is_group` selects a DM vs group-chat variant and `bot_name` is the bot's
+    /// own display name (so it knows who it is / when it's addressed). Both inputs are effectively
+    /// static per deployment, so the cached system prefix stays stable. The group variant tells the
+    /// model it's one participant among many and that it may stay silent by replying `<empty>`.
+    pub fn system_content(&self, is_group: bool, bot_name: &str) -> String {
         let context_note = if is_group {
-            "\n\nYou are in a GROUP CHAT with multiple people. Every message is prefixed with the sender's name (\"Name: ...\"); use names to keep track of who said what, and address people by name when it helps. You are one participant among many, not a personal assistant — only reply when you're addressed or can genuinely add something. If a message doesn't call for a response from you, reply with an empty string to stay silent (an empty reply sends nothing to the chat)."
+            format!("\n\nYou are in a GROUP CHAT with multiple people, and your own name here is \"{bot_name}\" — when someone writes \"{bot_name}\" (or @mentions you) they are addressing you. Every message is prefixed with its sender's name (\"Name: ...\"); use those names to track who said what, and address people by name when it helps. You are one participant among many, not a personal assistant — only reply when you're addressed or can genuinely add something. If a message doesn't call for a response from you, reply with exactly `<empty>` to stay silent — that sends nothing to the chat.")
         } else {
-            ""
+            format!("\n\nYour name is \"{bot_name}\".")
         };
         format!(
             "{}{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nIMPORTANT — A [Followup] message arrived while you were still replying or while tools were running, so the user hadn't seen the result yet (they never see tool calls or their outputs, only your replies). If it follows one of your replies: gauge what you already covered and build on it rather than repeat — or handle it normally if it's a different track. If it follows tool results: weigh it against those results and consider whether it needs new information before answering. Either way, the goal is the same: make sure the user ends up with everything they asked for across your replies.",
@@ -239,6 +241,7 @@ impl Agent {
         conversation: serde_json::Value,
         allow_tools: bool,
         is_group: bool,
+        bot_name: String,
     ) -> anyhow::Result<serde_json::Value> {
         let task = spawn_blocking(move || {
             respond_blocking(
@@ -250,6 +253,7 @@ impl Agent {
                 conversation,
                 allow_tools,
                 is_group,
+                bot_name,
             )
         });
 

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -222,13 +222,19 @@ impl Agent {
     /// group variant tells the model it's one participant among many and may stay silent via `<empty>`.
     pub fn system_content(&self, is_group: bool, bot_identity: &str) -> String {
         let context_note = if is_group {
-            format!("\n\nYou are in a GROUP CHAT with multiple participants. You are \"{bot_identity}\". Every message is prefixed with its sender's identity in the form \"Name (id:NUMBER)\", and any @mention is shown the same way — so each participant is identified by both a name and a stable numeric id. A message addresses you when it mentions the id that matches yours; match on the id, not just the name (names can repeat or change). Address people by name, and use ids to keep who's who straight. You are one participant among many, not a personal assistant — only reply when you're addressed or can genuinely add something. If a message doesn't call for a response from you, reply with exactly `<empty>` to stay silent — that sends nothing to the chat.")
+            format!("\n\nYou are in a GROUP CHAT with multiple participants. You are \"{bot_identity}\". Every message is prefixed with its sender's identity in the form \"Name (id:NUMBER)\", and any @mention is shown the same way — so each participant is identified by both a name and a stable numeric id. A message addresses you when it mentions the id that matches yours; match on the id, not just the name (names can repeat or change). Address people by name, and use ids to keep who's who straight. You are one participant among many, not a personal assistant — the conversation mostly does not involve you, so your default is to stay silent. Reply when you're directly addressed. You may also interject on your own when you genuinely have something worth adding — but do this only infrequently; strongly prefer silence and don't insert yourself into others' exchanges. Whenever a message doesn't call for a response from you, reply with exactly `<empty>` to stay silent — that sends nothing to the chat.")
         } else {
             format!("\n\nYou are \"{bot_identity}\".")
         };
+        // In a group, a [Followup] needs the extra question of whether it's even aimed at the bot.
+        let followup_group_note = if is_group {
+            " In a group chat especially, weigh the surrounding context and whether the [Followup] is even addressed to you before responding — it may not need anything from you, in which case stay silent (`<empty>`)."
+        } else {
+            ""
+        };
         format!(
-            "{}{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nIMPORTANT — A [Followup] message arrived while you were still replying or while tools were running, so the user hadn't seen the result yet (they never see tool calls or their outputs, only your replies). If it follows one of your replies: gauge what you already covered and build on it rather than repeat — or handle it normally if it's a different track. If it follows tool results: weigh it against those results and consider whether it needs new information before answering. Either way, the goal is the same: make sure the user ends up with everything they asked for across your replies.",
-            self.system_prompt, context_note
+            "{}{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nIMPORTANT — A [Followup] message arrived while you were still replying or while tools were running, so the user hadn't seen the result yet (they never see tool calls or their outputs, only your replies). If it follows one of your replies: gauge what you already covered and build on it rather than repeat — or handle it normally if it's a different track. If it follows tool results: weigh it against those results and consider whether it needs new information before answering. Either way, the goal is the same: make sure the user ends up with everything they asked for across your replies.{}",
+            self.system_prompt, context_note, followup_group_note
         )
     }
 

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -139,14 +139,14 @@ fn respond_blocking(
     conversation: serde_json::Value,
     allow_tools: bool,
     is_group: bool,
-    bot_name: String,
+    bot_identity: String,
 ) -> anyhow::Result<serde_json::Value> {
     // Prepend the system turn (persona + DM/group guidance), then render with the model's template.
     // At the budget cap, advertise no tools so the model physically cannot emit another tool call
     // (the synthesis nudge itself rides the message stream, not this stable system turn).
     let mut messages = vec![serde_json::json!({
         "role": "system",
-        "content": agent.system_content(is_group, &bot_name),
+        "content": agent.system_content(is_group, &bot_identity),
     })];
     if let Some(arr) = conversation.as_array() {
         messages.extend(arr.iter().cloned());
@@ -216,15 +216,15 @@ impl Agent {
         self.temperature
     }
 
-    /// The system turn. `is_group` selects a DM vs group-chat variant and `bot_name` is the bot's
-    /// own display name (so it knows who it is / when it's addressed). Both inputs are effectively
-    /// static per deployment, so the cached system prefix stays stable. The group variant tells the
-    /// model it's one participant among many and that it may stay silent by replying `<empty>`.
-    pub fn system_content(&self, is_group: bool, bot_name: &str) -> String {
+    /// The system turn. `is_group` selects a DM vs group-chat variant and `bot_identity` is the
+    /// bot's own `Name (id:NUMBER)` handle (so it can recognize itself among the participants). Both
+    /// inputs are effectively static per deployment, so the cached system prefix stays stable. The
+    /// group variant tells the model it's one participant among many and may stay silent via `<empty>`.
+    pub fn system_content(&self, is_group: bool, bot_identity: &str) -> String {
         let context_note = if is_group {
-            format!("\n\nYou are in a GROUP CHAT with multiple people, and your own name here is \"{bot_name}\" — when someone writes \"{bot_name}\" (or @mentions you) they are addressing you. Every message is prefixed with its sender's name (\"Name: ...\"); use those names to track who said what, and address people by name when it helps. You are one participant among many, not a personal assistant — only reply when you're addressed or can genuinely add something. If a message doesn't call for a response from you, reply with exactly `<empty>` to stay silent — that sends nothing to the chat.")
+            format!("\n\nYou are in a GROUP CHAT with multiple participants. You are \"{bot_identity}\". Every message is prefixed with its sender's identity in the form \"Name (id:NUMBER)\", and any @mention is shown the same way — so each participant is identified by both a name and a stable numeric id. A message addresses you when it mentions the id that matches yours; match on the id, not just the name (names can repeat or change). Address people by name, and use ids to keep who's who straight. You are one participant among many, not a personal assistant — only reply when you're addressed or can genuinely add something. If a message doesn't call for a response from you, reply with exactly `<empty>` to stay silent — that sends nothing to the chat.")
         } else {
-            format!("\n\nYour name is \"{bot_name}\".")
+            format!("\n\nYou are \"{bot_identity}\".")
         };
         format!(
             "{}{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nIMPORTANT — A [Followup] message arrived while you were still replying or while tools were running, so the user hadn't seen the result yet (they never see tool calls or their outputs, only your replies). If it follows one of your replies: gauge what you already covered and build on it rather than repeat — or handle it normally if it's a different track. If it follows tool results: weigh it against those results and consider whether it needs new information before answering. Either way, the goal is the same: make sure the user ends up with everything they asked for across your replies.",
@@ -241,7 +241,7 @@ impl Agent {
         conversation: serde_json::Value,
         allow_tools: bool,
         is_group: bool,
-        bot_name: String,
+        bot_identity: String,
     ) -> anyhow::Result<serde_json::Value> {
         let task = spawn_blocking(move || {
             respond_blocking(
@@ -253,7 +253,7 @@ impl Agent {
                 conversation,
                 allow_tools,
                 is_group,
-                bot_name,
+                bot_identity,
             )
         });
 

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -138,13 +138,14 @@ fn respond_blocking(
     batch_chunk_size: usize,
     conversation: serde_json::Value,
     allow_tools: bool,
+    is_group: bool,
 ) -> anyhow::Result<serde_json::Value> {
-    // Prepend the system turn (persona + current time), then render with the model's template. At
-    // the budget cap, advertise no tools so the model physically cannot emit another tool call (the
-    // synthesis nudge itself rides the message stream, not this stable system turn).
+    // Prepend the system turn (persona + DM/group guidance), then render with the model's template.
+    // At the budget cap, advertise no tools so the model physically cannot emit another tool call
+    // (the synthesis nudge itself rides the message stream, not this stable system turn).
     let mut messages = vec![serde_json::json!({
         "role": "system",
-        "content": agent.system_content(),
+        "content": agent.system_content(is_group),
     })];
     if let Some(arr) = conversation.as_array() {
         messages.extend(arr.iter().cloned());
@@ -214,10 +215,18 @@ impl Agent {
         self.temperature
     }
 
-    pub fn system_content(&self) -> String {
+    /// The system turn. `is_group` selects a DM vs group-chat variant; both are static per kind so
+    /// the cached system prefix stays stable. The group variant tells the model it's one participant
+    /// among many and that it may stay silent by replying with an empty string.
+    pub fn system_content(&self, is_group: bool) -> String {
+        let context_note = if is_group {
+            "\n\nYou are in a GROUP CHAT with multiple people. Every message is prefixed with the sender's name (\"Name: ...\"); use names to keep track of who said what, and address people by name when it helps. You are one participant among many, not a personal assistant — only reply when you're addressed or can genuinely add something. If a message doesn't call for a response from you, reply with an empty string to stay silent (an empty reply sends nothing to the chat)."
+        } else {
+            ""
+        };
         format!(
-            "{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nIMPORTANT — A [Followup] message arrived while you were still replying or while tools were running, so the user hadn't seen the result yet (they never see tool calls or their outputs, only your replies). If it follows one of your replies: gauge what you already covered and build on it rather than repeat — or handle it normally if it's a different track. If it follows tool results: weigh it against those results and consider whether it needs new information before answering. Either way, the goal is the same: make sure the user ends up with everything they asked for across your replies.",
-            self.system_prompt
+            "{}{}\n\nUse tools deliberately and answer once you've gathered enough. You can call multiple tools in one turn when that helps.\n\nIMPORTANT — A [Followup] message arrived while you were still replying or while tools were running, so the user hadn't seen the result yet (they never see tool calls or their outputs, only your replies). If it follows one of your replies: gauge what you already covered and build on it rather than repeat — or handle it normally if it's a different track. If it follows tool results: weigh it against those results and consider whether it needs new information before answering. Either way, the goal is the same: make sure the user ends up with everything they asked for across your replies.",
+            self.system_prompt, context_note
         )
     }
 
@@ -229,6 +238,7 @@ impl Agent {
         batch_chunk_size: usize,
         conversation: serde_json::Value,
         allow_tools: bool,
+        is_group: bool,
     ) -> anyhow::Result<serde_json::Value> {
         let task = spawn_blocking(move || {
             respond_blocking(
@@ -239,6 +249,7 @@ impl Agent {
                 batch_chunk_size,
                 conversation,
                 allow_tools,
+                is_group,
             )
         });
 

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -120,6 +120,7 @@ async fn get_response_from_llm(
     tool_rounds: usize,
     max_tool_rounds: usize,
     allow_tools: bool,
+    bot_name: &str,
 ) -> anyhow::Result<LLMResponse> {
     // DM-vs-group context for system-prompt selection: the latest message wins. Use the current
     // input's flag when it's a message (or carries a folded message); otherwise (a tool-result
@@ -147,7 +148,7 @@ async fn get_response_from_llm(
     );
 
     let parsed = llama_cpp
-        .get_primary_response(conversation, allow_tools, is_group)
+        .get_primary_response(conversation, allow_tools, is_group, bot_name)
         .await?;
 
     let thoughts = parsed
@@ -157,11 +158,13 @@ async fn get_response_from_llm(
         .to_string();
 
     // Straight from JSON to Option — absent / null / blank content is None, never a "" round-trip.
+    // The model also emits the literal "<empty>" to deliberately stay silent (easier for it than
+    // producing nothing at all); map that to None too, so it flows into the silent path.
     let message = parsed
         .get("content")
         .and_then(|v| v.as_str())
         .map(str::trim)
-        .filter(|s| !s.is_empty())
+        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("<empty>"))
         .map(String::from);
 
     // message and tool calls are independent — a turn may carry either or both. Binding failures
@@ -205,6 +208,7 @@ pub async fn get_llm_decision(
         tool_rounds,
         max_tool_rounds,
         allow_tools,
+        &env.bot_name,
     )
     .await;
 

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::conversation::{
-        HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
+        latest_is_group, HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
         ToolType, ConversationAction,
     },
     services::llama_cpp::LlamaCppService,
@@ -121,6 +121,18 @@ async fn get_response_from_llm(
     max_tool_rounds: usize,
     allow_tools: bool,
 ) -> anyhow::Result<LLMResponse> {
+    // DM-vs-group context for system-prompt selection: the latest message wins. Use the current
+    // input's flag when it's a message (or carries a folded message); otherwise (a tool-result
+    // continuation) read the most recent message from history.
+    let is_group = match current_input {
+        LLMInput::ConversationMessage(m) => m.is_group,
+        LLMInput::ToolResults(_, Some(m)) => m.is_group,
+        LLMInput::ToolResults(_, None) => maybe_recent_conversation
+            .as_ref()
+            .map(|rc| latest_is_group(&rc.history))
+            .unwrap_or(false),
+    };
+
     let conversation = build_conversation(
         current_input,
         maybe_recent_conversation,
@@ -135,7 +147,7 @@ async fn get_response_from_llm(
     );
 
     let parsed = llama_cpp
-        .get_primary_response(conversation, allow_tools)
+        .get_primary_response(conversation, allow_tools, is_group)
         .await?;
 
     let thoughts = parsed

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::conversation::{
-        latest_is_group, HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
+        last_conversation_message, HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
         ToolType, ConversationAction,
     },
     services::llama_cpp::LlamaCppService,
@@ -120,19 +120,19 @@ async fn get_response_from_llm(
     tool_rounds: usize,
     max_tool_rounds: usize,
     allow_tools: bool,
-    bot_identity: &str,
 ) -> anyhow::Result<LLMResponse> {
-    // DM-vs-group context for system-prompt selection: the latest message wins. Use the current
-    // input's flag when it's a message (or carries a folded message); otherwise (a tool-result
-    // continuation) read the most recent message from history.
-    let is_group = match current_input {
-        LLMInput::ConversationMessage(m) => m.is_group,
-        LLMInput::ToolResults(_, Some(m)) => m.is_group,
+    // Per-message context for the system prompt (latest message wins): the DM-vs-group flag and the
+    // bot's own identity on this conversation's platform. Use the current input's message when it
+    // has one; otherwise (a tool-result continuation) read the most recent message from history.
+    let latest = match current_input {
+        LLMInput::ConversationMessage(m) => Some(m),
+        LLMInput::ToolResults(_, Some(m)) => Some(m),
         LLMInput::ToolResults(_, None) => maybe_recent_conversation
             .as_ref()
-            .map(|rc| latest_is_group(&rc.history))
-            .unwrap_or(false),
+            .and_then(|rc| last_conversation_message(&rc.history)),
     };
+    let is_group = latest.map(|m| m.is_group).unwrap_or(false);
+    let bot_identity = latest.map(|m| m.bot_identity.clone()).unwrap_or_default();
 
     let conversation = build_conversation(
         current_input,
@@ -148,7 +148,7 @@ async fn get_response_from_llm(
     );
 
     let parsed = llama_cpp
-        .get_primary_response(conversation, allow_tools, is_group, bot_identity)
+        .get_primary_response(conversation, allow_tools, is_group, &bot_identity)
         .await?;
 
     let thoughts = parsed
@@ -201,10 +201,6 @@ pub async fn get_llm_decision(
         if allow_tools { "on" } else { "off — synthesizing" }
     );
 
-    // The bot's own identity in the same name+id form used for message prefixes / mentions, so the
-    // model can recognize when an id refers to itself.
-    let bot_identity = format!("{} (id:{})", env.bot_name, env.bot_user_id);
-
     let llama_cpp_result = get_response_from_llm(
         env.llama_cpp.as_ref(),
         &current_input,
@@ -212,7 +208,6 @@ pub async fn get_llm_decision(
         tool_rounds,
         max_tool_rounds,
         allow_tools,
-        &bot_identity,
     )
     .await;
 

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -120,7 +120,7 @@ async fn get_response_from_llm(
     tool_rounds: usize,
     max_tool_rounds: usize,
     allow_tools: bool,
-    bot_name: &str,
+    bot_identity: &str,
 ) -> anyhow::Result<LLMResponse> {
     // DM-vs-group context for system-prompt selection: the latest message wins. Use the current
     // input's flag when it's a message (or carries a folded message); otherwise (a tool-result
@@ -148,7 +148,7 @@ async fn get_response_from_llm(
     );
 
     let parsed = llama_cpp
-        .get_primary_response(conversation, allow_tools, is_group, bot_name)
+        .get_primary_response(conversation, allow_tools, is_group, bot_identity)
         .await?;
 
     let thoughts = parsed
@@ -201,6 +201,10 @@ pub async fn get_llm_decision(
         if allow_tools { "on" } else { "off — synthesizing" }
     );
 
+    // The bot's own identity in the same name+id form used for message prefixes / mentions, so the
+    // model can recognize when an id refers to itself.
+    let bot_identity = format!("{} (id:{})", env.bot_name, env.bot_user_id);
+
     let llama_cpp_result = get_response_from_llm(
         env.llama_cpp.as_ref(),
         &current_input,
@@ -208,7 +212,7 @@ pub async fn get_llm_decision(
         tool_rounds,
         max_tool_rounds,
         allow_tools,
-        &env.bot_name,
+        &bot_identity,
     )
     .await;
 

--- a/chatbot/src/externals/long_term_memory_external.rs
+++ b/chatbot/src/externals/long_term_memory_external.rs
@@ -53,7 +53,7 @@ async fn commit(
     let filtered: Vec<String> = history
         .iter()
         .filter_map(|h| match h {
-            HistoryEntry::Input(LLMInput::IncomingUpdate(msg)) => {
+            HistoryEntry::Input(LLMInput::ConversationMessage(msg)) => {
                 Some(format!("USER MESSAGE: {}", msg.text))
             }
             HistoryEntry::Output(LLMResponse {

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -30,6 +30,12 @@ struct Env {
     /// Feature flag (from `configuration::features`): announce each tool batch to the user with a
     /// fixed "Using tool: <name>" notice. Read via `env.announce_tool_use`, never the const inline.
     announce_tool_use: bool,
+    /// The bot's own Discord user id — used to ignore only *our own* messages (so other bots are
+    /// still seen), and to recognize when we're addressed.
+    bot_user_id: u64,
+    /// The bot's own display name, surfaced in the system prompt so the model knows who it is in a
+    /// (group) conversation.
+    bot_name: String,
 }
 
 // ENV needs to be initialized asynchronously, so we use OnceCell
@@ -43,13 +49,26 @@ async fn init_env() -> anyhow::Result<Arc<Env>> {
 
     // let ollama_service = OllamaService::new().await?;
 
+    let discord_http = Arc::new(HttpBuilder::new(discord_token).build());
+
+    // Fetch our own Discord identity once, up front, so the message filter can ignore only our own
+    // messages (not other bots) and the system prompt can tell the model its name.
+    let bot_user = discord_http.get_current_user().await?;
+    let bot_user_id = bot_user.id.get();
+    let bot_name = bot_user
+        .global_name
+        .clone()
+        .unwrap_or_else(|| bot_user.name.clone());
+
     Ok(Arc::new(Env {
-        discord_http: Arc::new(HttpBuilder::new(discord_token).build()),
+        discord_http,
         bot_singleton_handle: BotHandle::new(),
         lance_service: Arc::new(lance_service),
         llama_cpp: Arc::new(llama_cpp_service),
         // ollama: Arc::new(ollama_service),
         announce_tool_use: configuration::features::ANNOUNCE_TOOL_USE,
+        bot_user_id,
+        bot_name,
     }))
 }
 

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -30,12 +30,6 @@ struct Env {
     /// Feature flag (from `configuration::features`): announce each tool batch to the user with a
     /// fixed "Using tool: <name>" notice. Read via `env.announce_tool_use`, never the const inline.
     announce_tool_use: bool,
-    /// The bot's own Discord user id — used to ignore only *our own* messages (so other bots are
-    /// still seen), and to recognize when we're addressed.
-    bot_user_id: u64,
-    /// The bot's own display name, surfaced in the system prompt so the model knows who it is in a
-    /// (group) conversation.
-    bot_name: String,
 }
 
 // ENV needs to be initialized asynchronously, so we use OnceCell
@@ -51,15 +45,6 @@ async fn init_env() -> anyhow::Result<Arc<Env>> {
 
     let discord_http = Arc::new(HttpBuilder::new(discord_token).build());
 
-    // Fetch our own Discord identity once, up front, so the message filter can ignore only our own
-    // messages (not other bots) and the system prompt can tell the model its name.
-    let bot_user = discord_http.get_current_user().await?;
-    let bot_user_id = bot_user.id.get();
-    let bot_name = bot_user
-        .global_name
-        .clone()
-        .unwrap_or_else(|| bot_user.name.clone());
-
     Ok(Arc::new(Env {
         discord_http,
         bot_singleton_handle: BotHandle::new(),
@@ -67,8 +52,6 @@ async fn init_env() -> anyhow::Result<Arc<Env>> {
         llama_cpp: Arc::new(llama_cpp_service),
         // ollama: Arc::new(ollama_service),
         announce_tool_use: configuration::features::ANNOUNCE_TOOL_USE,
-        bot_user_id,
-        bot_name,
     }))
 }
 

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -16,11 +16,25 @@ pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Clien
         | GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT;
 
+    // Fetch our own Discord identity up front (id + display name). This is adapter-local — bot
+    // identity is per-platform, not a global Env concept, so each platform's adapter holds its own.
+    let http = serenity::all::HttpBuilder::new(discord_token).build();
+    let bot_user = http.get_current_user().await?;
+    let bot_user_id = bot_user.id.get();
+    let bot_name = bot_user
+        .global_name
+        .clone()
+        .unwrap_or_else(|| bot_user.name.clone());
+
     let conversation_state_machine = CONVERSATION_STATE_MACHINE.clone();
 
     // Create a new instance of the Client, logging in as a bot. This will
     let client = Client::builder(discord_token, intents)
-        .event_handler(Handler { conversation_state_machine })
+        .event_handler(Handler {
+            conversation_state_machine,
+            bot_user_id,
+            bot_name,
+        })
         .await?;
 
     Ok(client)
@@ -34,6 +48,11 @@ pub async fn run_discord(mut client: Client) -> anyhow::Result<()> {
 
 struct Handler {
     conversation_state_machine: StateMachineHandle<ConversationId, ConversationAction>,
+    /// This bot's own Discord identity (adapter-local — bot identity is per-platform, never a global
+    /// Env value). Used to ignore our own messages, humanize our own @mentions, and stamp the
+    /// `bot_identity` carried on each message into the domain.
+    bot_user_id: u64,
+    bot_name: String,
 }
 
 #[async_trait]
@@ -41,15 +60,13 @@ impl EventHandler for Handler {
     // Set a handler for the `message` event - so that whenever a new message
     // is received - the closure (or function) passed will be called.
     async fn message(&self, _ctx: Context, message: DMessage) {
-        let env = crate::ENV.get().expect("ENV initialized before clients start");
-
         // Ignore only our OWN messages (matched by id), not all bots — so the bot still sees and can
         // react to other bots in the channel. (Our own replies are already in history as assistant
         // turns; re-ingesting them as user input would double them and risk a self-loop.)
-        if message.author.id.get() == env.bot_user_id {
+        if message.author.id.get() == self.bot_user_id {
             return;
         }
-        let Some(text) = filter(&message, env.bot_user_id, &env.bot_name) else {
+        let Some(text) = filter(&message, self.bot_user_id, &self.bot_name) else {
             return;
         };
 
@@ -72,6 +89,10 @@ impl EventHandler for Handler {
         // `identity` / mention humanization in `filter`).
         let msg = format!("{}: {text}", identity(&name, author_id));
 
+        // The bot's own identity on this platform, stamped onto the message so the domain/LLM path
+        // knows it per-conversation without a global Env value (identity is per-platform).
+        let bot_identity = identity(&self.bot_name, self.bot_user_id);
+
         // Key the conversation by the channel the message arrived on (a DM channel is 1:1, a server
         // channel is shared). The channel id is stored as the opaque conversation id string; only
         // this Discord adapter knows it's a channel id.
@@ -82,6 +103,7 @@ impl EventHandler for Handler {
             user_id,
             name,
             is_group,
+            bot_identity,
         };
         self.conversation_state_machine
             .act(conversation_id, action)

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -41,10 +41,15 @@ impl EventHandler for Handler {
     // Set a handler for the `message` event - so that whenever a new message
     // is received - the closure (or function) passed will be called.
     async fn message(&self, ctx: Context, message: DMessage) {
-        if message.author.bot {
+        let env = crate::ENV.get().expect("ENV initialized before clients start");
+
+        // Ignore only our OWN messages (matched by id), not all bots — so the bot still sees and can
+        // react to other bots in the channel. (Our own replies are already in history as assistant
+        // turns; re-ingesting them as user input would double them and risk a self-loop.)
+        if message.author.id.get() == env.bot_user_id {
             return;
         }
-        let Some(text) = filter(&message, &ctx).await else {
+        let Some(text) = filter(&message, env.bot_user_id, &env.bot_name) else {
             return;
         };
 
@@ -88,29 +93,20 @@ impl EventHandler for Handler {
 }
 
 /// Clean a raw message into the text we feed the model, or `None` to ignore it:
-/// - strips a leading `/` and the bot's own `@mention`,
-/// - collapses runs of whitespace,
-/// - returns `None` if nothing textual remains (e.g. an attachment-only or bare-mention message),
-///   so we don't run the model on empty content.
-async fn filter(message: &DMessage, ctx: &Context) -> Option<String> {
-    let Ok(info) = ctx.http.get_current_application_info().await else {
-        return None;
-    };
+/// - replaces the bot's own `@mention` (both `<@id>` and `<@!id>` forms) with its **name**, so the
+///   model can see when it's being addressed instead of the mention being silently stripped,
+/// - strips a leading `/`, collapses runs of whitespace,
+/// - returns `None` if nothing textual remains (e.g. an attachment-only message), so we don't run
+///   the model on empty content.
+fn filter(message: &DMessage, bot_user_id: u64, bot_name: &str) -> Option<String> {
+    let mut text = message.content.clone();
+    for handle in [format!("<@{bot_user_id}>"), format!("<@!{bot_user_id}>")] {
+        text = text.replace(&handle, bot_name);
+    }
 
-    let id: i64 = info.id.into();
-    //-----------------------remove self mention from message
-    let handle = format!("<@{}>", &id);
-
-    let msg = message
-        .content
-        .replace(handle.as_str(), "")
-        .trim()
-        .trim_start_matches('/')
-        .trim()
-        .to_string();
-
+    let text = text.trim().trim_start_matches('/').trim().to_string();
     let space_trimmer = Regex::new(r"\s+").unwrap();
-    let msg: String = space_trimmer.replace_all(&msg, " ").trim().to_string();
+    let text: String = space_trimmer.replace_all(&text, " ").trim().to_string();
 
-    (!msg.is_empty()).then_some(msg)
+    (!text.is_empty()).then_some(text)
 }

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -54,7 +54,8 @@ impl EventHandler for Handler {
         };
 
         let is_group = message.guild_id.is_some();
-        let user_id = message.author.id.get().to_string();
+        let author_id = message.author.id.get();
+        let user_id = author_id.to_string();
         // Display name: a guild nick if set, else the global/display name, else the username (no nick
         // in a DM). Name resolution lives only in this adapter — the domain layer never sees it.
         let name = match message.guild_id {
@@ -70,10 +71,11 @@ impl EventHandler for Handler {
                 .unwrap_or_else(|| message.author.name.clone()),
         };
 
-        // Prefix the sender's name onto the text — for every message, DM or group — so the model
-        // always knows who is speaking (every human maps to OpenAI role "user", so the name in the
-        // content is the only speaker signal).
-        let msg = format!("{name}: {text}");
+        // Prefix the sender's identity — name AND Discord id — onto the text, for every message, DM
+        // or group. The id makes the speaker unambiguous: names can collide or change, and the model
+        // needs a stable handle to tell who's who and whether a mention refers to itself (see
+        // `identity` / mention humanization in `filter`).
+        let msg = format!("{}: {text}", identity(&name, author_id));
 
         // Key the conversation by the channel the message arrived on (a DM channel is 1:1, a server
         // channel is shared). The channel id is stored as the opaque conversation id string; only
@@ -92,16 +94,34 @@ impl EventHandler for Handler {
     }
 }
 
+/// A person's stable identifier as the model sees it: name plus Discord id, e.g.
+/// `Zireael9797 (id:12345)`. Used for both message prefixes and humanized @mentions so the model
+/// can always correlate who's who — and tell when an id matches its own. Deliberately *not* the
+/// `<@id>` ping form, so the bot echoing an identity can't accidentally ping anyone.
+fn identity(name: &str, id: u64) -> String {
+    format!("{name} (id:{id})")
+}
+
 /// Clean a raw message into the text we feed the model, or `None` to ignore it:
-/// - replaces the bot's own `@mention` (both `<@id>` and `<@!id>` forms) with its **name**, so the
-///   model can see when it's being addressed instead of the mention being silently stripped,
+/// - rewrites every `@mention` (`<@id>` / `<@!id>`) into the mentioned user's `identity` (name+id),
+///   so no raw numeric id ever reaches the model with no name attached,
 /// - strips a leading `/`, collapses runs of whitespace,
 /// - returns `None` if nothing textual remains (e.g. an attachment-only message), so we don't run
 ///   the model on empty content.
 fn filter(message: &DMessage, bot_user_id: u64, bot_name: &str) -> Option<String> {
     let mut text = message.content.clone();
-    for handle in [format!("<@{bot_user_id}>"), format!("<@!{bot_user_id}>")] {
-        text = text.replace(&handle, bot_name);
+    for user in &message.mentions {
+        let id = user.id.get();
+        // Use our configured name for ourselves; otherwise the mentioned user's display name.
+        let name = if id == bot_user_id {
+            bot_name.to_string()
+        } else {
+            user.global_name.clone().unwrap_or_else(|| user.name.clone())
+        };
+        let label = identity(&name, id);
+        text = text
+            .replace(&format!("<@{id}>"), &label)
+            .replace(&format!("<@!{id}>"), &label);
     }
 
     let text = text.trim().trim_start_matches('/').trim().to_string();

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -10,7 +10,11 @@ use crate::{
 pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Client> {
     // Configure the client with your Discord bot token in the environment.
 
-    let intents = GatewayIntents::DIRECT_MESSAGES;
+    // DMs + group/server channels. MESSAGE_CONTENT is a privileged intent (must also be enabled in
+    // the Discord Developer Portal) — required to read the text of messages that don't mention us.
+    let intents = GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
 
     let conversation_state_machine = CONVERSATION_STATE_MACHINE.clone();
 
@@ -37,29 +41,58 @@ impl EventHandler for Handler {
     // Set a handler for the `message` event - so that whenever a new message
     // is received - the closure (or function) passed will be called.
     async fn message(&self, ctx: Context, message: DMessage) {
-        if !message.author.bot {
-            if let Some((msg, start_conversation)) = filter(&message, &ctx).await {
-                // Key the conversation by the channel the message arrived on (a DM channel is 1:1,
-                // a server channel is shared). The channel id is stored as the opaque conversation
-                // id string; only this Discord adapter knows it's a channel id.
-                let conversation_id = ConversationId(Platform::Discord, message.channel_id.get().to_string());
-                let action = ConversationAction::NewMessage {
-                    start_conversation,
-                    msg,
-                };
-                self.conversation_state_machine.act(conversation_id, action).await;
-            }
+        if message.author.bot {
+            return;
         }
+        let Some(text) = filter(&message, &ctx).await else {
+            return;
+        };
+
+        let is_group = message.guild_id.is_some();
+        let user_id = message.author.id.get().to_string();
+        // Display name: a guild nick if set, else the global/display name, else the username (no nick
+        // in a DM). Name resolution lives only in this adapter — the domain layer never sees it.
+        let name = match message.guild_id {
+            Some(_) => message
+                .author_nick(&ctx)
+                .await
+                .or_else(|| message.author.global_name.clone())
+                .unwrap_or_else(|| message.author.name.clone()),
+            None => message
+                .author
+                .global_name
+                .clone()
+                .unwrap_or_else(|| message.author.name.clone()),
+        };
+
+        // Prefix the sender's name onto the text — for every message, DM or group — so the model
+        // always knows who is speaking (every human maps to OpenAI role "user", so the name in the
+        // content is the only speaker signal).
+        let msg = format!("{name}: {text}");
+
+        // Key the conversation by the channel the message arrived on (a DM channel is 1:1, a server
+        // channel is shared). The channel id is stored as the opaque conversation id string; only
+        // this Discord adapter knows it's a channel id.
+        let conversation_id =
+            ConversationId(Platform::Discord, message.channel_id.get().to_string());
+        let action = ConversationAction::NewMessage {
+            msg,
+            user_id,
+            name,
+            is_group,
+        };
+        self.conversation_state_machine
+            .act(conversation_id, action)
+            .await;
     }
 }
 
-///Filter basically does some spring cleaning.
-/// - checks whether the update is actually a message or some other type.
-/// - trims leading and trailing spaces ("   /hellow    @machinelifeformbot   world  " becomes "/hellow    @machinelifeformbot   world").
-/// - removes / from start if it's there ("/hellow    @machinelifeformbot   world" becomes "hellow    @machinelifeformbot   world").
-/// - removes mentions of the bot from the message ("hellow    @machinelifeformbot   world" becomes "hellow      world").
-/// - replaces redundant spaces with single spaces using regex ("hellow      world" becomes "hellow world").
-async fn filter(message: &DMessage, ctx: &Context) -> Option<(String, bool)> {
+/// Clean a raw message into the text we feed the model, or `None` to ignore it:
+/// - strips a leading `/` and the bot's own `@mention`,
+/// - collapses runs of whitespace,
+/// - returns `None` if nothing textual remains (e.g. an attachment-only or bare-mention message),
+///   so we don't run the model on empty content.
+async fn filter(message: &DMessage, ctx: &Context) -> Option<String> {
     let Ok(info) = ctx.http.get_current_application_info().await else {
         return None;
     };
@@ -77,11 +110,7 @@ async fn filter(message: &DMessage, ctx: &Context) -> Option<(String, bool)> {
         .to_string();
 
     let space_trimmer = Regex::new(r"\s+").unwrap();
+    let msg: String = space_trimmer.replace_all(&msg, " ").trim().to_string();
 
-    let msg: String = space_trimmer.replace_all(&msg, " ").into();
-    //-----------------------check if message is from a group chat.......
-    Some((
-        msg,
-        message.guild_id.is_none() || message.content.contains(handle.as_str()),
-    ))
+    (!msg.is_empty()).then_some(msg)
 }

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -40,7 +40,7 @@ struct Handler {
 impl EventHandler for Handler {
     // Set a handler for the `message` event - so that whenever a new message
     // is received - the closure (or function) passed will be called.
-    async fn message(&self, ctx: Context, message: DMessage) {
+    async fn message(&self, _ctx: Context, message: DMessage) {
         let env = crate::ENV.get().expect("ENV initialized before clients start");
 
         // Ignore only our OWN messages (matched by id), not all bots — so the bot still sees and can
@@ -56,20 +56,15 @@ impl EventHandler for Handler {
         let is_group = message.guild_id.is_some();
         let author_id = message.author.id.get();
         let user_id = author_id.to_string();
-        // Display name: a guild nick if set, else the global/display name, else the username (no nick
-        // in a DM). Name resolution lives only in this adapter — the domain layer never sees it.
-        let name = match message.guild_id {
-            Some(_) => message
-                .author_nick(&ctx)
-                .await
-                .or_else(|| message.author.global_name.clone())
-                .unwrap_or_else(|| message.author.name.clone()),
-            None => message
-                .author
-                .global_name
-                .clone()
-                .unwrap_or_else(|| message.author.name.clone()),
-        };
+        // Display name straight from the message payload (global/display name, else username). No
+        // guild-nick lookup: that would be a blocking HTTP member fetch on every group message (we
+        // don't request GUILD_MEMBERS, so it's never cached), which can stall the whole inbound path
+        // under rate limiting. Nicks can be re-added later via the cache without a blocking call.
+        let name = message
+            .author
+            .global_name
+            .clone()
+            .unwrap_or_else(|| message.author.name.clone());
 
         // Prefix the sender's identity — name AND Discord id — onto the text, for every message, DM
         // or group. The id makes the speaker unambiguous: names can collide or change, and the model
@@ -125,7 +120,7 @@ fn filter(message: &DMessage, bot_user_id: u64, bot_name: &str) -> Option<String
     }
 
     let text = text.trim().trim_start_matches('/').trim().to_string();
-    let space_trimmer = Regex::new(r"\s+").unwrap();
+    let space_trimmer = Regex::new(r"\s+").expect("static whitespace regex is valid");
     let text: String = space_trimmer.replace_all(&text, " ").trim().to_string();
 
     (!text.is_empty()).then_some(text)

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -83,6 +83,7 @@ impl LlamaCppService {
         conversation: serde_json::Value,
         allow_tools: bool,
         is_group: bool,
+        bot_name: &str,
     ) -> anyhow::Result<serde_json::Value> {
         self.primary_agent
             .respond(
@@ -93,6 +94,7 @@ impl LlamaCppService {
                 conversation,
                 allow_tools,
                 is_group,
+                bot_name.to_string(),
             )
             .await
     }

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -82,6 +82,7 @@ impl LlamaCppService {
         &self,
         conversation: serde_json::Value,
         allow_tools: bool,
+        is_group: bool,
     ) -> anyhow::Result<serde_json::Value> {
         self.primary_agent
             .respond(
@@ -91,6 +92,7 @@ impl LlamaCppService {
                 Self::BATCH_CHUNK_SIZE,
                 conversation,
                 allow_tools,
+                is_group,
             )
             .await
     }

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -83,7 +83,7 @@ impl LlamaCppService {
         conversation: serde_json::Value,
         allow_tools: bool,
         is_group: bool,
-        bot_name: &str,
+        bot_identity: &str,
     ) -> anyhow::Result<serde_json::Value> {
         self.primary_agent
             .respond(
@@ -94,7 +94,7 @@ impl LlamaCppService {
                 conversation,
                 allow_tools,
                 is_group,
-                bot_name.to_string(),
+                bot_identity.to_string(),
             )
             .await
     }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -3,10 +3,12 @@ use crate::externals::{
     llama_cpp_external::get_llm_decision, message_external::send_message,
     tool_call_external::execute_tool,
 };
-use crate::types::conversation::{LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
+use crate::types::conversation::{
+    latest_is_group, LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS,
+};
 use crate::{
     types::conversation::{
-        HistoryEntry, LLMInput, RecentConversation, Conversation, ConversationAction, ConversationId, IncomingUpdate,
+        HistoryEntry, LLMInput, RecentConversation, Conversation, ConversationAction, ConversationId, ConversationMessage,
         ConversationState,
     },
     Env, ENV,
@@ -30,7 +32,7 @@ fn handle_outcome(
     is_timeout: bool,
     response: LLMResponse,
     recent_conversation: RecentConversation,
-    pending: Vec<IncomingUpdate>,
+    pending: Vec<ConversationMessage>,
     tool_rounds: usize,
 ) -> ConversationTransitionResult {
     // Any `message` was already sent on the way into SendingMessage; here we act on the tool calls.
@@ -102,32 +104,24 @@ pub fn conversation_transition(
                 user_state,
                 ConversationAction::NewMessage {
                     msg,
-                    start_conversation,
+                    user_id,
+                    name,
+                    is_group,
                 },
             ) => {
-                let accept_message = match (&user_state, start_conversation) {
-                    (
-                        ConversationState::Idle {
-                            recent_conversation: None,
-                        },
-                        false,
-                    ) => false,
-                    _ => true,
-                };
-
-                let pending = if accept_message {
-                    let mut pending = conversation.pending;
-                    // Queued iff it arrived while the bot was busy (any non-Idle state) — i.e. it
-                    // crossed an in-flight response. An Idle arrival drains immediately and isn't.
-                    let queued = !matches!(&user_state, ConversationState::Idle { .. });
-                    pending.push(IncomingUpdate {
-                        text: msg.clone(),
-                        queued,
-                    });
-                    pending
-                } else {
-                    conversation.pending
-                };
+                // Every message is accepted and buffered (the old `start_conversation` mention-gate
+                // is gone — in a group the model itself decides whether to reply; see the group
+                // system prompt). Queued iff it arrived while the bot was busy (any non-Idle state),
+                // so it crossed an in-flight response; an Idle arrival drains immediately and isn't.
+                let mut pending = conversation.pending;
+                let queued = !matches!(&user_state, ConversationState::Idle { .. });
+                pending.push(ConversationMessage {
+                    text: msg.clone(),
+                    queued,
+                    user_id: user_id.clone(),
+                    name: name.clone(),
+                    is_group: *is_group,
+                });
 
                 Ok((
                     Conversation {
@@ -365,9 +359,14 @@ pub fn conversation_transition(
                 println!("Commited to Memory");
 
                 let timeout_message = "User said goodbye, RESPOND WITH GOODBYE BUT MENTION RELEVANT THINGS ABOUT THE CONVERSATION".to_string();
-                let current_input = LLMInput::IncomingUpdate(IncomingUpdate {
+                // Synthetic system message (no real sender). Inherit the conversation's group-ness
+                // from the last real message so the goodbye uses the right system prompt.
+                let current_input = LLMInput::ConversationMessage(ConversationMessage {
                     text: timeout_message,
                     queued: false,
+                    user_id: String::new(),
+                    name: String::new(),
+                    is_group: latest_is_group(&recent_conversation.history),
                 });
 
                 let mut external = Vec::<ConversationExternalOperation>::new();
@@ -404,18 +403,29 @@ pub fn conversation_transition(
 /// Drain buffered user messages into a single newline-joined string, clearing `pending`. Returns
 /// `None` if there was nothing buffered. Single source of truth for both pending drain points (the
 /// Idle drain below and the mid-tool-loop fold in the RunningTools branch), so they stay identical.
-fn take_pending(pending: &mut Vec<IncomingUpdate>) -> Option<IncomingUpdate> {
+fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMessage> {
     (!pending.is_empty()).then(|| {
         let drained = std::mem::take(pending);
         // Messages drained together are homogeneous (all queued during a busy turn, or a single
-        // Idle arrival); mark the merged message queued if any were.
+        // Idle arrival); mark the merged message queued if any were. Each member's `text` already
+        // carries its own name prefix, so joining keeps per-speaker attribution even when a group
+        // batch mixes senders. Identity fields take the last message's (best-effort for the merge).
         let queued = drained.iter().any(|m| m.queued);
+        let is_group = drained.last().map(|m| m.is_group).unwrap_or(false);
+        let user_id = drained.last().map(|m| m.user_id.clone()).unwrap_or_default();
+        let name = drained.last().map(|m| m.name.clone()).unwrap_or_default();
         let text = drained
             .into_iter()
             .map(|m| m.text)
             .collect::<Vec<_>>()
             .join("\n");
-        IncomingUpdate { text, queued }
+        ConversationMessage {
+            text,
+            queued,
+            user_id,
+            name,
+            is_group,
+        }
     })
 }
 
@@ -444,7 +454,7 @@ fn post_transition(
         .map(|(rc, _)| rc.history())
         .unwrap_or_else(Vec::new);
 
-    let current_input = LLMInput::IncomingUpdate(msg);
+    let current_input = LLMInput::ConversationMessage(msg);
 
     external.push(Box::pin(get_llm_decision(
         env.clone(),

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -4,7 +4,7 @@ use crate::externals::{
     tool_call_external::execute_tool,
 };
 use crate::types::conversation::{
-    last_conversation_message, LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS,
+    LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS,
 };
 use crate::{
     types::conversation::{
@@ -29,7 +29,6 @@ type ConversationExternalOperation = ExternalOperation<ConversationAction>;
 fn handle_outcome(
     env: Arc<Env>,
     conversation_id: &ConversationId,
-    is_timeout: bool,
     response: LLMResponse,
     recent_conversation: RecentConversation,
     pending: Vec<ConversationMessage>,
@@ -37,15 +36,11 @@ fn handle_outcome(
 ) -> ConversationTransitionResult {
     // Any `message` was already sent on the way into SendingMessage; here we act on the tool calls.
     if response.tool_calls.is_empty() {
-        // No tools to run — settle into Idle.
+        // No tools to run — settle back into Idle, holding the conversation for the idle window.
         Ok((
             Conversation {
                 state: ConversationState::Idle {
-                    recent_conversation: if is_timeout {
-                        None
-                    } else {
-                        Some((recent_conversation, Utc::now()))
-                    },
+                    recent_conversation: Some((recent_conversation, Utc::now())),
                 },
                 last_transition: Utc::now(),
                 pending,
@@ -70,7 +65,6 @@ fn handle_outcome(
         Ok((
             Conversation {
                 state: ConversationState::RunningTools {
-                    is_timeout,
                     recent_conversation,
                     tool_rounds: tool_rounds + 1,
                     pending_tools,
@@ -136,7 +130,6 @@ pub fn conversation_transition(
             }
             (
                 ConversationState::AwaitingLLMDecision {
-                    is_timeout,
                     history,
                     current_input,
                     tool_rounds,
@@ -190,7 +183,6 @@ pub fn conversation_transition(
                             Ok((
                                 Conversation {
                                     state: ConversationState::SendingMessage {
-                                        is_timeout,
                                         outcome: response.clone(),
                                         recent_conversation: updated_conversation,
                                         tool_rounds,
@@ -204,7 +196,6 @@ pub fn conversation_transition(
                         None => handle_outcome(
                             env.clone(),
                             &conversation_id,
-                            is_timeout,
                             response.clone(),
                             updated_conversation,
                             conversation.pending,
@@ -225,7 +216,6 @@ pub fn conversation_transition(
             },
             (
                 ConversationState::SendingMessage {
-                    is_timeout,
                     outcome,
                     recent_conversation,
                     tool_rounds,
@@ -234,7 +224,6 @@ pub fn conversation_transition(
             ) => handle_outcome(
                 env.clone(),
                 &conversation_id,
-                is_timeout,
                 outcome,
                 recent_conversation,
                 conversation.pending,
@@ -243,7 +232,6 @@ pub fn conversation_transition(
             (
                 ConversationState::RunningTools {
                     recent_conversation,
-                    is_timeout,
                     tool_rounds,
                     mut pending_tools,
                     mut completed_tools,
@@ -297,7 +285,6 @@ pub fn conversation_transition(
                     Ok((
                         Conversation {
                             state: ConversationState::AwaitingLLMDecision {
-                                is_timeout,
                                 history,
                                 current_input,
                                 tool_rounds,
@@ -312,7 +299,6 @@ pub fn conversation_transition(
                     Ok((
                         Conversation {
                             state: ConversationState::RunningTools {
-                                is_timeout,
                                 recent_conversation,
                                 tool_rounds,
                                 pending_tools,
@@ -353,49 +339,22 @@ pub fn conversation_transition(
                 ))
             }
             (
-                ConversationState::CommitingToMemory {
-                    recent_conversation,
-                },
+                ConversationState::CommitingToMemory { .. },
                 ConversationAction::CommitResult(_),
             ) => {
                 println!("Commited to Memory");
 
-                let timeout_message = "User said goodbye, RESPOND WITH GOODBYE BUT MENTION RELEVANT THINGS ABOUT THE CONVERSATION".to_string();
-                // Synthetic system message (no real sender). Inherit the conversation's group-ness
-                // and the bot's platform identity from the last real message so the goodbye uses the
-                // right system prompt.
-                let last = last_conversation_message(&recent_conversation.history);
-                let current_input = LLMInput::ConversationMessage(ConversationMessage {
-                    text: timeout_message,
-                    queued: false,
-                    user_id: String::new(),
-                    name: String::new(),
-                    is_group: last.map(|m| m.is_group).unwrap_or(false),
-                    bot_identity: last.map(|m| m.bot_identity.clone()).unwrap_or_default(),
-                });
-
-                let mut external = Vec::<ConversationExternalOperation>::new();
-
-                external.push(Box::pin(get_llm_decision(
-                    env.clone(),
-                    current_input.clone(),
-                    Some(recent_conversation.clone()),
-                    0,
-                    MAX_TOOL_ROUNDS,
-                )));
-
+                // History has been committed to long-term memory; drop it and return to a fresh
+                // Idle. (No goodbye turn — we don't send a parting message.)
                 Ok((
                     Conversation {
-                        state: ConversationState::AwaitingLLMDecision {
-                            is_timeout: true,
-                            history: recent_conversation.history,
-                            current_input,
-                            tool_rounds: 0,
+                        state: ConversationState::Idle {
+                            recent_conversation: None,
                         },
                         last_transition: Utc::now(),
                         ..conversation
                     },
-                    external,
+                    Vec::new(),
                 ))
             }
             _ => Err(anyhow::anyhow!("Invalid state or action")),
@@ -474,7 +433,6 @@ fn post_transition(
     Ok((
         Conversation {
             state: ConversationState::AwaitingLLMDecision {
-                is_timeout: false,
                 history,
                 current_input,
                 tool_rounds: 0,

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -4,7 +4,7 @@ use crate::externals::{
     tool_call_external::execute_tool,
 };
 use crate::types::conversation::{
-    latest_is_group, LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS,
+    last_conversation_message, LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS,
 };
 use crate::{
     types::conversation::{
@@ -107,6 +107,7 @@ pub fn conversation_transition(
                     user_id,
                     name,
                     is_group,
+                    bot_identity,
                 },
             ) => {
                 // Every message is accepted and buffered (the old `start_conversation` mention-gate
@@ -121,6 +122,7 @@ pub fn conversation_transition(
                     user_id: user_id.clone(),
                     name: name.clone(),
                     is_group: *is_group,
+                    bot_identity: bot_identity.clone(),
                 });
 
                 Ok((
@@ -360,13 +362,16 @@ pub fn conversation_transition(
 
                 let timeout_message = "User said goodbye, RESPOND WITH GOODBYE BUT MENTION RELEVANT THINGS ABOUT THE CONVERSATION".to_string();
                 // Synthetic system message (no real sender). Inherit the conversation's group-ness
-                // from the last real message so the goodbye uses the right system prompt.
+                // and the bot's platform identity from the last real message so the goodbye uses the
+                // right system prompt.
+                let last = last_conversation_message(&recent_conversation.history);
                 let current_input = LLMInput::ConversationMessage(ConversationMessage {
                     text: timeout_message,
                     queued: false,
                     user_id: String::new(),
                     name: String::new(),
-                    is_group: latest_is_group(&recent_conversation.history),
+                    is_group: last.map(|m| m.is_group).unwrap_or(false),
+                    bot_identity: last.map(|m| m.bot_identity.clone()).unwrap_or_default(),
                 });
 
                 let mut external = Vec::<ConversationExternalOperation>::new();
@@ -414,6 +419,7 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
         let is_group = drained.last().map(|m| m.is_group).unwrap_or(false);
         let user_id = drained.last().map(|m| m.user_id.clone()).unwrap_or_default();
         let name = drained.last().map(|m| m.name.clone()).unwrap_or_default();
+        let bot_identity = drained.last().map(|m| m.bot_identity.clone()).unwrap_or_default();
         let text = drained
             .into_iter()
             .map(|m| m.text)
@@ -425,6 +431,7 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
             user_id,
             name,
             is_group,
+            bot_identity,
         }
     })
 }

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -99,20 +99,28 @@ impl Default for ConversationState {
     }
 }
 
-/// An inbound update from a conversation — today always a user's message (later may also carry
-/// non-message events: edits, reactions, joins). `queued` is true when it was buffered into
-/// `pending` while the bot was busy (a non-Idle state), so it crossed an in-flight response. The
-/// flag is the persisted truth; the `[Followup]` tag is applied only at prompt-render time (see
-/// `to_content`).
+/// One inbound message in a conversation. `text` already carries the sender's name prefix
+/// (`"Alice: hello"`) — the Discord adapter prepends it for every message, DM or group, so the
+/// model always knows who is speaking (in a group, every human still maps to OpenAI `role: "user"`,
+/// so the name in the text is the only speaker signal). `name`/`user_id` keep the same identity in
+/// structured form. `is_group` is the DM-vs-group context of the message (latest message wins; not
+/// persisted on the `Conversation`). `queued` is true when it was buffered into `pending` while the
+/// bot was busy, so it crossed an in-flight response — surfaced as a `[Followup]` tag at render time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IncomingUpdate {
+pub struct ConversationMessage {
     pub text: String,
     pub queued: bool,
+    /// Sender's platform user id (stable identity); empty for synthetic/system messages.
+    pub user_id: String,
+    /// Sender's display name; empty for synthetic/system messages. Already baked into `text`.
+    pub name: String,
+    /// Whether this message came from a group chat (vs a 1:1 DM). Drives system-prompt selection.
+    pub is_group: bool,
 }
 
-impl IncomingUpdate {
-    /// Prompt content: the text, prefixed with `[Followup]` when it was queued mid-response so the
-    /// model knows it may already be addressed. Render-time only — the stored `text` stays clean.
+impl ConversationMessage {
+    /// Prompt content: the text (which already includes the `name:` prefix), tagged with
+    /// `[Followup]` when it was queued mid-response so the model knows it may already be addressed.
     pub fn to_content(&self) -> String {
         if self.queued {
             format!("[Followup] {}", self.text)
@@ -127,19 +135,34 @@ impl IncomingUpdate {
 /// channel/DM on some [`Platform`]) — one independent instance per conversation.
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct Conversation {
-    pub pending: Vec<IncomingUpdate>,
+    pub pending: Vec<ConversationMessage>,
     pub state: ConversationState,
     pub last_transition: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
-    IncomingUpdate(IncomingUpdate),
+    ConversationMessage(ConversationMessage),
     /// One turn's batch of tool results (id order), each tagged with the call it answers.
-    /// The optional trailing `IncomingUpdate` is input that arrived mid-tool-run, folded into this
+    /// The optional trailing `ConversationMessage` is input that arrived mid-tool-run, folded into this
     /// same turn *after* the results — OpenAI requires tool responses to immediately follow the
     /// assistant's `tool_calls`, so the user message comes last.
-    ToolResults(Vec<ToolResult>, Option<IncomingUpdate>),
+    ToolResults(Vec<ToolResult>, Option<ConversationMessage>),
+}
+
+/// The `is_group` of the most recent message in `history` (latest message wins; defaults to DM /
+/// `false` when there's no message to read). Used to pick the DM-vs-group system prompt and to give
+/// synthetic messages (e.g. the timeout goodbye) the conversation's group-ness.
+pub fn latest_is_group(history: &[HistoryEntry]) -> bool {
+    history
+        .iter()
+        .rev()
+        .find_map(|e| match e {
+            HistoryEntry::Input(LLMInput::ConversationMessage(m)) => Some(m.is_group),
+            HistoryEntry::Input(LLMInput::ToolResults(_, Some(m))) => Some(m.is_group),
+            _ => None,
+        })
+        .unwrap_or(false)
 }
 
 impl LLMInput {
@@ -147,7 +170,7 @@ impl LLMInput {
     /// message per result (the template groups them into a single tool-response turn).
     pub fn to_openai_messages(&self) -> Vec<Value> {
         match self {
-            LLMInput::IncomingUpdate(msg) => vec![json!({ "role": "user", "content": msg.to_content() })],
+            LLMInput::ConversationMessage(msg) => vec![json!({ "role": "user", "content": msg.to_content() })],
             LLMInput::ToolResults(results, user_msg) => {
                 let mut messages: Vec<Value> = results
                     .iter()
@@ -260,7 +283,7 @@ impl HistoryEntry {
     pub fn format_simplified(&self) -> String {
         match self {
             HistoryEntry::Input(llm_input) => match llm_input {
-                LLMInput::IncomingUpdate(m) => format!("User:\n{}", m.text),
+                LLMInput::ConversationMessage(m) => format!("User:\n{}", m.text),
                 LLMInput::ToolResults(results, user_msg) => {
                     let joined = results
                         .iter()
@@ -294,8 +317,13 @@ impl HistoryEntry {
 pub enum ConversationAction {
     ForceReset,
     NewMessage {
+        /// Message text with the sender's name already prefixed (`"Alice: hello"`).
         msg: String,
-        start_conversation: bool,
+        /// Sender's platform user id and display name (for the structured `ConversationMessage`).
+        user_id: String,
+        name: String,
+        /// Whether it arrived from a group chat (vs a 1:1 DM).
+        is_group: bool,
     },
     Timeout,
     CommitResult(Result<(), String>),

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -240,9 +240,8 @@ pub struct LLMResponse {
 }
 
 impl LLMResponse {
-    /// A degenerate decision: no user-facing message and no tool calls. Currently unused — we keep
-    /// empty decisions in history (they render as `content: ""`) — but kept as a ready predicate.
-    #[allow(dead_code)]
+    /// A degenerate decision: no user-facing message and no tool calls — i.e. the model chose to
+    /// stay silent. Used to render an explicit silent marker (see `to_openai_message`).
     pub fn is_empty(&self) -> bool {
         self.message.as_deref().map_or(true, str::is_empty) && self.tool_calls.is_empty()
     }
@@ -250,9 +249,19 @@ impl LLMResponse {
     pub fn to_openai_message(&self) -> Value {
         // Assistant turn: the message (if any) as content, plus a native tool_calls array when
         // present. name/arguments are derived back from each bound ToolType (the inverse of `bind`).
+        //
+        // A silent turn (empty message, no tools — the model chose not to reply, common in groups)
+        // is stored faithfully as `message: None`, but rendered here with an explicit marker so the
+        // model can see in later turns that it deliberately passed (matters for [Followup] context).
+        // The marker is render-time only — it is NEVER written back into stored history.
+        let content = if self.is_empty() {
+            "(stayed silent — chose not to reply)"
+        } else {
+            self.message.as_deref().unwrap_or("")
+        };
         let mut msg = json!({
             "role": "assistant",
-            "content": self.message.as_deref().unwrap_or(""),
+            "content": content,
         });
         if !self.tool_calls.is_empty() {
             msg["tool_calls"] = Value::Array(

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -66,14 +66,12 @@ pub enum ConversationState {
         recent_conversation: RecentConversation,
     },
     AwaitingLLMDecision {
-        is_timeout: bool,
         history: Vec<HistoryEntry>,
         current_input: LLMInput,
         /// Tool calls made so far in this turn (resets to 0 on a new user turn).
         tool_rounds: usize,
     },
     SendingMessage {
-        is_timeout: bool,
         outcome: LLMResponse,
         recent_conversation: RecentConversation,
         /// Tool rounds so far this turn, carried through so that if `outcome` holds tool calls
@@ -82,7 +80,6 @@ pub enum ConversationState {
         tool_rounds: usize,
     },
     RunningTools {
-        is_timeout: bool,
         recent_conversation: RecentConversation,
         tool_rounds: usize,
         /// Calls still in flight this batch, keyed by id (id duplicated as the key).

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -103,9 +103,12 @@ impl Default for ConversationState {
 /// (`"Alice: hello"`) — the Discord adapter prepends it for every message, DM or group, so the
 /// model always knows who is speaking (in a group, every human still maps to OpenAI `role: "user"`,
 /// so the name in the text is the only speaker signal). `name`/`user_id` keep the same identity in
-/// structured form. `is_group` is the DM-vs-group context of the message (latest message wins; not
-/// persisted on the `Conversation`). `queued` is true when it was buffered into `pending` while the
-/// bot was busy, so it crossed an in-flight response — surfaced as a `[Followup]` tag at render time.
+/// structured form. `is_group` is the DM-vs-group context of the message, and `bot_identity` is the
+/// bot's own `Name (id:N)` handle *on the platform this message came from* — both ride the message
+/// because they're platform-specific facts the adapter knows (the domain layer must not assume one
+/// global bot identity; different conversations can be on different platforms). Latest message wins;
+/// neither is persisted on the `Conversation`. `queued` is true when it was buffered into `pending`
+/// while the bot was busy, so it crossed an in-flight response — surfaced as `[Followup]` at render.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationMessage {
     pub text: String,
@@ -116,6 +119,9 @@ pub struct ConversationMessage {
     pub name: String,
     /// Whether this message came from a group chat (vs a 1:1 DM). Drives system-prompt selection.
     pub is_group: bool,
+    /// The bot's own identity (`Name (id:N)`) on the platform this message arrived from, stamped by
+    /// that adapter. Fed to the system prompt so the model can recognize when it's addressed.
+    pub bot_identity: String,
 }
 
 impl ConversationMessage {
@@ -150,19 +156,15 @@ pub enum LLMInput {
     ToolResults(Vec<ToolResult>, Option<ConversationMessage>),
 }
 
-/// The `is_group` of the most recent message in `history` (latest message wins; defaults to DM /
-/// `false` when there's no message to read). Used to pick the DM-vs-group system prompt and to give
-/// synthetic messages (e.g. the timeout goodbye) the conversation's group-ness.
-pub fn latest_is_group(history: &[HistoryEntry]) -> bool {
-    history
-        .iter()
-        .rev()
-        .find_map(|e| match e {
-            HistoryEntry::Input(LLMInput::ConversationMessage(m)) => Some(m.is_group),
-            HistoryEntry::Input(LLMInput::ToolResults(_, Some(m))) => Some(m.is_group),
-            _ => None,
-        })
-        .unwrap_or(false)
+/// The most recent real `ConversationMessage` in `history` (latest wins). Source of the per-message
+/// context facts (`is_group`, `bot_identity`) for turns whose current input isn't itself a message —
+/// e.g. a tool-result continuation, or the synthetic timeout goodbye.
+pub fn last_conversation_message(history: &[HistoryEntry]) -> Option<&ConversationMessage> {
+    history.iter().rev().find_map(|e| match e {
+        HistoryEntry::Input(LLMInput::ConversationMessage(m)) => Some(m),
+        HistoryEntry::Input(LLMInput::ToolResults(_, Some(m))) => Some(m),
+        _ => None,
+    })
 }
 
 impl LLMInput {
@@ -333,6 +335,8 @@ pub enum ConversationAction {
         name: String,
         /// Whether it arrived from a group chat (vs a 1:1 DM).
         is_group: bool,
+        /// The bot's own `Name (id:N)` identity on the platform this message came from.
+        bot_identity: String,
     },
     Timeout,
     CommitResult(Result<(), String>),


### PR DESCRIPTION
Closes #118. Builds on #117 (channel-keyed `Conversation`). Removes the DM-only blockers so the bot participates in server channels, with author attribution everywhere and a group-specific system prompt.

## Remove blockers
- **Intents** ([discord.rs](chatbot/src/services/discord.rs)): `DIRECT_MESSAGES | GUILD_MESSAGES | MESSAGE_CONTENT`. (MESSAGE_CONTENT is privileged — must also be toggled in the Developer Portal; documented in the README.)
- **Drop `start_conversation` entirely**: the filter just cleans text (and ignores empty/attachment-only messages), `NewMessage` loses the flag, and the `accept_message` gate is gone. Every message is processed. No-op for DMs; in groups the model decides whether to reply.

## Author attribution (every message, DMs included)
- `IncomingUpdate` → **`ConversationMessage`**, enriched with `user_id`, `name`, `is_group`.
- The adapter resolves the Discord display name (guild nick → global name → username) and **prefixes it onto the text** (`"Alice: hello"`) — so the model always knows who's speaking (every human maps to OpenAI `role: "user"`; the name in the content is the only speaker signal). Name resolution stays in the adapter.

## `is_group` threading (latest message wins, not persisted)
- Carried on every message; **not** stored on `Conversation` (per the ticket — simple now, promotable later).
- Threaded `get_primary_response → respond → system_content(is_group)`. `latest_is_group(history)` recovers it for tool-result and timeout-goodbye turns where the current input isn't a fresh message.

## Group system prompt + empty-to-stay-silent
- `Agent::system_content(is_group)` selects a DM vs group variant (both static, so the cached system prefix stays stable per #111). The group variant says: you're one participant among many, names prefix each message, and **reply with an empty string to stay silent**.
- **Empty responses are recorded in history but never sent** — this is the existing path (history is pushed before the send branch; an empty message → `None` → settle to Idle, nothing sent), preserved and now leveraged as the group self-gating mechanism.

## Notes
- **Cost**: the bot now runs an LLM decision per group message (no hard mention-gate). Acceptable at small scale; a cheap pre-filter can be added later if needed (tracked in #118).
- Group memory is the shared channel history (#117); the `name` prefix records who said what.

## Testing
- `cargo build` + `cargo test --no-run` clean (pre-existing config warnings only).
- Behavior-preserving for DMs (name prefix added; otherwise same flow). Recommend deploying and exercising both a DM and a server channel before merge.