### PR TITLE
framework: explicit Constructor for state-machine init (drop implicit lazy Default)

### DIFF
--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::conversation::{
-        last_conversation_message, HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
+        HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
         ToolType, ConversationAction,
     },
     services::llama_cpp::LlamaCppService,
@@ -120,20 +120,12 @@ async fn get_response_from_llm(
     tool_rounds: usize,
     max_tool_rounds: usize,
     allow_tools: bool,
+    is_group: bool,
+    bot_identity: &str,
 ) -> anyhow::Result<LLMResponse> {
-    // Per-message context for the system prompt (latest message wins): the DM-vs-group flag and the
-    // bot's own identity on this conversation's platform. Use the current input's message when it
-    // has one; otherwise (a tool-result continuation) read the most recent message from history.
-    let latest = match current_input {
-        LLMInput::ConversationMessage(m) => Some(m),
-        LLMInput::ToolResults(_, Some(m)) => Some(m),
-        LLMInput::ToolResults(_, None) => maybe_recent_conversation
-            .as_ref()
-            .and_then(|rc| last_conversation_message(&rc.history)),
-    };
-    let is_group = latest.map(|m| m.is_group).unwrap_or(false);
-    let bot_identity = latest.map(|m| m.bot_identity.clone()).unwrap_or_default();
-
+    // DM-vs-group flag and the bot's own identity on this conversation's platform are conversation
+    // facts (set once at construction, persisted on the state) — they're passed straight in now,
+    // no longer reconstructed per message from history.
     let conversation = build_conversation(
         current_input,
         maybe_recent_conversation,
@@ -148,7 +140,7 @@ async fn get_response_from_llm(
     );
 
     let parsed = llama_cpp
-        .get_primary_response(conversation, allow_tools, is_group, &bot_identity)
+        .get_primary_response(conversation, allow_tools, is_group, bot_identity)
         .await?;
 
     let thoughts = parsed
@@ -191,6 +183,8 @@ pub async fn get_llm_decision(
     maybe_recent_conversation: Option<RecentConversation>,
     tool_rounds: usize,
     max_tool_rounds: usize,
+    is_group: bool,
+    bot_identity: String,
 ) -> ConversationAction {
     // Budget spent → final call with tools off, so the model can't emit another tool call; the
     // matching synthesis directive on the last tool result (see `budget_note`) nudges it to answer
@@ -208,6 +202,8 @@ pub async fn get_llm_decision(
         tool_rounds,
         max_tool_rounds,
         allow_tools,
+        is_group,
+        &bot_identity,
     )
     .await;
 

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -3,8 +3,8 @@ use regex::Regex;
 use serenity::{async_trait, model::channel::Message as DMessage, prelude::*};
 
 use crate::{
-    types::conversation::{ConversationAction, ConversationConstructor, Platform, ConversationId},
     state_machines::conversation_state_machine::CONVERSATION_STATE_MACHINE,
+    types::conversation::{ConversationAction, ConversationConstructor, ConversationId, Platform},
 };
 
 pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Client> {
@@ -100,11 +100,12 @@ impl EventHandler for Handler {
         let conversation_id =
             ConversationId(Platform::Discord, message.channel_id.get().to_string());
 
-        // Construct-then-act: ensure the conversation exists (idempotent — only the first message on
-        // this channel actually creates it, baking in the group-vs-DM context and our identity),
-        // then deliver the message. `is_group`/`bot_identity` are conversation facts, set once here.
+        // maybe_construct-then-act: ensure the conversation exists (idempotent — only the first
+        // message on this channel actually creates it, baking in the group-vs-DM context and our
+        // identity), then deliver the message. `is_group`/`bot_identity` are conversation facts,
+        // set once here.
         self.conversation_state_machine
-            .construct(
+            .maybe_construct(
                 conversation_id.clone(),
                 ConversationConstructor {
                     is_group,
@@ -112,11 +113,9 @@ impl EventHandler for Handler {
                 },
             )
             .await;
-        let action = ConversationAction::NewMessage {
-            msg,
-            user_id,
-            name,
-        };
+
+        let action = ConversationAction::NewMessage { msg, user_id, name };
+
         self.conversation_state_machine
             .act(conversation_id, action)
             .await;
@@ -145,7 +144,9 @@ fn filter(message: &DMessage, bot_user_id: u64, bot_name: &str) -> Option<String
         let name = if id == bot_user_id {
             bot_name.to_string()
         } else {
-            user.global_name.clone().unwrap_or_else(|| user.name.clone())
+            user.global_name
+                .clone()
+                .unwrap_or_else(|| user.name.clone())
         };
         let label = identity(&name, id);
         text = text

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use serenity::{async_trait, model::channel::Message as DMessage, prelude::*};
 
 use crate::{
-    types::conversation::{ConversationAction, Platform, ConversationId},
+    types::conversation::{ConversationAction, ConversationConstructor, Platform, ConversationId},
     state_machines::conversation_state_machine::CONVERSATION_STATE_MACHINE,
 };
 
@@ -47,7 +47,8 @@ pub async fn run_discord(mut client: Client) -> anyhow::Result<()> {
 }
 
 struct Handler {
-    conversation_state_machine: StateMachineHandle<ConversationId, ConversationAction>,
+    conversation_state_machine:
+        StateMachineHandle<ConversationId, ConversationConstructor, ConversationAction>,
     /// This bot's own Discord identity (adapter-local — bot identity is per-platform, never a global
     /// Env value). Used to ignore our own messages, humanize our own @mentions, and stamp the
     /// `bot_identity` carried on each message into the domain.
@@ -98,12 +99,23 @@ impl EventHandler for Handler {
         // this Discord adapter knows it's a channel id.
         let conversation_id =
             ConversationId(Platform::Discord, message.channel_id.get().to_string());
+
+        // Construct-then-act: ensure the conversation exists (idempotent — only the first message on
+        // this channel actually creates it, baking in the group-vs-DM context and our identity),
+        // then deliver the message. `is_group`/`bot_identity` are conversation facts, set once here.
+        self.conversation_state_machine
+            .construct(
+                conversation_id.clone(),
+                ConversationConstructor {
+                    is_group,
+                    bot_identity,
+                },
+            )
+            .await;
         let action = ConversationAction::NewMessage {
             msg,
             user_id,
             name,
-            is_group,
-            bot_identity,
         };
         self.conversation_state_machine
             .act(conversation_id, action)

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -8,14 +8,15 @@ use crate::types::conversation::{
 };
 use crate::{
     types::conversation::{
-        HistoryEntry, LLMInput, RecentConversation, Conversation, ConversationAction, ConversationId, ConversationMessage,
+        HistoryEntry, LLMInput, RecentConversation, Conversation, ConversationAction, ConversationConstructor, ConversationId, ConversationMessage,
         ConversationState,
     },
     Env, ENV,
 };
 use chrono::{Duration as ChronoDuration, Utc};
 use framework::{
-    new_state_machine, ExternalOperation, Schedule, Scheduled, Transition, TransitionResult,
+    new_state_machine, Construct, ExternalOperation, Schedule, Scheduled, Transition,
+    TransitionResult,
 };
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -33,6 +34,8 @@ fn handle_outcome(
     recent_conversation: RecentConversation,
     pending: Vec<ConversationMessage>,
     tool_rounds: usize,
+    is_group: bool,
+    bot_identity: String,
 ) -> ConversationTransitionResult {
     // Any `message` was already sent on the way into SendingMessage; here we act on the tool calls.
     if response.tool_calls.is_empty() {
@@ -44,6 +47,8 @@ fn handle_outcome(
                 },
                 last_transition: Utc::now(),
                 pending,
+                is_group,
+                bot_identity,
             },
             Vec::new(),
         ))
@@ -72,6 +77,8 @@ fn handle_outcome(
                 },
                 last_transition: Utc::now(),
                 pending,
+                is_group,
+                bot_identity,
             },
             external,
         ))
@@ -91,6 +98,9 @@ pub fn conversation_transition(
                     pending: Vec::new(),
                     state: ConversationState::default(),
                     last_transition: Utc::now(),
+                    // is_group/bot_identity persist across a reset — they're conversation identity,
+                    // set once at construction, not turn state.
+                    ..conversation
                 },
                 Vec::new(),
             )),
@@ -100,8 +110,6 @@ pub fn conversation_transition(
                     msg,
                     user_id,
                     name,
-                    is_group,
-                    bot_identity,
                 },
             ) => {
                 // Every message is accepted and buffered (the old `start_conversation` mention-gate
@@ -115,8 +123,6 @@ pub fn conversation_transition(
                     queued,
                     user_id: user_id.clone(),
                     name: name.clone(),
-                    is_group: *is_group,
-                    bot_identity: bot_identity.clone(),
                 });
 
                 Ok((
@@ -200,6 +206,8 @@ pub fn conversation_transition(
                             updated_conversation,
                             conversation.pending,
                             tool_rounds,
+                            conversation.is_group,
+                            conversation.bot_identity.clone(),
                         ),
                     }
                 }
@@ -228,6 +236,8 @@ pub fn conversation_transition(
                 recent_conversation,
                 conversation.pending,
                 tool_rounds,
+                conversation.is_group,
+                conversation.bot_identity.clone(),
             ),
             (
                 ConversationState::RunningTools {
@@ -271,6 +281,8 @@ pub fn conversation_transition(
                     // post_transition drains it again at Idle and the message is sent twice.
                     let mut pending = conversation.pending;
                     let current_input = LLMInput::ToolResults(results, take_pending(&mut pending));
+                    let is_group = conversation.is_group;
+                    let bot_identity = conversation.bot_identity.clone();
 
                     let history = recent_conversation.history();
                     let mut external = Vec::<ConversationExternalOperation>::new();
@@ -280,6 +292,8 @@ pub fn conversation_transition(
                         Some(recent_conversation),
                         tool_rounds,
                         MAX_TOOL_ROUNDS,
+                        is_group,
+                        bot_identity.clone(),
                     )));
 
                     Ok((
@@ -291,6 +305,8 @@ pub fn conversation_transition(
                             },
                             last_transition: Utc::now(),
                             pending,
+                            is_group,
+                            bot_identity,
                         },
                         external,
                     ))
@@ -375,10 +391,8 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
         // carries its own name prefix, so joining keeps per-speaker attribution even when a group
         // batch mixes senders. Identity fields take the last message's (best-effort for the merge).
         let queued = drained.iter().any(|m| m.queued);
-        let is_group = drained.last().map(|m| m.is_group).unwrap_or(false);
         let user_id = drained.last().map(|m| m.user_id.clone()).unwrap_or_default();
         let name = drained.last().map(|m| m.name.clone()).unwrap_or_default();
-        let bot_identity = drained.last().map(|m| m.bot_identity.clone()).unwrap_or_default();
         let text = drained
             .into_iter()
             .map(|m| m.text)
@@ -389,8 +403,6 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
             queued,
             user_id,
             name,
-            is_group,
-            bot_identity,
         }
     })
 }
