### PR TITLE
re_framework: simplification — sync RAII mailbox, append-only effects, spawn-less timer

### DIFF
--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -152,12 +152,13 @@ async fn get_response_from_llm(
         .unwrap_or("")
         .to_string();
 
-    let message = parsed
+    let content = parsed
         .get("content")
         .and_then(|v| v.as_str())
         .map(str::trim)
-        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("<empty>"))
-        .map(String::from);
+        .unwrap_or("");
+    let explicit_empty = content.eq_ignore_ascii_case("<empty>");
+    let message = (!content.is_empty() && !explicit_empty).then(|| content.to_string());
 
     let calls = all_tool_calls(&parsed);
     let mut tool_calls = Vec::with_capacity(calls.len());
@@ -166,6 +167,12 @@ async fn get_response_from_llm(
         tool_calls.push(ToolCall { id, tool_type });
     }
     tool_calls.sort_by(|a, b| a.id.cmp(&b.id));
+
+    if message.is_none() && tool_calls.is_empty() && !explicit_empty {
+        eprintln!(
+            "[llm] implicit empty response — model produced no message and no tool calls; nothing will be sent"
+        );
+    }
 
     Ok(LLMResponse {
         thoughts,
@@ -203,6 +210,9 @@ pub async fn get_llm_decision(
 
     match llama_cpp_result {
         Ok(llama_cpp_response) => ConversationAction::LLMDecisionResult(Ok(llama_cpp_response)),
-        Err(err) => ConversationAction::LLMDecisionResult(Err(err.to_string())),
+        Err(err) => {
+            eprintln!("[llm] decision failed: {err}");
+            ConversationAction::LLMDecisionResult(Err(err.to_string()))
+        }
     }
 }

--- a/chatbot/src/externals/long_term_memory_external.rs
+++ b/chatbot/src/externals/long_term_memory_external.rs
@@ -122,5 +122,9 @@ pub async fn commit_to_memory(
     conversation_id: String,
     history: Vec<HistoryEntry>,
 ) -> ConversationAction {
-    ConversationAction::CommitResult(commit(Arc::clone(&env.lance_service), conversation_id, history).await)
+    let result = commit(Arc::clone(&env.lance_service), conversation_id, history).await;
+    if let Err(err) = &result {
+        eprintln!("[memory] commit failed: {err}");
+    }
+    ConversationAction::CommitResult(result)
 }

--- a/chatbot/src/externals/message_external.rs
+++ b/chatbot/src/externals/message_external.rs
@@ -38,7 +38,10 @@ pub async fn send_message(env: Arc<Env>, conversation_id: ConversationId, messag
         Platform::Discord => {
             let channel = match conversation_id.1.parse::<u64>() {
                 Ok(id) => serenity::all::ChannelId::new(id),
-                Err(err) => return ConversationAction::MessageSent(Err(err.to_string())),
+                Err(err) => {
+                    eprintln!("[send] invalid channel id {:?}: {err}", conversation_id.1);
+                    return ConversationAction::MessageSent(Err(err.to_string()));
+                }
             };
 
             for chunk in split_for_discord(&message) {
@@ -46,7 +49,7 @@ pub async fn send_message(env: Arc<Env>, conversation_id: ConversationId, messag
                     .send_message(&env.discord_http, CreateMessage::new().content(&chunk))
                     .await
                 {
-                    eprintln!("Failed to send Discord message: {err}");
+                    eprintln!("[send] Discord send failed: {err}");
                     return ConversationAction::MessageSent(Err(err.to_string()));
                 }
             }

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -442,7 +442,11 @@ pub async fn execute_tool(
     conversation_id: String,
     history: Vec<HistoryEntry>,
 ) -> ConversationAction {
+    let tool_name = tool_call.tool_type.wire_name().to_string();
     let result = run_tool(env, tool_call.tool_type, conversation_id, history).await;
+    if let Err(err) = &result {
+        eprintln!("[tool {tool_name} id {}] failed: {err}", tool_call.id);
+    }
     ConversationAction::ToolResult {
         id: tool_call.id,
         result,

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -68,17 +68,15 @@ impl EventHandler for Handler {
 
         let handle = ConversationMachine::handle();
 
-        handle
-            .maybe_construct(ConversationConstructor {
-                id: conversation_id.clone(),
-                is_group,
-                bot_identity,
-            })
-            .await;
+        handle.maybe_construct(ConversationConstructor {
+            id: conversation_id.clone(),
+            is_group,
+            bot_identity,
+        });
 
         let action = ConversationAction::NewMessage { msg, user_id, name };
 
-        handle.act(conversation_id, action).await;
+        handle.act(conversation_id, action);
     }
 }
 

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -3,13 +3,11 @@ use crate::externals::{
     llama_cpp_external::get_llm_decision, message_external::send_message,
     tool_call_external::execute_tool,
 };
-use crate::types::conversation::{
-    LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS,
-};
+use crate::types::conversation::{LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
 use crate::{
     types::conversation::{
-        HistoryEntry, LLMInput, RecentConversation, Conversation, ConversationAction, ConversationConstructor, ConversationId, ConversationMessage,
-        ConversationState,
+        Conversation, ConversationAction, ConversationConstructor, ConversationId,
+        ConversationMessage, ConversationState, HistoryEntry, LLMInput, RecentConversation,
     },
     Env,
 };
@@ -18,20 +16,10 @@ use re_framework::{Effects, Scheduled, StateMachine, StateMachineHandle};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-type ConversationTransitionResult = anyhow::Result<(Conversation, Effects)>;
+type ConversationTransitionResult = anyhow::Result<Conversation>;
+type ConversationEffects = Effects<ConversationMachine>;
 
 static CONVERSATION: OnceLock<StateMachineHandle<ConversationMachine>> = OnceLock::new();
-
-fn loop_back(
-    effects: Effects,
-    conversation_id: ConversationId,
-    fut: impl std::future::Future<Output = ConversationAction> + Send + 'static,
-) -> Effects {
-    effects.fire(async move {
-        let action = fut.await;
-        ConversationMachine::handle().act(conversation_id, action).await;
-    })
-}
 
 pub struct ConversationMachine;
 
@@ -42,7 +30,10 @@ impl StateMachine for ConversationMachine {
     type Construction = ConversationConstructor;
     type Env = crate::Env;
 
-    fn construct(constructor: ConversationConstructor) -> (Conversation, Effects) {
+    fn construct(
+        constructor: ConversationConstructor,
+        _effects: &mut ConversationEffects,
+    ) -> Conversation {
         construct_conversation(constructor)
     }
 
@@ -51,8 +42,9 @@ impl StateMachine for ConversationMachine {
         id: &ConversationId,
         env: &Arc<Env>,
         action: &ConversationAction,
+        effects: &mut ConversationEffects,
     ) -> ConversationTransitionResult {
-        conversation_transition(env, id, state.clone(), action)
+        conversation_transition(env, id, state.clone(), action, effects)
     }
 
     fn schedule(state: &Conversation) -> Option<Scheduled<ConversationAction>> {
@@ -60,7 +52,9 @@ impl StateMachine for ConversationMachine {
     }
 
     fn handle() -> &'static StateMachineHandle<ConversationMachine> {
-        CONVERSATION.get().expect("ConversationMachine not initialized")
+        CONVERSATION
+            .get()
+            .expect("ConversationMachine not initialized")
     }
 }
 
@@ -81,52 +75,42 @@ fn handle_outcome(
     tool_rounds: usize,
     is_group: bool,
     bot_identity: String,
+    effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
     if response.tool_calls.is_empty() {
-        Ok((
-            Conversation {
-                state: ConversationState::Idle {
-                    recent_conversation: Some((recent_conversation, Utc::now())),
-                },
-                last_transition: Utc::now(),
-                pending,
-                is_group,
-                bot_identity,
+        Ok(Conversation {
+            state: ConversationState::Idle {
+                recent_conversation: Some((recent_conversation, Utc::now())),
             },
-            Effects::none(),
-        ))
+            last_transition: Utc::now(),
+            pending,
+            is_group,
+            bot_identity,
+        })
     } else {
-        let mut effects = Effects::none();
         let mut pending_tools = HashMap::new();
         for tool_call in response.tool_calls {
-            effects = loop_back(
-                effects,
-                conversation_id.clone(),
-                execute_tool(
-                    env.clone(),
-                    tool_call.clone(),
-                    conversation_id.to_string(),
-                    recent_conversation.history.clone(),
-                ),
-            );
+            effects.enqueue_external(execute_tool(
+                env.clone(),
+                tool_call.clone(),
+                conversation_id.to_string(),
+                recent_conversation.history.clone(),
+            ));
             pending_tools.insert(tool_call.id.clone(), tool_call);
         }
 
-        Ok((
-            Conversation {
-                state: ConversationState::RunningTools {
-                    recent_conversation,
-                    tool_rounds: tool_rounds + 1,
-                    pending_tools,
-                    completed_tools: Vec::new(),
-                },
-                last_transition: Utc::now(),
-                pending,
-                is_group,
-                bot_identity,
+        Ok(Conversation {
+            state: ConversationState::RunningTools {
+                recent_conversation,
+                tool_rounds: tool_rounds + 1,
+                pending_tools,
+                completed_tools: Vec::new(),
             },
-            effects,
-        ))
+            last_transition: Utc::now(),
+            pending,
+            is_group,
+            bot_identity,
+        })
     }
 }
 
@@ -135,25 +119,16 @@ fn conversation_transition(
     conversation_id: &ConversationId,
     conversation: Conversation,
     action: &ConversationAction,
+    effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
     let state = match (conversation.state, action) {
-        (_, ConversationAction::ForceReset) => Ok((
-            Conversation {
-                pending: Vec::new(),
-                state: ConversationState::default(),
-                last_transition: Utc::now(),
-                ..conversation
-            },
-            Effects::none(),
-        )),
-        (
-            user_state,
-            ConversationAction::NewMessage {
-                msg,
-                user_id,
-                name,
-            },
-        ) => {
+        (_, ConversationAction::ForceReset) => Ok(Conversation {
+            pending: Vec::new(),
+            state: ConversationState::default(),
+            last_transition: Utc::now(),
+            ..conversation
+        }),
+        (user_state, ConversationAction::NewMessage { msg, user_id, name }) => {
             let mut pending = conversation.pending;
             let queued = !matches!(&user_state, ConversationState::Idle { .. });
             pending.push(ConversationMessage {
@@ -163,14 +138,11 @@ fn conversation_transition(
                 name: name.clone(),
             });
 
-            Ok((
-                Conversation {
-                    pending,
-                    state: user_state,
-                    ..conversation
-                },
-                Effects::none(),
-            ))
+            Ok(Conversation {
+                pending,
+                state: user_state,
+                ..conversation
+            })
         }
         (
             ConversationState::AwaitingLLMDecision {
@@ -206,24 +178,21 @@ fn conversation_transition(
 
                 match message_to_send {
                     Some(message) => {
-                        let effects = loop_back(
-                            Effects::none(),
+                        effects.enqueue_external(send_message(
+                            env.clone(),
                             conversation_id.clone(),
-                            send_message(env.clone(), conversation_id.clone(), message),
-                        );
+                            message,
+                        ));
 
-                        Ok((
-                            Conversation {
-                                state: ConversationState::SendingMessage {
-                                    outcome: response.clone(),
-                                    recent_conversation: updated_conversation,
-                                    tool_rounds,
-                                },
-                                last_transition: Utc::now(),
-                                ..conversation
+                        Ok(Conversation {
+                            state: ConversationState::SendingMessage {
+                                outcome: response.clone(),
+                                recent_conversation: updated_conversation,
+                                tool_rounds,
                             },
-                            effects,
-                        ))
+                            last_transition: Utc::now(),
+                            ..conversation
+                        })
                     }
                     None => handle_outcome(
                         env,
@@ -234,19 +203,17 @@ fn conversation_transition(
                         tool_rounds,
                         conversation.is_group,
                         conversation.bot_identity.clone(),
+                        effects,
                     ),
                 }
             }
-            Err(_) => Ok((
-                Conversation {
-                    state: ConversationState::Idle {
-                        recent_conversation: None,
-                    },
-                    last_transition: Utc::now(),
-                    ..conversation
+            Err(_) => Ok(Conversation {
+                state: ConversationState::Idle {
+                    recent_conversation: None,
                 },
-                Effects::none(),
-            )),
+                last_transition: Utc::now(),
+                ..conversation
+            }),
         },
         (
             ConversationState::SendingMessage {
@@ -264,6 +231,7 @@ fn conversation_transition(
             tool_rounds,
             conversation.is_group,
             conversation.bot_identity.clone(),
+            effects,
         ),
         (
             ConversationState::RunningTools {
@@ -305,48 +273,38 @@ fn conversation_transition(
                 let bot_identity = conversation.bot_identity.clone();
 
                 let history = recent_conversation.history();
-                let effects = loop_back(
-                    Effects::none(),
-                    conversation_id.clone(),
-                    get_llm_decision(
-                        env.clone(),
-                        current_input.clone(),
-                        Some(recent_conversation),
-                        tool_rounds,
-                        MAX_TOOL_ROUNDS,
-                        is_group,
-                        bot_identity.clone(),
-                    ),
-                );
+                effects.enqueue_external(get_llm_decision(
+                    env.clone(),
+                    current_input.clone(),
+                    Some(recent_conversation),
+                    tool_rounds,
+                    MAX_TOOL_ROUNDS,
+                    is_group,
+                    bot_identity.clone(),
+                ));
 
-                Ok((
-                    Conversation {
-                        state: ConversationState::AwaitingLLMDecision {
-                            history,
-                            current_input,
-                            tool_rounds,
-                        },
-                        last_transition: Utc::now(),
-                        pending,
-                        is_group,
-                        bot_identity,
+                Ok(Conversation {
+                    state: ConversationState::AwaitingLLMDecision {
+                        history,
+                        current_input,
+                        tool_rounds,
                     },
-                    effects,
-                ))
+                    last_transition: Utc::now(),
+                    pending,
+                    is_group,
+                    bot_identity,
+                })
             } else {
-                Ok((
-                    Conversation {
-                        state: ConversationState::RunningTools {
-                            recent_conversation,
-                            tool_rounds,
-                            pending_tools,
-                            completed_tools,
-                        },
-                        last_transition: Utc::now(),
-                        ..conversation
+                Ok(Conversation {
+                    state: ConversationState::RunningTools {
+                        recent_conversation,
+                        tool_rounds,
+                        pending_tools,
+                        completed_tools,
                     },
-                    Effects::none(),
-                ))
+                    last_transition: Utc::now(),
+                    ..conversation
+                })
             }
         }
         (
@@ -357,55 +315,45 @@ fn conversation_transition(
         ) => {
             println!("Timed Out");
 
-            let effects = loop_back(
-                Effects::none(),
-                conversation_id.clone(),
-                commit_to_memory(
-                    env.clone(),
-                    conversation_id.to_string(),
-                    recent_conversation.history.clone(),
-                ),
-            );
+            effects.enqueue_external(commit_to_memory(
+                env.clone(),
+                conversation_id.to_string(),
+                recent_conversation.history.clone(),
+            ));
 
-            Ok((
-                Conversation {
-                    state: ConversationState::CommitingToMemory {
-                        recent_conversation,
-                    },
-                    last_transition: Utc::now(),
-                    ..conversation
+            Ok(Conversation {
+                state: ConversationState::CommitingToMemory {
+                    recent_conversation,
                 },
-                effects,
-            ))
+                last_transition: Utc::now(),
+                ..conversation
+            })
         }
-        (
-            ConversationState::CommitingToMemory { .. },
-            ConversationAction::CommitResult(_),
-        ) => {
+        (ConversationState::CommitingToMemory { .. }, ConversationAction::CommitResult(_)) => {
             println!("Commited to Memory");
 
-            Ok((
-                Conversation {
-                    state: ConversationState::Idle {
-                        recent_conversation: None,
-                    },
-                    last_transition: Utc::now(),
-                    ..conversation
+            Ok(Conversation {
+                state: ConversationState::Idle {
+                    recent_conversation: None,
                 },
-                Effects::none(),
-            ))
+                last_transition: Utc::now(),
+                ..conversation
+            })
         }
         _ => Err(anyhow::anyhow!("Invalid state or action")),
     };
 
-    post_transition(env, conversation_id, state)
+    post_transition(env, conversation_id, state, effects)
 }
 
 fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMessage> {
     (!pending.is_empty()).then(|| {
         let drained = std::mem::take(pending);
         let queued = drained.iter().any(|m| m.queued);
-        let user_id = drained.last().map(|m| m.user_id.clone()).unwrap_or_default();
+        let user_id = drained
+            .last()
+            .map(|m| m.user_id.clone())
+            .unwrap_or_default();
         let name = drained.last().map(|m| m.name.clone()).unwrap_or_default();
         let text = drained
             .into_iter()
@@ -423,20 +371,21 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
 
 fn post_transition(
     env: &Arc<Env>,
-    conversation_id: &ConversationId,
+    _conversation_id: &ConversationId,
     result: ConversationTransitionResult,
+    effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
-    let (mut conversation, effects) = result?;
+    let mut conversation = result?;
 
     let recent_conversation = match &conversation.state {
         ConversationState::Idle {
             recent_conversation,
         } => recent_conversation.clone(),
-        _ => return Ok((conversation, effects)),
+        _ => return Ok(conversation),
     };
 
     let Some(msg) = take_pending(&mut conversation.pending) else {
-        return Ok((conversation, effects));
+        return Ok(conversation);
     };
 
     let is_group = conversation.is_group;
@@ -449,34 +398,27 @@ fn post_transition(
 
     let current_input = LLMInput::ConversationMessage(msg);
 
-    let effects = loop_back(
-        effects,
-        conversation_id.clone(),
-        get_llm_decision(
-            env.clone(),
-            current_input.clone(),
-            recent_conversation.map(|(rc, _)| rc),
-            0,
-            MAX_TOOL_ROUNDS,
-            is_group,
-            bot_identity.clone(),
-        ),
-    );
+    effects.enqueue_external(get_llm_decision(
+        env.clone(),
+        current_input.clone(),
+        recent_conversation.map(|(rc, _)| rc),
+        0,
+        MAX_TOOL_ROUNDS,
+        is_group,
+        bot_identity.clone(),
+    ));
 
-    Ok((
-        Conversation {
-            state: ConversationState::AwaitingLLMDecision {
-                history,
-                current_input,
-                tool_rounds: 0,
-            },
-            last_transition: Utc::now(),
-            pending: Vec::new(),
-            is_group,
-            bot_identity,
+    Ok(Conversation {
+        state: ConversationState::AwaitingLLMDecision {
+            history,
+            current_input,
+            tool_rounds: 0,
         },
-        effects,
-    ))
+        last_transition: Utc::now(),
+        pending: Vec::new(),
+        is_group,
+        bot_identity,
+    })
 }
 
 fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<ConversationAction>> {
@@ -498,17 +440,12 @@ fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<Conver
     }
 }
 
-fn construct_conversation(
-    constructor: ConversationConstructor,
-) -> (Conversation, Effects) {
-    (
-        Conversation {
-            pending: Vec::new(),
-            state: ConversationState::default(),
-            last_transition: Utc::now(),
-            is_group: constructor.is_group,
-            bot_identity: constructor.bot_identity,
-        },
-        Effects::none(),
-    )
+fn construct_conversation(constructor: ConversationConstructor) -> Conversation {
+    Conversation {
+        pending: Vec::new(),
+        state: ConversationState::default(),
+        last_transition: Utc::now(),
+        is_group: constructor.is_group,
+        bot_identity: constructor.bot_identity,
+    }
 }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -18,9 +18,20 @@ use re_framework::{Effects, Scheduled, StateMachine, StateMachineHandle};
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-type ConversationTransitionResult = anyhow::Result<(Conversation, Effects<ConversationMachine>)>;
+type ConversationTransitionResult = anyhow::Result<(Conversation, Effects)>;
 
 static CONVERSATION: OnceLock<StateMachineHandle<ConversationMachine>> = OnceLock::new();
+
+fn loop_back(
+    effects: Effects,
+    conversation_id: ConversationId,
+    fut: impl std::future::Future<Output = ConversationAction> + Send + 'static,
+) -> Effects {
+    effects.fire(async move {
+        let action = fut.await;
+        ConversationMachine::handle().act(conversation_id, action).await;
+    })
+}
 
 pub struct ConversationMachine;
 
@@ -31,7 +42,7 @@ impl StateMachine for ConversationMachine {
     type Construction = ConversationConstructor;
     type Env = crate::Env;
 
-    fn construct(constructor: ConversationConstructor) -> (Conversation, Effects<Self>) {
+    fn construct(constructor: ConversationConstructor) -> (Conversation, Effects) {
         construct_conversation(constructor)
     }
 
@@ -88,12 +99,16 @@ fn handle_outcome(
         let mut effects = Effects::none();
         let mut pending_tools = HashMap::new();
         for tool_call in response.tool_calls {
-            effects = effects.then(execute_tool(
-                env.clone(),
-                tool_call.clone(),
-                conversation_id.to_string(),
-                recent_conversation.history.clone(),
-            ));
+            effects = loop_back(
+                effects,
+                conversation_id.clone(),
+                execute_tool(
+                    env.clone(),
+                    tool_call.clone(),
+                    conversation_id.to_string(),
+                    recent_conversation.history.clone(),
+                ),
+            );
             pending_tools.insert(tool_call.id.clone(), tool_call);
         }
 
@@ -191,11 +206,11 @@ fn conversation_transition(
 
                 match message_to_send {
                     Some(message) => {
-                        let effects = Effects::none().then(send_message(
-                            env.clone(),
+                        let effects = loop_back(
+                            Effects::none(),
                             conversation_id.clone(),
-                            message,
-                        ));
+                            send_message(env.clone(), conversation_id.clone(), message),
+                        );
 
                         Ok((
                             Conversation {
@@ -290,15 +305,19 @@ fn conversation_transition(
                 let bot_identity = conversation.bot_identity.clone();
 
                 let history = recent_conversation.history();
-                let effects = Effects::none().then(get_llm_decision(
-                    env.clone(),
-                    current_input.clone(),
-                    Some(recent_conversation),
-                    tool_rounds,
-                    MAX_TOOL_ROUNDS,
-                    is_group,
-                    bot_identity.clone(),
-                ));
+                let effects = loop_back(
+                    Effects::none(),
+                    conversation_id.clone(),
+                    get_llm_decision(
+                        env.clone(),
+                        current_input.clone(),
+                        Some(recent_conversation),
+                        tool_rounds,
+                        MAX_TOOL_ROUNDS,
+                        is_group,
+                        bot_identity.clone(),
+                    ),
+                );
 
                 Ok((
                     Conversation {
@@ -338,11 +357,15 @@ fn conversation_transition(
         ) => {
             println!("Timed Out");
 
-            let effects = Effects::none().then(commit_to_memory(
-                env.clone(),
-                conversation_id.to_string(),
-                recent_conversation.history.clone(),
-            ));
+            let effects = loop_back(
+                Effects::none(),
+                conversation_id.clone(),
+                commit_to_memory(
+                    env.clone(),
+                    conversation_id.to_string(),
+                    recent_conversation.history.clone(),
+                ),
+            );
 
             Ok((
                 Conversation {
@@ -375,7 +398,7 @@ fn conversation_transition(
         _ => Err(anyhow::anyhow!("Invalid state or action")),
     };
 
-    post_transition(env, state)
+    post_transition(env, conversation_id, state)
 }
 
 fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMessage> {
@@ -400,6 +423,7 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
 
 fn post_transition(
     env: &Arc<Env>,
+    conversation_id: &ConversationId,
     result: ConversationTransitionResult,
 ) -> ConversationTransitionResult {
     let (mut conversation, effects) = result?;
@@ -425,15 +449,19 @@ fn post_transition(
 
     let current_input = LLMInput::ConversationMessage(msg);
 
-    let effects = effects.then(get_llm_decision(
-        env.clone(),
-        current_input.clone(),
-        recent_conversation.map(|(rc, _)| rc),
-        0,
-        MAX_TOOL_ROUNDS,
-        is_group,
-        bot_identity.clone(),
-    ));
+    let effects = loop_back(
+        effects,
+        conversation_id.clone(),
+        get_llm_decision(
+            env.clone(),
+            current_input.clone(),
+            recent_conversation.map(|(rc, _)| rc),
+            0,
+            MAX_TOOL_ROUNDS,
+            is_group,
+            bot_identity.clone(),
+        ),
+    );
 
     Ok((
         Conversation {
@@ -472,7 +500,7 @@ fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<Conver
 
 fn construct_conversation(
     constructor: ConversationConstructor,
-) -> (Conversation, Effects<ConversationMachine>) {
+) -> (Conversation, Effects) {
     (
         Conversation {
             pending: Vec::new(),

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -66,6 +66,16 @@ pub fn init_conversation_state_machine(env: Env) {
         .expect("ConversationMachine initialized once");
 }
 
+fn state_label(state: &ConversationState) -> &'static str {
+    match state {
+        ConversationState::Idle { .. } => "Idle",
+        ConversationState::CommitingToMemory { .. } => "CommitingToMemory",
+        ConversationState::AwaitingLLMDecision { .. } => "AwaitingLLMDecision",
+        ConversationState::SendingMessage { .. } => "SendingMessage",
+        ConversationState::RunningTools { .. } => "RunningTools",
+    }
+}
+
 fn handle_outcome(
     env: &Arc<Env>,
     conversation_id: &ConversationId,
@@ -121,6 +131,7 @@ fn conversation_transition(
     action: &ConversationAction,
     effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
+    let from = state_label(&conversation.state);
     let state = match (conversation.state, action) {
         (_, ConversationAction::ForceReset) => Ok(Conversation {
             pending: Vec::new(),
@@ -340,7 +351,7 @@ fn conversation_transition(
                 ..conversation
             })
         }
-        _ => Err(anyhow::anyhow!("Invalid state or action")),
+        _ => Err(anyhow::anyhow!("no transition for {action:?} in state {from}")),
     };
 
     post_transition(env, conversation_id, state, effects)

--- a/re_framework/src/effects.rs
+++ b/re_framework/src/effects.rs
@@ -4,26 +4,33 @@ use std::pin::Pin;
 
 type Outbound = Pin<Box<dyn Future<Output = ()> + Send>>;
 
-pub struct Effects {
+pub struct Effects<SM: StateMachine> {
+    id: SM::Id,
     pub(crate) outbound: Vec<Outbound>,
 }
 
-impl Effects {
-    pub fn none() -> Self {
+impl<SM: StateMachine> Effects<SM> {
+    pub(crate) fn new(id: SM::Id) -> Self {
         Effects {
+            id,
             outbound: Vec::new(),
         }
     }
 
-    pub fn send<T: StateMachine>(mut self, id: T::Id, action: T::Action) -> Self {
+    pub fn enqueue_action<T: StateMachine>(&mut self, id: T::Id, action: T::Action) {
         self.outbound.push(Box::pin(async move {
             T::handle().act(id, action).await;
         }));
-        self
     }
 
-    pub fn fire(mut self, fut: impl Future<Output = ()> + Send + 'static) -> Self {
-        self.outbound.push(Box::pin(fut));
-        self
+    pub fn enqueue_external(
+        &mut self,
+        fut: impl Future<Output = SM::Action> + Send + 'static,
+    ) {
+        let id = self.id.clone();
+        self.outbound.push(Box::pin(async move {
+            let action = fut.await;
+            SM::handle().act(id, action).await;
+        }));
     }
 }

--- a/re_framework/src/effects.rs
+++ b/re_framework/src/effects.rs
@@ -19,7 +19,7 @@ impl<SM: StateMachine> Effects<SM> {
 
     pub fn enqueue_action<T: StateMachine>(&mut self, id: T::Id, action: T::Action) {
         self.outbound.push(Box::pin(async move {
-            T::handle().act(id, action).await;
+            T::handle().act(id, action);
         }));
     }
 
@@ -30,7 +30,7 @@ impl<SM: StateMachine> Effects<SM> {
         let id = self.id.clone();
         self.outbound.push(Box::pin(async move {
             let action = fut.await;
-            SM::handle().act(id, action).await;
+            SM::handle().act(id, action);
         }));
     }
 }

--- a/re_framework/src/effects.rs
+++ b/re_framework/src/effects.rs
@@ -2,26 +2,17 @@ use crate::machine::StateMachine;
 use std::future::Future;
 use std::pin::Pin;
 
-pub type SelfEffect<SM> = Pin<Box<dyn Future<Output = <SM as StateMachine>::Action> + Send>>;
-
 type Outbound = Pin<Box<dyn Future<Output = ()> + Send>>;
 
-pub struct Effects<SM: StateMachine> {
-    pub(crate) self_actions: Vec<SelfEffect<SM>>,
+pub struct Effects {
     pub(crate) outbound: Vec<Outbound>,
 }
 
-impl<SM: StateMachine> Effects<SM> {
+impl Effects {
     pub fn none() -> Self {
         Effects {
-            self_actions: Vec::new(),
             outbound: Vec::new(),
         }
-    }
-
-    pub fn then(mut self, fut: impl Future<Output = SM::Action> + Send + 'static) -> Self {
-        self.self_actions.push(Box::pin(fut));
-        self
     }
 
     pub fn send<T: StateMachine>(mut self, id: T::Id, action: T::Action) -> Self {

--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -114,10 +114,7 @@ fn log_transition<SM: StateMachine>(label: &str) {
     println!(
         "TRANSITION AT {} - StateMachine: {} - {}",
         Utc::now(),
-        std::any::type_name::<SM::State>()
-            .rsplit("::")
-            .next()
-            .unwrap_or("?"),
+        SM::name(),
         label
     );
 }

--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -49,7 +49,6 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
                     self.entities.clone(),
                     id,
                     incarnation,
-                    tx.clone(),
                     effects,
                 ));
                 slot.insert(Entry {
@@ -67,7 +66,14 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
             .map(|e| e.sender.clone());
         match sender {
             Some(sender) => {
-                let _ = sender.send(Envelope::Act(action)).await;
+                if let Err(mpsc::error::SendError(Envelope::Act(action))) =
+                    sender.send(Envelope::Act(action)).await
+                {
+                    eprintln!(
+                        "[warn] action {action:?} for entity {} dropped — mailbox closed (entity deleted?)",
+                        id.get_id_string()
+                    );
+                }
             }
             None => eprintln!(
                 "[warn] action {action:?} for unconstructed entity {}; dropping (maybe_construct must precede act)",
@@ -82,7 +88,12 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
             .get(&id.get_id_string())
             .map(|e| e.sender.clone());
         if let Some(sender) = sender {
-            let _ = sender.send(Envelope::Delete).await;
+            if sender.send(Envelope::Delete).await.is_err() {
+                eprintln!(
+                    "[warn] delete for entity {} — mailbox already closed",
+                    id.get_id_string()
+                );
+            }
         }
     }
 }
@@ -94,10 +105,9 @@ async fn run_entity<SM: StateMachine>(
     entities: Arc<DashMap<String, Entry<SM>>>,
     id: SM::Id,
     incarnation: u64,
-    self_tx: mpsc::Sender<Envelope<SM::Action>>,
-    initial: Effects<SM>,
+    initial: Effects,
 ) {
-    spawn_effects::<SM>(initial, &self_tx);
+    spawn_effects(initial);
 
     loop {
         let action = match SM::schedule(&state) {
@@ -106,6 +116,7 @@ async fn run_entity<SM: StateMachine>(
                 let delay = (scheduled.at - Utc::now())
                     .to_std()
                     .unwrap_or(std::time::Duration::ZERO);
+
                 tokio::time::timeout(delay, rx.recv())
                     .await
                     .unwrap_or_else(|_e| Some(Envelope::Act(scheduled.action)))
@@ -114,8 +125,15 @@ async fn run_entity<SM: StateMachine>(
 
         let action = match action {
             Some(Envelope::Act(action)) => action,
-            Some(Envelope::Delete) | None => {
+            Some(Envelope::Delete) => {
                 log_transition::<SM>("Delete");
+                break;
+            }
+            None => {
+                eprintln!(
+                    "[error] entity {} mailbox closed while live — all senders dropped unexpectedly (framework bug)",
+                    id.get_id_string()
+                );
                 break;
             }
         };
@@ -123,24 +141,14 @@ async fn run_entity<SM: StateMachine>(
         log_transition::<SM>(&format!("Action: {action:?}"));
         if let Ok((next, effects)) = SM::transition(&state, &id, &env, &action) {
             state = next;
-            spawn_effects::<SM>(effects, &self_tx);
+            spawn_effects(effects);
         }
     }
 
     entities.remove_if(&id.get_id_string(), |_, e| e.incarnation == incarnation);
 }
 
-fn spawn_effects<SM: StateMachine>(
-    effects: Effects<SM>,
-    self_tx: &mpsc::Sender<Envelope<SM::Action>>,
-) {
-    for fut in effects.self_actions {
-        let tx = self_tx.clone();
-        tokio::spawn(async move {
-            let action = fut.await;
-            let _ = tx.send(Envelope::Act(action)).await;
-        });
-    }
+fn spawn_effects(effects: Effects) {
     for outbound in effects.outbound {
         tokio::spawn(outbound);
     }

--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -2,26 +2,28 @@ use crate::effects::Effects;
 use crate::machine::{EntityId, Identified, StateMachine};
 use chrono::Utc;
 use dashmap::DashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
-const MAILBOX: usize = 64;
-
+/// Mailbox message; single-variant for now, kept as an enum for planned control messages.
 enum Envelope<A> {
     Act(A),
-    Delete,
 }
 
-struct Entry<SM: StateMachine> {
-    sender: mpsc::Sender<Envelope<SM::Action>>,
-    incarnation: u64,
+/// Sole sender to a live actor's mailbox; not `Clone` — dropping it (via registry removal) stops the actor (RAII).
+struct SoleMailboxHandle<SM: StateMachine> {
+    sender: mpsc::UnboundedSender<Envelope<SM::Action>>,
+}
+
+impl<SM: StateMachine> SoleMailboxHandle<SM> {
+    fn deliver(&self, action: SM::Action) {
+        let _ = self.sender.send(Envelope::Act(action));
+    }
 }
 
 pub struct StateMachineHandle<SM: StateMachine> {
-    entities: Arc<DashMap<String, Entry<SM>>>,
+    entities: Arc<DashMap<String, SoleMailboxHandle<SM>>>,
     env: Arc<SM::Env>,
-    next_incarnation: Arc<AtomicU64>,
 }
 
 impl<SM: StateMachine> StateMachineHandle<SM> {
@@ -29,53 +31,27 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
         StateMachineHandle {
             entities: Arc::new(DashMap::new()),
             env: Arc::new(env),
-            next_incarnation: Arc::new(AtomicU64::new(0)),
         }
     }
 
-    pub async fn maybe_construct(&self, construction: SM::Construction) {
+    pub fn maybe_construct(&self, construction: SM::Construction) {
         use dashmap::mapref::entry::Entry as DEntry;
         let id = construction.get_id().clone();
         match self.entities.entry(id.get_id_string()) {
             DEntry::Occupied(_) => {}
             DEntry::Vacant(slot) => {
-                let incarnation = self.next_incarnation.fetch_add(1, Ordering::Relaxed);
-                let (tx, rx) = mpsc::channel(MAILBOX);
+                let (tx, rx) = mpsc::unbounded_channel();
                 let mut effects = Effects::new(id.clone());
                 let state = SM::construct(construction, &mut effects);
-                tokio::spawn(run_entity::<SM>(
-                    state,
-                    rx,
-                    self.env.clone(),
-                    self.entities.clone(),
-                    id,
-                    incarnation,
-                    effects,
-                ));
-                slot.insert(Entry {
-                    sender: tx,
-                    incarnation,
-                });
+                tokio::spawn(run_entity::<SM>(state, rx, self.env.clone(), id, effects));
+                slot.insert(SoleMailboxHandle { sender: tx });
             }
         }
     }
 
-    pub async fn act(&self, id: SM::Id, action: SM::Action) {
-        let sender = self
-            .entities
-            .get(&id.get_id_string())
-            .map(|e| e.sender.clone());
-        match sender {
-            Some(sender) => {
-                if let Err(mpsc::error::SendError(Envelope::Act(action))) =
-                    sender.send(Envelope::Act(action)).await
-                {
-                    eprintln!(
-                        "[warn] action {action:?} for entity {} dropped — mailbox closed (entity deleted?)",
-                        id.get_id_string()
-                    );
-                }
-            }
+    pub fn act(&self, id: SM::Id, action: SM::Action) {
+        match self.entities.get(&id.get_id_string()) {
+            Some(mailbox) => mailbox.deliver(action),
             None => eprintln!(
                 "[warn] action {action:?} for unconstructed entity {}; dropping (maybe_construct must precede act)",
                 id.get_id_string()
@@ -83,29 +59,16 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
         }
     }
 
-    pub async fn delete(&self, id: SM::Id) {
-        let sender = self
-            .entities
-            .get(&id.get_id_string())
-            .map(|e| e.sender.clone());
-        if let Some(sender) = sender {
-            if sender.send(Envelope::Delete).await.is_err() {
-                eprintln!(
-                    "[warn] delete for entity {} — mailbox already closed",
-                    id.get_id_string()
-                );
-            }
-        }
+    pub fn delete(&self, id: SM::Id) {
+        self.entities.remove(&id.get_id_string());
     }
 }
 
 async fn run_entity<SM: StateMachine>(
     mut state: SM::State,
-    mut rx: mpsc::Receiver<Envelope<SM::Action>>,
+    mut rx: mpsc::UnboundedReceiver<Envelope<SM::Action>>,
     env: Arc<SM::Env>,
-    entities: Arc<DashMap<String, Entry<SM>>>,
     id: SM::Id,
-    incarnation: u64,
     initial: Effects<SM>,
 ) {
     spawn_effects(initial);
@@ -124,19 +87,9 @@ async fn run_entity<SM: StateMachine>(
             }
         };
 
-        let action = match action {
-            Some(Envelope::Act(action)) => action,
-            Some(Envelope::Delete) => {
-                log_transition::<SM>("Delete");
-                break;
-            }
-            None => {
-                eprintln!(
-                    "[error] entity {} mailbox closed while live — all senders dropped unexpectedly (framework bug)",
-                    id.get_id_string()
-                );
-                break;
-            }
+        let Some(Envelope::Act(action)) = action else {
+            log_transition::<SM>("Delete");
+            break;
         };
 
         log_transition::<SM>(&format!("Action: {action:?}"));
@@ -146,8 +99,6 @@ async fn run_entity<SM: StateMachine>(
             spawn_effects(effects);
         }
     }
-
-    entities.remove_if(&id.get_id_string(), |_, e| e.incarnation == incarnation);
 }
 
 fn spawn_effects<SM: StateMachine>(effects: Effects<SM>) {

--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -41,7 +41,8 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
             DEntry::Vacant(slot) => {
                 let incarnation = self.next_incarnation.fetch_add(1, Ordering::Relaxed);
                 let (tx, rx) = mpsc::channel(MAILBOX);
-                let (state, effects) = SM::construct(construction);
+                let mut effects = Effects::new(id.clone());
+                let state = SM::construct(construction, &mut effects);
                 tokio::spawn(run_entity::<SM>(
                     state,
                     rx,
@@ -105,7 +106,7 @@ async fn run_entity<SM: StateMachine>(
     entities: Arc<DashMap<String, Entry<SM>>>,
     id: SM::Id,
     incarnation: u64,
-    initial: Effects,
+    initial: Effects<SM>,
 ) {
     spawn_effects(initial);
 
@@ -139,7 +140,8 @@ async fn run_entity<SM: StateMachine>(
         };
 
         log_transition::<SM>(&format!("Action: {action:?}"));
-        if let Ok((next, effects)) = SM::transition(&state, &id, &env, &action) {
+        let mut effects = Effects::new(id.clone());
+        if let Ok(next) = SM::transition(&state, &id, &env, &action, &mut effects) {
             state = next;
             spawn_effects(effects);
         }
@@ -148,7 +150,7 @@ async fn run_entity<SM: StateMachine>(
     entities.remove_if(&id.get_id_string(), |_, e| e.incarnation == incarnation);
 }
 
-fn spawn_effects(effects: Effects) {
+fn spawn_effects<SM: StateMachine>(effects: Effects<SM>) {
     for outbound in effects.outbound {
         tokio::spawn(outbound);
     }

--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -5,13 +5,11 @@ use dashmap::DashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 
 const MAILBOX: usize = 64;
 
 enum Envelope<A> {
     Act(A),
-    Wakeup(u64),
     Delete,
 }
 
@@ -63,7 +61,10 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
     }
 
     pub async fn act(&self, id: SM::Id, action: SM::Action) {
-        let sender = self.entities.get(&id.get_id_string()).map(|e| e.sender.clone());
+        let sender = self
+            .entities
+            .get(&id.get_id_string())
+            .map(|e| e.sender.clone());
         match sender {
             Some(sender) => {
                 let _ = sender.send(Envelope::Act(action)).await;
@@ -76,7 +77,10 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
     }
 
     pub async fn delete(&self, id: SM::Id) {
-        let sender = self.entities.get(&id.get_id_string()).map(|e| e.sender.clone());
+        let sender = self
+            .entities
+            .get(&id.get_id_string())
+            .map(|e| e.sender.clone());
         if let Some(sender) = sender {
             let _ = sender.send(Envelope::Delete).await;
         }
@@ -93,53 +97,36 @@ async fn run_entity<SM: StateMachine>(
     self_tx: mpsc::Sender<Envelope<SM::Action>>,
     initial: Effects<SM>,
 ) {
-    let mut generation: u64 = 0;
-    let mut timer: Option<JoinHandle<()>> = None;
     spawn_effects::<SM>(initial, &self_tx);
-    reschedule_timer::<SM>(&state, &mut generation, &mut timer, &self_tx);
 
-    while let Some(msg) = rx.recv().await {
-        let label = match &msg {
-            Envelope::Act(action) => format!("Action: {action:?}"),
-            Envelope::Wakeup(_) => "Wakeup".to_string(),
-            Envelope::Delete => "Delete".to_string(),
+    loop {
+        let action = match SM::schedule(&state) {
+            None => rx.recv().await,
+            Some(scheduled) => {
+                let delay = (scheduled.at - Utc::now())
+                    .to_std()
+                    .unwrap_or(std::time::Duration::ZERO);
+                tokio::time::timeout(delay, rx.recv())
+                    .await
+                    .unwrap_or_else(|_e| Some(Envelope::Act(scheduled.action)))
+            }
         };
-        println!(
-            "TRANSITION AT {} - StateMachine: {} - {}",
-            Utc::now(),
-            std::any::type_name::<SM::State>().rsplit("::").next().unwrap_or("?"),
-            label
-        );
-        match msg {
-            Envelope::Act(action) => {
-                match SM::transition(&state, &id, &env, &action) {
-                    Ok((next, effects)) => {
-                        state = next;
-                        spawn_effects::<SM>(effects, &self_tx);
-                        reschedule_timer::<SM>(&state, &mut generation, &mut timer, &self_tx);
-                    }
-                    Err(_e) => {}
-                }
+
+        let action = match action {
+            Some(Envelope::Act(action)) => action,
+            Some(Envelope::Delete) | None => {
+                log_transition::<SM>("Delete");
+                break;
             }
-            Envelope::Wakeup(g) => {
-                if g != generation {
-                    continue;
-                }
-                match SM::schedule(&state) {
-                    Some(s) if s.at <= Utc::now() => {
-                        let _ = self_tx.send(Envelope::Act(s.action)).await;
-                    }
-                    Some(_) => reschedule_timer::<SM>(&state, &mut generation, &mut timer, &self_tx),
-                    None => {}
-                }
-            }
-            Envelope::Delete => break,
+        };
+
+        log_transition::<SM>(&format!("Action: {action:?}"));
+        if let Ok((next, effects)) = SM::transition(&state, &id, &env, &action) {
+            state = next;
+            spawn_effects::<SM>(effects, &self_tx);
         }
     }
 
-    if let Some(t) = timer.take() {
-        t.abort();
-    }
     entities.remove_if(&id.get_id_string(), |_, e| e.incarnation == incarnation);
 }
 
@@ -159,25 +146,14 @@ fn spawn_effects<SM: StateMachine>(
     }
 }
 
-fn reschedule_timer<SM: StateMachine>(
-    state: &SM::State,
-    generation: &mut u64,
-    timer: &mut Option<JoinHandle<()>>,
-    self_tx: &mpsc::Sender<Envelope<SM::Action>>,
-) {
-    if let Some(t) = timer.take() {
-        t.abort();
-    }
-    *generation += 1;
-    let g = *generation;
-    if let Some(scheduled) = SM::schedule(state) {
-        let tx = self_tx.clone();
-        let delay = (scheduled.at - Utc::now())
-            .to_std()
-            .unwrap_or(std::time::Duration::ZERO);
-        *timer = Some(tokio::spawn(async move {
-            tokio::time::sleep(delay).await;
-            let _ = tx.send(Envelope::Wakeup(g)).await;
-        }));
-    }
+fn log_transition<SM: StateMachine>(label: &str) {
+    println!(
+        "TRANSITION AT {} - StateMachine: {} - {}",
+        Utc::now(),
+        std::any::type_name::<SM::State>()
+            .rsplit("::")
+            .next()
+            .unwrap_or("?"),
+        label
+    );
 }

--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -94,9 +94,12 @@ async fn run_entity<SM: StateMachine>(
 
         log_transition::<SM>(&format!("Action: {action:?}"));
         let mut effects = Effects::new(id.clone());
-        if let Ok(next) = SM::transition(&state, &id, &env, &action, &mut effects) {
-            state = next;
-            spawn_effects(effects);
+        match SM::transition(&state, &id, &env, &action, &mut effects) {
+            Ok(next) => {
+                state = next;
+                spawn_effects(effects);
+            }
+            Err(err) => log_transition::<SM>(&format!("dropped — no state change: {err}")),
         }
     }
 }

--- a/re_framework/src/machine.rs
+++ b/re_framework/src/machine.rs
@@ -25,13 +25,14 @@ pub trait StateMachine: Sized + 'static {
     type Construction: Identified<Id = Self::Id> + Send + 'static;
     type Env: Send + Sync + 'static;
 
-    fn construct(construction: Self::Construction) -> (Self::State, Effects);
+    fn construct(construction: Self::Construction, effects: &mut Effects<Self>) -> Self::State;
     fn transition(
         state: &Self::State,
         id: &Self::Id,
         env: &Arc<Self::Env>,
         action: &Self::Action,
-    ) -> anyhow::Result<(Self::State, Effects)>;
+        effects: &mut Effects<Self>,
+    ) -> anyhow::Result<Self::State>;
     fn schedule(state: &Self::State) -> Option<Scheduled<Self::Action>>;
     fn handle() -> &'static StateMachineHandle<Self>;
 }

--- a/re_framework/src/machine.rs
+++ b/re_framework/src/machine.rs
@@ -25,13 +25,13 @@ pub trait StateMachine: Sized + 'static {
     type Construction: Identified<Id = Self::Id> + Send + 'static;
     type Env: Send + Sync + 'static;
 
-    fn construct(construction: Self::Construction) -> (Self::State, Effects<Self>);
+    fn construct(construction: Self::Construction) -> (Self::State, Effects);
     fn transition(
         state: &Self::State,
         id: &Self::Id,
         env: &Arc<Self::Env>,
         action: &Self::Action,
-    ) -> anyhow::Result<(Self::State, Effects<Self>)>;
+    ) -> anyhow::Result<(Self::State, Effects)>;
     fn schedule(state: &Self::State) -> Option<Scheduled<Self::Action>>;
     fn handle() -> &'static StateMachineHandle<Self>;
 }

--- a/re_framework/src/machine.rs
+++ b/re_framework/src/machine.rs
@@ -35,4 +35,11 @@ pub trait StateMachine: Sized + 'static {
     ) -> anyhow::Result<Self::State>;
     fn schedule(state: &Self::State) -> Option<Scheduled<Self::Action>>;
     fn handle() -> &'static StateMachineHandle<Self>;
+
+    fn name() -> &'static str {
+        std::any::type_name::<Self>()
+            .rsplit("::")
+            .next()
+            .unwrap_or("?")
+    }
 }

--- a/re_framework/src/smoke.rs
+++ b/re_framework/src/smoke.rs
@@ -56,7 +56,7 @@ impl StateMachine for CounterMachine {
     type Construction = CounterInit;
     type Env = CounterEnv;
 
-    fn construct(init: CounterInit) -> (CounterState, Effects<Self>) {
+    fn construct(init: CounterInit) -> (CounterState, Effects) {
         (
             CounterState {
                 total: init.start,
@@ -68,10 +68,10 @@ impl StateMachine for CounterMachine {
 
     fn transition(
         state: &CounterState,
-        _id: &String,
+        id: &String,
         env: &Arc<CounterEnv>,
         action: &CounterAction,
-    ) -> anyhow::Result<(CounterState, Effects<Self>)> {
+    ) -> anyhow::Result<(CounterState, Effects)> {
         match action {
             CounterAction::Add(n) => {
                 if state.total + n < 0 {
@@ -82,9 +82,10 @@ impl StateMachine for CounterMachine {
                 env.obs.lock().unwrap().totals.push(next.total);
                 Ok((next, Effects::none()))
             }
-            CounterAction::Ping => {
-                Ok((state.clone(), Effects::none().then(async { CounterAction::Add(10) })))
-            }
+            CounterAction::Ping => Ok((
+                state.clone(),
+                Effects::none().send::<CounterMachine>(id.clone(), CounterAction::Add(10)),
+            )),
             CounterAction::Tick => {
                 let mut next = state.clone();
                 next.tick_at = None;
@@ -170,7 +171,7 @@ impl StateMachine for PongerMachine {
     type Action = PongerAction;
     type Construction = PongerInit;
     type Env = RtEnv;
-    fn construct(_init: PongerInit) -> (PongerState, Effects<Self>) {
+    fn construct(_init: PongerInit) -> (PongerState, Effects) {
         (PongerState, Effects::none())
     }
     fn transition(
@@ -178,7 +179,7 @@ impl StateMachine for PongerMachine {
         _id: &String,
         env: &Arc<RtEnv>,
         action: &PongerAction,
-    ) -> anyhow::Result<(PongerState, Effects<Self>)> {
+    ) -> anyhow::Result<(PongerState, Effects)> {
         let PongerAction::Pong(n) = action;
         env.received.lock().unwrap().push(*n);
         Ok((state.clone(), Effects::none()))
@@ -214,7 +215,7 @@ impl StateMachine for PingerMachine {
     type Action = PingerAction;
     type Construction = PingerInit;
     type Env = RtEnv;
-    fn construct(_init: PingerInit) -> (PingerState, Effects<Self>) {
+    fn construct(_init: PingerInit) -> (PingerState, Effects) {
         (
             PingerState,
             Effects::none().send::<PongerMachine>("pong1".to_string(), PongerAction::Pong(0)),
@@ -225,7 +226,7 @@ impl StateMachine for PingerMachine {
         _id: &String,
         _env: &Arc<RtEnv>,
         action: &PingerAction,
-    ) -> anyhow::Result<(PingerState, Effects<Self>)> {
+    ) -> anyhow::Result<(PingerState, Effects)> {
         let PingerAction::Ping(n) = action;
         if *n < 0 {
             anyhow::bail!("no negative pings");

--- a/re_framework/src/smoke.rs
+++ b/re_framework/src/smoke.rs
@@ -56,14 +56,11 @@ impl StateMachine for CounterMachine {
     type Construction = CounterInit;
     type Env = CounterEnv;
 
-    fn construct(init: CounterInit) -> (CounterState, Effects) {
-        (
-            CounterState {
-                total: init.start,
-                tick_at: Some(Utc::now() + Duration::milliseconds(50)),
-            },
-            Effects::none(),
-        )
+    fn construct(init: CounterInit, _effects: &mut Effects<Self>) -> CounterState {
+        CounterState {
+            total: init.start,
+            tick_at: Some(Utc::now() + Duration::milliseconds(50)),
+        }
     }
 
     fn transition(
@@ -71,7 +68,8 @@ impl StateMachine for CounterMachine {
         id: &String,
         env: &Arc<CounterEnv>,
         action: &CounterAction,
-    ) -> anyhow::Result<(CounterState, Effects)> {
+        effects: &mut Effects<Self>,
+    ) -> anyhow::Result<CounterState> {
         match action {
             CounterAction::Add(n) => {
                 if state.total + n < 0 {
@@ -80,17 +78,17 @@ impl StateMachine for CounterMachine {
                 let mut next = state.clone();
                 next.total += n;
                 env.obs.lock().unwrap().totals.push(next.total);
-                Ok((next, Effects::none()))
+                Ok(next)
             }
-            CounterAction::Ping => Ok((
-                state.clone(),
-                Effects::none().send::<CounterMachine>(id.clone(), CounterAction::Add(10)),
-            )),
+            CounterAction::Ping => {
+                effects.enqueue_action::<CounterMachine>(id.clone(), CounterAction::Add(10));
+                Ok(state.clone())
+            }
             CounterAction::Tick => {
                 let mut next = state.clone();
                 next.tick_at = None;
                 env.obs.lock().unwrap().ticks += 1;
-                Ok((next, Effects::none()))
+                Ok(next)
             }
         }
     }
@@ -171,18 +169,19 @@ impl StateMachine for PongerMachine {
     type Action = PongerAction;
     type Construction = PongerInit;
     type Env = RtEnv;
-    fn construct(_init: PongerInit) -> (PongerState, Effects) {
-        (PongerState, Effects::none())
+    fn construct(_init: PongerInit, _effects: &mut Effects<Self>) -> PongerState {
+        PongerState
     }
     fn transition(
         state: &PongerState,
         _id: &String,
         env: &Arc<RtEnv>,
         action: &PongerAction,
-    ) -> anyhow::Result<(PongerState, Effects)> {
+        _effects: &mut Effects<Self>,
+    ) -> anyhow::Result<PongerState> {
         let PongerAction::Pong(n) = action;
         env.received.lock().unwrap().push(*n);
-        Ok((state.clone(), Effects::none()))
+        Ok(state.clone())
     }
     fn schedule(_state: &PongerState) -> Option<Scheduled<PongerAction>> {
         None
@@ -215,26 +214,23 @@ impl StateMachine for PingerMachine {
     type Action = PingerAction;
     type Construction = PingerInit;
     type Env = RtEnv;
-    fn construct(_init: PingerInit) -> (PingerState, Effects) {
-        (
-            PingerState,
-            Effects::none().send::<PongerMachine>("pong1".to_string(), PongerAction::Pong(0)),
-        )
+    fn construct(_init: PingerInit, effects: &mut Effects<Self>) -> PingerState {
+        effects.enqueue_action::<PongerMachine>("pong1".to_string(), PongerAction::Pong(0));
+        PingerState
     }
     fn transition(
         state: &PingerState,
         _id: &String,
         _env: &Arc<RtEnv>,
         action: &PingerAction,
-    ) -> anyhow::Result<(PingerState, Effects)> {
+        effects: &mut Effects<Self>,
+    ) -> anyhow::Result<PingerState> {
         let PingerAction::Ping(n) = action;
         if *n < 0 {
             anyhow::bail!("no negative pings");
         }
-        Ok((
-            state.clone(),
-            Effects::none().send::<PongerMachine>("pong1".to_string(), PongerAction::Pong(*n)),
-        ))
+        effects.enqueue_action::<PongerMachine>("pong1".to_string(), PongerAction::Pong(*n));
+        Ok(state.clone())
     }
     fn schedule(_state: &PingerState) -> Option<Scheduled<PingerAction>> {
         None

--- a/re_framework/src/smoke.rs
+++ b/re_framework/src/smoke.rs
@@ -114,14 +114,14 @@ async fn smoke() {
         .expect("set COUNTER once");
     let sm = CounterMachine::handle();
 
-    sm.maybe_construct(CounterInit { id: "c1".to_string(), start: 0 }).await;
-    sm.act("c1".to_string(), CounterAction::Add(5)).await;
+    sm.maybe_construct(CounterInit { id: "c1".to_string(), start: 0 });
+    sm.act("c1".to_string(), CounterAction::Add(5));
 
-    sm.maybe_construct(CounterInit { id: "c1".to_string(), start: 999 }).await;
-    sm.act("c1".to_string(), CounterAction::Add(3)).await;
+    sm.maybe_construct(CounterInit { id: "c1".to_string(), start: 999 });
+    sm.act("c1".to_string(), CounterAction::Add(3));
 
-    sm.act("c1".to_string(), CounterAction::Add(-1000)).await;
-    sm.act("c1".to_string(), CounterAction::Ping).await;
+    sm.act("c1".to_string(), CounterAction::Add(-1000));
+    sm.act("c1".to_string(), CounterAction::Ping);
 
     tokio::time::sleep(StdDuration::from_millis(120)).await;
 
@@ -131,9 +131,9 @@ async fn smoke() {
         assert_eq!(o.ticks, 1, "timer fired exactly once");
     }
 
-    sm.delete("c1".to_string()).await;
+    sm.delete("c1".to_string());
     tokio::time::sleep(StdDuration::from_millis(20)).await;
-    sm.act("c1".to_string(), CounterAction::Add(1)).await;
+    sm.act("c1".to_string(), CounterAction::Add(1));
     tokio::time::sleep(StdDuration::from_millis(20)).await;
 
     assert_eq!(obs.lock().unwrap().totals, vec![5, 8, 18], "post-delete act dropped");
@@ -254,11 +254,11 @@ async fn outbound() {
     let ponger = PongerMachine::handle();
     let pinger = PingerMachine::handle();
 
-    ponger.maybe_construct(PongerInit { id: "pong1".to_string() }).await;
-    pinger.maybe_construct(PingerInit { id: "ping1".to_string() }).await;
+    ponger.maybe_construct(PongerInit { id: "pong1".to_string() });
+    pinger.maybe_construct(PingerInit { id: "ping1".to_string() });
 
-    pinger.act("ping1".to_string(), PingerAction::Ping(42)).await;
-    pinger.act("ping1".to_string(), PingerAction::Ping(-1)).await;
+    pinger.act("ping1".to_string(), PingerAction::Ping(42));
+    pinger.act("ping1".to_string(), PingerAction::Ping(-1));
 
     tokio::time::sleep(StdDuration::from_millis(50)).await;
     assert_eq!(


### PR DESCRIPTION
Consolidates several `re_framework` simplifications (supersedes #136, which was scoped only to the timer).

## Changes

**Spawn-less timer** — replaces the per-arm spawned sleeper task with a timed `recv` (`tokio::time::timeout(delay, rx.recv())`); the deadline is recomputed from live state each loop. Drops the spawned task, JoinHandle, generation counter, and the `Wakeup` envelope variant.

**Append-only `Effects<SM>`** — `Effects` is generic over the machine and carries the entity's own id. `construct`/`transition` take `&mut Effects<Self>` and return just the state; the framework spawns effects only after a successful (`Ok`) commit. Public surface is append-only:
- `enqueue_action::<T>(id, action)` — deliver to any entity/machine
- `enqueue_external(future_of_self_action)` — run an external, deliver its result back to self via the registry handle

This reinstates self-actions cleanly (routed through `SM::handle().act`, no captured `self_tx`) and lets the chatbot drop its `loop_back` helper — all five loop-back sites collapse to `effects.enqueue_external(...)`.

**Unbounded sync mailbox + RAII delete** — the per-entity mailbox is an unbounded channel, so `act`/`delete`/`maybe_construct` are synchronous (no await in the send path). This removes the lock-across-await hazard and makes delete pure RAII: `delete` removes the registry entry, dropping the sole sender, so `recv` drains queued actions then returns `None` and the actor stops. The sender is wrapped in a non-`Clone` `SoleMailboxHandle`, held only by the registry and delivered through `&self`, so nothing can clone or stash a second sender and outlive deletion. `Envelope` is kept as a single-variant enum for planned control messages. Backpressure is intentionally gone — mailbox overflow is now a domain-side concern.

Net effect across the framework: large deletions (incarnation guard, `remove_if` cleanup, bounded mailbox const, the `Delete` message arm, the spawned timer task), with the chatbot ported to the new APIs.

## Testing
- `cargo test -p re_framework` — 2/2 pass (incl. post-delete-act-dropped, exercising RAII delete)
- `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)