@@ -415,6 +427,9 @@ fn post_transition(
         return Ok((conversation, external));
     };
 
+    let is_group = conversation.is_group;
+    let bot_identity = conversation.bot_identity.clone();
+
     let history = recent_conversation
         .as_ref()
         .map(|(rc, _)| rc.history())
@@ -428,6 +443,8 @@ fn post_transition(
         recent_conversation.map(|(rc, _)| rc),
         0,
         MAX_TOOL_ROUNDS,
+        is_group,
+        bot_identity.clone(),
     )));
 
     Ok((
@@ -439,6 +456,8 @@ fn post_transition(
             },
             last_transition: Utc::now(),
             pending: Vec::new(),
+            is_group,
+            bot_identity,
         },
         external,
     ))
@@ -466,11 +485,30 @@ pub fn schedule(conversation: &Conversation) -> Vec<Scheduled<ConversationAction
     schedules
 }
 
-pub static CONVERSATION_STATE_MACHINE: Lazy<framework::StateMachineHandle<ConversationId, ConversationAction>> =
-    Lazy::new(|| {
-        new_state_machine(
-            ENV.get().expect("ENV not initialized").clone(),
-            Transition(conversation_transition),
-            Schedule(schedule),
-        )
-    });
+/// The one and only path that produces a fresh [`Conversation`]: bake the adapter-supplied
+/// construction facts onto an otherwise-empty `Idle` conversation. The framework calls this exactly
+/// once per id (idempotent construct), so `is_group`/`bot_identity` are set once and then persisted
+/// for the conversation's whole life.
+fn construct_conversation(
+    _id: ConversationId,
+    constructor: ConversationConstructor,
+) -> Conversation {
+    Conversation {
+        pending: Vec::new(),
+        state: ConversationState::default(),
+        last_transition: Utc::now(),
+        is_group: constructor.is_group,
+        bot_identity: constructor.bot_identity,
+    }
+}
+
+pub static CONVERSATION_STATE_MACHINE: Lazy<
+    framework::StateMachineHandle<ConversationId, ConversationConstructor, ConversationAction>,
+> = Lazy::new(|| {
+    new_state_machine(
+        ENV.get().expect("ENV not initialized").clone(),
+        Construct(construct_conversation),
+        Transition(conversation_transition),
+        Schedule(schedule),
+    )
+});

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -100,12 +100,11 @@ impl Default for ConversationState {
 /// (`"Alice: hello"`) — the Discord adapter prepends it for every message, DM or group, so the
 /// model always knows who is speaking (in a group, every human still maps to OpenAI `role: "user"`,
 /// so the name in the text is the only speaker signal). `name`/`user_id` keep the same identity in
-/// structured form. `is_group` is the DM-vs-group context of the message, and `bot_identity` is the
-/// bot's own `Name (id:N)` handle *on the platform this message came from* — both ride the message
-/// because they're platform-specific facts the adapter knows (the domain layer must not assume one
-/// global bot identity; different conversations can be on different platforms). Latest message wins;
-/// neither is persisted on the `Conversation`. `queued` is true when it was buffered into `pending`
-/// while the bot was busy, so it crossed an in-flight response — surfaced as `[Followup]` at render.
+/// structured form. `queued` is true when it was buffered into `pending` while the bot was busy, so
+/// it crossed an in-flight response — surfaced as `[Followup]` at render.
+///
+/// The DM-vs-group context and the bot's own identity used to ride each message; they now live on
+/// the [`Conversation`], set once at construction (see [`ConversationConstructor`]).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationMessage {
     pub text: String,
@@ -114,10 +113,18 @@ pub struct ConversationMessage {
     pub user_id: String,
     /// Sender's display name; empty for synthetic/system messages. Already baked into `text`.
     pub name: String,
-    /// Whether this message came from a group chat (vs a 1:1 DM). Drives system-prompt selection.
+}
+
+/// The construction-time facts for a conversation, supplied by the adapter on first contact and
+/// baked into the [`Conversation`] state once (never per-message). Both are platform-specific facts
+/// the adapter knows — the domain layer must not assume one global bot identity, since different
+/// conversations can be on different platforms.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationConstructor {
+    /// Whether this conversation is a group chat (vs a 1:1 DM). Drives system-prompt selection.
     pub is_group: bool,
-    /// The bot's own identity (`Name (id:N)`) on the platform this message arrived from, stamped by
-    /// that adapter. Fed to the system prompt so the model can recognize when it's addressed.
+    /// The bot's own identity (`Name (id:N)`) on the platform this conversation lives on. Fed to the
+    /// system prompt so the model can recognize when it's addressed.
     pub bot_identity: String,
 }
 
@@ -136,11 +143,20 @@ impl ConversationMessage {
 /// The per-conversation entity the state machine drives: its current `state`, any `pending`
 /// updates buffered while busy, and when it last transitioned. Keyed by [`ConversationId`] (a
 /// channel/DM on some [`Platform`]) — one independent instance per conversation.
-#[derive(Clone, Default, Serialize, Deserialize)]
+///
+/// `is_group` and `bot_identity` are set once at construction (from [`ConversationConstructor`]) and
+/// persisted for the conversation's whole life — they're properties of the conversation/channel, not
+/// of individual messages. There is no `Default`: a `Conversation` is only ever produced by
+/// `construct_conversation`, never conjured implicitly.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Conversation {
     pub pending: Vec<ConversationMessage>,
     pub state: ConversationState,
     pub last_transition: DateTime<Utc>,
+    /// Whether this conversation is a group chat (vs a 1:1 DM). Drives system-prompt selection.
+    pub is_group: bool,
+    /// The bot's own `Name (id:N)` identity on this conversation's platform.
+    pub bot_identity: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,17 +167,6 @@ pub enum LLMInput {
     /// same turn *after* the results — OpenAI requires tool responses to immediately follow the
     /// assistant's `tool_calls`, so the user message comes last.
     ToolResults(Vec<ToolResult>, Option<ConversationMessage>),
-}
-
-/// The most recent real `ConversationMessage` in `history` (latest wins). Source of the per-message
-/// context facts (`is_group`, `bot_identity`) for turns whose current input isn't itself a message —
-/// e.g. a tool-result continuation, or the synthetic timeout goodbye.
-pub fn last_conversation_message(history: &[HistoryEntry]) -> Option<&ConversationMessage> {
-    history.iter().rev().find_map(|e| match e {
-        HistoryEntry::Input(LLMInput::ConversationMessage(m)) => Some(m),
-        HistoryEntry::Input(LLMInput::ToolResults(_, Some(m))) => Some(m),
-        _ => None,
-    })
 }
 
 impl LLMInput {
@@ -330,10 +335,6 @@ pub enum ConversationAction {
         /// Sender's platform user id and display name (for the structured `ConversationMessage`).
         user_id: String,
         name: String,
-        /// Whether it arrived from a group chat (vs a 1:1 DM).
-        is_group: bool,
-        /// The bot's own `Name (id:N)` identity on the platform this message came from.
-        bot_identity: String,
     },
     Timeout,
     CommitResult(Result<(), String>),

--- a/framework/src/bee_handle.rs
+++ b/framework/src/bee_handle.rs
@@ -30,13 +30,15 @@ where
 
 pub fn new_entity<
     Id: PersistedStateMachineItem + Ord + 'static,
-    State: PersistedStateMachineItem + 'static + Default,
+    State: PersistedStateMachineItem + 'static,
+    Constructor: PersistedStateMachineItem + 'static,
     Action: PersistedStateMachineItem + std::fmt::Debug + 'static,
     Env: StateMachineItem + 'static,
 >(
     env: Arc<Env>,
     id: Id,
-    handle: StateMachineHandle<Id, Action>,
+    initial_state: State,
+    handle: StateMachineHandle<Id, Constructor, Action>,
     transition: Transition<Id, State, Action, Env>,
     schedule: Schedule<State, Action>,
 ) -> Handle<Action> {
@@ -44,6 +46,7 @@ pub fn new_entity<
     tokio::spawn(run_entity(
         env,
         id,
+        initial_state,
         receiver,
         handle,
         transition,

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -102,62 +102,52 @@ async fn run_entity<
         );
         match activity {
             Activity::StateMachineAction(action) => {
-                match transition.0(env.clone(), id.clone(), state.clone(), &action).await {
-                    Ok((updated_state, external)) => {
-                        match &maybe_scheduled {
-                            Some(scheduled) => {
-                                scheduled.abort();
-                            }
-                            None => {}
-                        }
-                        let mut scheduled = schedule.0(&updated_state);
-
-                        scheduled.sort_by_key(|scheduled| scheduled.at);
-
-                        let earliest = scheduled.into_iter().next();
-
-                        match earliest {
-                            Some(scheduled) => {
-                                let self_sender = self_sender.clone();
-                                let timer_handle = tokio::spawn(async move {
-                                    let sleep_for = scheduled.clone().at - now;
-                                    match sleep_for.to_std() {
-                                        Ok(sleep_duration) => {
-                                            tokio::time::sleep(sleep_duration).await;
-                                            while Utc::now() < scheduled.at {
-                                                tokio::time::sleep(Duration::from_millis(10)).await;
-                                            }
-                                            let _ = self_sender
-                                                .clone()
-                                                .send(Activity::ScheduledWakeup)
-                                                .await;
-                                        }
-                                        Err(_negative_time_error) => {
-                                            // Negative duration means the scheduled time has already passed
-                                            let _ = self_sender
-                                                .clone()
-                                                .send(Activity::ScheduledWakeup)
-                                                .await;
-                                        }
-                                    }
-                                });
-
-                                maybe_scheduled = Some(timer_handle)
-                            }
-                            None => {}
-                        }
-
-                        external.into_iter().for_each(|f| {
-                            let handle: StateMachineHandle<Id, Constructor, Action> = handle.clone();
-                            let id = id.clone();
-                            tokio::spawn(async move {
-                                let action = f.await;
-                                handle.act(id, action).await;
-                            });
-                        });
-                        state = updated_state;
+                if let Ok((updated_state, external)) =
+                    transition.0(env.clone(), id.clone(), state.clone(), &action).await
+                {
+                    if let Some(scheduled) = &maybe_scheduled {
+                        scheduled.abort();
                     }
-                    Err(_) => (),
+
+                    let mut scheduled = schedule.0(&updated_state);
+
+                    scheduled.sort_by_key(|scheduled| scheduled.at);
+
+                    let earliest = scheduled.into_iter().next();
+
+                    if let Some(scheduled) = earliest {
+                        let self_sender = self_sender.clone();
+                        let timer_handle = tokio::spawn(async move {
+                            let sleep_for = scheduled.clone().at - now;
+                            match sleep_for.to_std() {
+                                Ok(sleep_duration) => {
+                                    tokio::time::sleep(sleep_duration).await;
+                                    while Utc::now() < scheduled.at {
+                                        tokio::time::sleep(Duration::from_millis(10)).await;
+                                    }
+                                    let _ =
+                                        self_sender.clone().send(Activity::ScheduledWakeup).await;
+                                }
+                                Err(_negative_time_error) => {
+                                    // Negative duration means the scheduled time has already passed
+                                    let _ =
+                                        self_sender.clone().send(Activity::ScheduledWakeup).await;
+                                }
+                            }
+                        });
+
+                        maybe_scheduled = Some(timer_handle)
+                    }
+
+                    external.into_iter().for_each(|f| {
+                        let handle: StateMachineHandle<Id, Constructor, Action> = handle.clone();
+                        let id = id.clone();
+                        tokio::spawn(async move {
+                            let action = f.await;
+                            handle.act(id, action).await;
+                        });
+                    });
+                    state = updated_state;
                 }
             }
             Activity::ScheduledWakeup => {
@@ -166,23 +156,20 @@ async fn run_entity<
 
                 let earliest = scheduled.into_iter().next();
 
-                match earliest {
-                    Some(scheduled) => {
-                        let sleep_for = scheduled.at - now;
+                if let Some(scheduled) = earliest {
+                    let sleep_for = scheduled.at - now;
 
-                        match sleep_for.to_std() {
-                            Ok(_time_left) => {
-                                println!("Not Ready"); //TODO handle unexpected wakeup
-                            }
-                            Err(_negative_time_error) => {
-                                // Negative duration means the scheduled time has already passed
-                                let _ = self_sender
-                                    .send(Activity::StateMachineAction(scheduled.action))
-                                    .await;
-                            }
+                    match sleep_for.to_std() {
+                        Ok(_time_left) => {
+                            println!("Not Ready"); //TODO handle unexpected wakeup
+                        }
+                        Err(_negative_time_error) => {
+                            // Negative duration means the scheduled time has already passed
+                            let _ = self_sender
+                                .send(Activity::StateMachineAction(scheduled.action))
+                                .await;
                         }
                     }
-                    None => {}
                 }
             }
             Activity::DeleteSelf => todo!(),

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -34,6 +34,13 @@ pub struct Transition<Id, State, Action, Env>(
     ) -> Pin<Box<dyn Future<Output = TransitionResult<State, Action>> + Send + '_>>,
 );
 
+/// Builds an entity's initial `State` from its `Id` and a domain-supplied `Constructor` payload.
+/// This is the *only* thing that ever produces a starting state — there is no implicit `Default`
+/// fallback — so the domain decides up front what a fresh entity looks like (e.g. carrying
+/// construction-time facts that are then persisted on the state for the entity's whole life).
+#[derive(Clone)]
+pub struct Construct<Id, State, Constructor>(pub fn(Id, Constructor) -> State);
+
 #[derive(Clone)]
 pub struct Scheduled<Action> {
     pub at: DateTime<Utc>,
@@ -49,21 +56,32 @@ pub enum Activity<Action: PersistedStateMachineItem + 'static> {
     DeleteSelf,
 }
 
+/// What the router receives for a given `Id`. `Construct` is the only path that creates an entity
+/// (idempotent — a second `Construct` for an already-live id is a no-op); `Act` delivers an action
+/// to an entity that must already exist. An `Act` for an unknown id is warned about and dropped —
+/// there is no implicit/lazy creation, so the domain is responsible for constructing before acting.
+pub enum Input<Constructor, Action> {
+    Construct(Constructor),
+    Act(Action),
+}
+
 async fn run_entity<
     Id: PersistedStateMachineItem + Ord + 'static,
-    State: PersistedStateMachineItem + Default + 'static,
+    State: PersistedStateMachineItem + 'static,
+    Constructor: PersistedStateMachineItem + 'static,
     Action: PersistedStateMachineItem + std::fmt::Debug + 'static,
     Env: StateMachineItem + 'static,
 >(
     env: Arc<Env>,
     id: Id,
+    initial_state: State,
     mut receiver: Receiver<Activity<Action>>,
-    handle: StateMachineHandle<Id, Action>,
+    handle: StateMachineHandle<Id, Constructor, Action>,
     transition: Transition<Id, State, Action, Env>,
     schedule: Schedule<State, Action>,
     self_sender: Sender<Activity<Action>>,
 ) {
-    let mut state = State::default();
+    let mut state = initial_state;
     let mut maybe_scheduled: Option<JoinHandle<()>> = None;
 
     while let Some(activity) = receiver.recv().await {
@@ -130,7 +148,7 @@ async fn run_entity<
                         }
 
                         external.into_iter().for_each(|f| {
-                            let handle: StateMachineHandle<Id, Action> = handle.clone();
+                            let handle: StateMachineHandle<Id, Constructor, Action> = handle.clone();
                             let id = id.clone();
                             tokio::spawn(async move {
                                 let action = f.await;
@@ -174,34 +192,56 @@ async fn run_entity<
 
 async fn start_state_machine<
     Id: PersistedStateMachineItem + Ord + 'static,
-    State: PersistedStateMachineItem + Default + 'static,
+    State: PersistedStateMachineItem + 'static,
+    Constructor: PersistedStateMachineItem + 'static,
     Action: PersistedStateMachineItem + std::fmt::Debug + 'static,
     Env: StateMachineItem + 'static,
 >(
     env: Arc<Env>,
-    state_machine_handle: StateMachineHandle<Id, Action>,
-    mut receiver: Receiver<(Id, Action)>,
+    state_machine_handle: StateMachineHandle<Id, Constructor, Action>,
+    mut receiver: Receiver<(Id, Input<Constructor, Action>)>,
+    construct: Construct<Id, State, Constructor>,
     transition: Transition<Id, State, Action, Env>,
     schedule: Schedule<State, Action>,
 ) -> ! {
     let mut handle_by_id = std::collections::BTreeMap::<Id, Handle<Action>>::new();
 
-    while let Some((id, action)) = receiver.recv().await {
-        match handle_by_id.contains_key(&id) {
-            true => (),
-            false => {
+    while let Some((id, input)) = receiver.recv().await {
+        match input {
+            // The single, idempotent creation path. The router owns the existence check, so the
+            // domain can construct unconditionally (e.g. on every inbound message) without tracking
+            // a seen-set; a Construct for a live id is dropped. mpsc FIFO makes this race-free, and
+            // an Act enqueued right after its Construct can never overtake it.
+            Input::Construct(constructor) => {
+                if handle_by_id.contains_key(&id) {
+                    continue;
+                }
+                let initial_state = construct.0(id.clone(), constructor);
                 let handle = new_entity(
                     env.clone(),
                     id.clone(),
+                    initial_state,
                     state_machine_handle.clone(),
                     transition.clone(),
                     schedule.clone(),
                 );
-                handle_by_id.insert(id.clone(), handle.clone());
+                handle_by_id.insert(id, handle);
             }
+            // No implicit creation: an action for an id we've never constructed is a bug in the
+            // caller (it should have constructed first), so warn and drop rather than silently
+            // spinning up a default entity.
+            Input::Act(action) => match handle_by_id.get(&id) {
+                Some(handle) => {
+                    let handle = handle.clone();
+                    tokio::spawn(async move { handle.act(action).await });
+                }
+                None => {
+                    eprintln!(
+                        "[warn] action {action:?} for unconstructed entity; dropping (Construct must precede Act)"
+                    );
+                }
+            },
         }
-        let handle = handle_by_id[&id].clone();
-        tokio::spawn(async move { handle.act(action).await });
     }
     panic!()
 }

--- a/framework/src/state_machine_handle.rs
+++ b/framework/src/state_machine_handle.rs
@@ -23,12 +23,12 @@ where
     Constructor: PersistedStateMachineItem + 'static,
     Action: PersistedStateMachineItem + 'static,
 {
-    /// Ensure the entity for `id` exists, building its initial state from `constructor`. Idempotent:
-    /// safe to call before every action (the router drops it if the entity is already live). Always
-    /// pair an `act` with a preceding `construct` for the same id.
-    pub async fn construct(&self, id: Id, constructor: Constructor) {
-        let _ = self
-            .sender
+    /// Ensure the entity for `id` exists, building its initial state from `constructor` *only if it
+    /// isn't already live* — hence "maybe". Idempotent: safe to call before every action (the router
+    /// drops it when the entity already exists). Always pair an `act` with a preceding
+    /// `maybe_construct` for the same id.
+    pub async fn maybe_construct(&self, id: Id, constructor: Constructor) {
+        self.sender
             .send((id, Input::Construct(constructor)))
             .await
             .expect("Send failed");
@@ -37,8 +37,7 @@ where
     /// Deliver an action to an already-constructed entity. If `id` was never constructed the router
     /// warns and drops it — there is no implicit creation.
     pub async fn act(&self, id: Id, action: Action) {
-        let _ = self
-            .sender
+        self.sender
             .send((id, Input::Act(action)))
             .await
             .expect("Send failed");

--- a/framework/src/state_machine_handle.rs
+++ b/framework/src/state_machine_handle.rs
@@ -3,27 +3,43 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::{
-    start_state_machine, PersistedStateMachineItem, Schedule, StateMachineItem, Transition,
+    start_state_machine, Construct, Input, PersistedStateMachineItem, Schedule, StateMachineItem,
+    Transition,
 };
 
 #[derive(Clone)]
-pub struct StateMachineHandle<Id, Action>
+pub struct StateMachineHandle<Id, Constructor, Action>
 where
     Id: PersistedStateMachineItem,
+    Constructor: PersistedStateMachineItem,
     Action: PersistedStateMachineItem,
 {
-    pub sender: mpsc::Sender<(Id, Action)>,
+    pub sender: mpsc::Sender<(Id, Input<Constructor, Action>)>,
 }
 
-impl<Id, Action> StateMachineHandle<Id, Action>
+impl<Id, Constructor, Action> StateMachineHandle<Id, Constructor, Action>
 where
     Id: PersistedStateMachineItem + Ord + 'static,
+    Constructor: PersistedStateMachineItem + 'static,
     Action: PersistedStateMachineItem + 'static,
 {
+    /// Ensure the entity for `id` exists, building its initial state from `constructor`. Idempotent:
+    /// safe to call before every action (the router drops it if the entity is already live). Always
+    /// pair an `act` with a preceding `construct` for the same id.
+    pub async fn construct(&self, id: Id, constructor: Constructor) {
+        let _ = self
+            .sender
+            .send((id, Input::Construct(constructor)))
+            .await
+            .expect("Send failed");
+    }
+
+    /// Deliver an action to an already-constructed entity. If `id` was never constructed the router
+    /// warns and drops it — there is no implicit creation.
     pub async fn act(&self, id: Id, action: Action) {
         let _ = self
             .sender
-            .send((id, action))
+            .send((id, Input::Act(action)))
             .await
             .expect("Send failed");
     }
@@ -31,20 +47,23 @@ where
 
 pub fn new_state_machine<
     Id: PersistedStateMachineItem + Ord + 'static,
-    State: PersistedStateMachineItem + Default + 'static,
+    State: PersistedStateMachineItem + 'static,
+    Constructor: PersistedStateMachineItem + 'static,
     Action: PersistedStateMachineItem + std::fmt::Debug + 'static,
     Env: StateMachineItem + 'static,
 >(
     env: Arc<Env>,
+    construct: Construct<Id, State, Constructor>,
     transition: Transition<Id, State, Action, Env>,
     schedule: Schedule<State, Action>,
-) -> StateMachineHandle<Id, Action> {
+) -> StateMachineHandle<Id, Constructor, Action> {
     let (sender, receiver) = mpsc::channel(8);
     let handle = StateMachineHandle { sender };
     tokio::spawn(start_state_machine(
         env,
         handle.clone(),
         receiver,
+        construct,
         transition,
         schedule,
     ));


### PR DESCRIPTION
Closes #120.

## Why
Entities were created implicitly — the router spun up `State::default()` on the first action for any unknown id ([lib.rs router](framework/src/lib.rs)). That made initial state un-parameterizable and forced a `Default` bound on every state machine. We were paying for it in the chatbot: `is_group`/`bot_identity` rode *every* `ConversationMessage` (latest-wins) with a `last_conversation_message` history-scan to recover them on tool-result turns.

## Framework (the substance)
- **`Construct<Id, State, Constructor>(fn(Id, Constructor) -> State)`** — a sibling to `Transition`/`Schedule`, the only thing that produces an initial state.
- **`enum Input<Constructor, Action> { Construct, Act }`** carried on the router channel; `StateMachineHandle` gains `construct(id, ctor)` next to `act(id, action)`.
- **Router rewrite:** `Construct` is the sole, **idempotent** creation path (second construct for a live id → no-op); **`Act` on an absent id → warn + drop**, no implicit creation. mpsc FIFO keeps construct-then-act race-free.
- **Dropped the `State: Default` bound** across `run_entity` / `new_entity` / `start_state_machine` / `new_state_machine`; the constructed state threads through instead.

## Chatbot (made compatible)
- `ConversationConstructor { is_group, bot_identity }` + `construct_conversation`.
- `is_group`/`bot_identity` **move off** `ConversationMessage`/`NewMessage` and **onto** the `Conversation` state — set once at construction, persisted for the conversation's life (channel/platform facts, not per-message). Deletes the per-message ride and `last_conversation_message`; the transition reads them off state and threads to `get_llm_decision`.
- Discord adapter sends `construct` then `act` per message.

## Out of scope
`DeleteSelf`, persistence rehydration (#106).

## Testing
`cargo build` clean (only pre-existing config dead-code warnings). Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)