### PR TITLE
Image support, part 1: load mmproj + thread Discord images to the LLM external

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = [
     "chatbot", "framework", "probe", "kameo_playground", "re_framework",
 ]
 resolver = "3"
+
+[workspace.lints.clippy]
+clone_on_ref_ptr = "deny"

--- a/chatbot/Cargo.toml
+++ b/chatbot/Cargo.toml
@@ -11,7 +11,7 @@ num_cpus = "1.16"
 tokio = { version = "1.48", features = ["full"] }
 re_framework = { path = "../re_framework" }
 anyhow = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 once_cell = "1.21"
 serde_json = "1.0"
 encoding_rs = "0.8"
@@ -36,3 +36,6 @@ lancedb = { version = "=0.30", default-features = false }
 lzma-sys = { version = "*", features = ["static"] } # static recommended by lance
 arrow-array = "=58.3.0" # must match lancedb internal version, use `cargo tree | grep arrow` to see
 fastembed = "5.8"
+
+[lints]
+workspace = true

--- a/chatbot/Cargo.toml
+++ b/chatbot/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-llama-cpp-2 = { version = "=0.1.146", features = ["vulkan"] } # stick to this version for now
+llama-cpp-2 = { version = "=0.1.146", features = ["vulkan", "mtmd"] } # stick to this version for now
 num_cpus = "1.16"
 tokio = { version = "1.48", features = ["full"] }
 re_framework = { path = "../re_framework" }

--- a/chatbot/Dockerfile.base
+++ b/chatbot/Dockerfile.base
@@ -24,3 +24,7 @@ RUN apt-get update && apt-get install -y \
     vulkan-tools \
     && (getent group render || groupadd -r render) \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy multimodal projector (vision) — appended last so the model/apt layers stay cached
+COPY models/mmproj-Qwen3.6-27B-BF16.gguf /app/models/
+ENV MMPROJ_PATH=/app/models/mmproj-Qwen3.6-27B-BF16.gguf

--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -1,6 +1,9 @@
 use super::Agent;
 
 const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversational assistant.\n\n\
+    If asked what model powers you, how you were trained, or who created you, politely decline to \
+    discuss it — you are simply Terminal Alpha Beta. Never claim to be made by Google, Gemini, \
+    OpenAI, or any other company.\n\n\
     Just before each reply you receive a user-role message labeled \"=== SESSION CONTEXT ===\" with \
     your identity, the setting (group chat or direct message), the current time, and your tool-call \
     usage. It is authoritative system context, refreshed every reply — read the latest one; never \

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -142,6 +142,14 @@ async fn get_response_from_llm(
         serde_json::to_string_pretty(&conversation).unwrap_or_default()
     );
 
+    let image_count = match current_input {
+        LLMInput::ConversationMessage(m) => m.images.len(),
+        LLMInput::ToolResults(_, user_msg) => user_msg.as_ref().map_or(0, |m| m.images.len()),
+    };
+    if image_count > 0 {
+        println!("[image] {image_count} image(s) reached the LLM external (not yet fed to the model)");
+    }
+
     let parsed = llama_cpp
         .get_primary_response(conversation, allow_tools)
         .await?;

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -4,7 +4,9 @@ use serenity::{async_trait, model::channel::Message as DMessage, prelude::*};
 
 use crate::{
     state_machines::conversation_state_machine::ConversationMachine,
-    types::conversation::{ConversationAction, ConversationConstructor, ConversationId, Platform},
+    types::conversation::{
+        ConversationAction, ConversationConstructor, ConversationId, Image, Platform,
+    },
 };
 
 pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Client> {
@@ -46,9 +48,14 @@ impl EventHandler for Handler {
         if message.author.id.get() == self.bot_user_id {
             return;
         }
-        let Some(text) = filter(&message, self.bot_user_id, &self.bot_name) else {
+
+        let images = download_images(&message).await;
+        let text = filter(&message, self.bot_user_id, &self.bot_name);
+
+        if text.is_none() && images.is_empty() {
             return;
-        };
+        }
+        let text = text.unwrap_or_default();
 
         let is_group = message.guild_id.is_some();
         let author_id = message.author.id.get();
@@ -74,10 +81,38 @@ impl EventHandler for Handler {
             bot_identity,
         });
 
-        let action = ConversationAction::NewMessage { msg, user_id, name };
+        let action = ConversationAction::NewMessage {
+            msg,
+            user_id,
+            name,
+            images,
+        };
 
         handle.act(conversation_id, action);
     }
+}
+
+async fn download_images(message: &DMessage) -> Vec<Image> {
+    let mut images = Vec::new();
+    for attachment in &message.attachments {
+        let Some(mime) = attachment.content_type.clone() else {
+            continue;
+        };
+        if !mime.starts_with("image/") {
+            continue;
+        }
+        match attachment.download().await {
+            Ok(bytes) => images.push(Image {
+                bytes: std::sync::Arc::new(bytes),
+                mime,
+            }),
+            Err(err) => eprintln!(
+                "[discord] failed to download image {}: {err}",
+                attachment.filename
+            ),
+        }
+    }
+    images
 }
 
 fn identity(name: &str, id: u64) -> String {

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -4,9 +4,8 @@ use serenity::{async_trait, model::channel::Message as DMessage, prelude::*};
 
 use crate::{
     state_machines::conversation_state_machine::ConversationMachine,
-    types::conversation::{
-        ConversationAction, ConversationConstructor, ConversationId, Image, Platform,
-    },
+    types::conversation::{ConversationAction, ConversationConstructor, ConversationId, Platform},
+    types::media::Image,
 };
 
 pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Client> {

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -3,6 +3,7 @@ use llama_cpp_2::{
     llama_backend::LlamaBackend,
     llama_batch::LlamaBatch,
     model::{params::LlamaModelParams, LlamaModel},
+    mtmd::{MtmdContext, MtmdContextParams},
 };
 use llama_cpp_2::{send_logs_to_tracing, LogOptions};
 use std::{num::NonZero, sync::Arc};
@@ -11,6 +12,8 @@ use tokio::task::{spawn_blocking, JoinHandle};
 use crate::agents::{Agent, PRIMARY_AGENT_IMPL};
 
 pub struct LlamaCppService {
+    #[allow(dead_code)]
+    mtmd: Arc<MtmdContext>,
     primary_model: Arc<LlamaModel>,
     backend: Arc<LlamaBackend>,
     primary_agent: &'static Agent,
@@ -38,6 +41,20 @@ impl LlamaCppService {
         Ok(model)
     }
 
+    fn mtmd_context(model: &LlamaModel) -> anyhow::Result<MtmdContext> {
+        let mmproj_path = std::env::var("MMPROJ_PATH")
+            .unwrap_or_else(|_| "./models/mmproj-Qwen3.6-27B-BF16.gguf".to_string());
+        println!("Loading multimodal projector from: {}", mmproj_path);
+        let mtmd = MtmdContext::init_from_file(&mmproj_path, model, &MtmdContextParams::default())?;
+        println!(
+            "Loaded multimodal projector from: {} (vision={}, audio={})",
+            mmproj_path,
+            mtmd.support_vision(),
+            mtmd.support_audio()
+        );
+        Ok(mtmd)
+    }
+
     pub async fn new() -> anyhow::Result<Self> {
         send_logs_to_tracing(LogOptions::default().with_logs_enabled(false));
 
@@ -47,18 +64,20 @@ impl LlamaCppService {
 
         let backend_arc = Arc::new(backend);
 
-        let primary_task: JoinHandle<anyhow::Result<Arc<LlamaModel>>> = {
+        let primary_task: JoinHandle<anyhow::Result<(Arc<LlamaModel>, Arc<MtmdContext>)>> = {
             let backend = Arc::clone(&backend_arc);
             spawn_blocking(move || {
                 let model_params = LlamaModelParams::default();
-                let model = Arc::new(Self::primary_model(backend.as_ref(), &model_params)?);
-                Ok(model)
+                let model = Self::primary_model(backend.as_ref(), &model_params)?;
+                let mtmd = Self::mtmd_context(&model)?;
+                Ok((Arc::new(model), Arc::new(mtmd)))
             })
         };
 
-        let primary_model = primary_task.await??;
+        let (primary_model, mtmd) = primary_task.await??;
 
         Ok(Self {
+            mtmd,
             primary_model,
             backend: backend_arc,
             primary_agent,

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -101,7 +101,7 @@ fn handle_outcome(
         let mut pending_tools = HashMap::new();
         for tool_call in response.tool_calls {
             effects.enqueue_external(execute_tool(
-                env.clone(),
+                Arc::clone(&env),
                 tool_call.clone(),
                 conversation_id.to_string(),
                 recent_conversation.history.clone(),
@@ -139,7 +139,7 @@ fn conversation_transition(
             last_transition: Utc::now(),
             ..conversation
         }),
-        (user_state, ConversationAction::NewMessage { msg, user_id, name }) => {
+        (user_state, ConversationAction::NewMessage { msg, user_id, name, images }) => {
             let mut pending = conversation.pending;
             let queued = !matches!(&user_state, ConversationState::Idle { .. });
             pending.push(ConversationMessage {
@@ -147,6 +147,7 @@ fn conversation_transition(
                 queued,
                 user_id: user_id.clone(),
                 name: name.clone(),
+                images: images.clone(),
             });
 
             Ok(Conversation {
@@ -190,7 +191,7 @@ fn conversation_transition(
                 match message_to_send {
                     Some(message) => {
                         effects.enqueue_external(send_message(
-                            env.clone(),
+                            Arc::clone(&env),
                             conversation_id.clone(),
                             message,
                         ));
@@ -285,7 +286,7 @@ fn conversation_transition(
 
                 let history = recent_conversation.history();
                 effects.enqueue_external(get_llm_decision(
-                    env.clone(),
+                    Arc::clone(&env),
                     current_input.clone(),
                     Some(recent_conversation),
                     tool_rounds,
@@ -327,7 +328,7 @@ fn conversation_transition(
             println!("Timed Out");
 
             effects.enqueue_external(commit_to_memory(
-                env.clone(),
+                Arc::clone(&env),
                 conversation_id.to_string(),
                 recent_conversation.history.clone(),
             ));
@@ -366,6 +367,7 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
             .map(|m| m.user_id.clone())
             .unwrap_or_default();
         let name = drained.last().map(|m| m.name.clone()).unwrap_or_default();
+        let images = drained.iter().flat_map(|m| m.images.clone()).collect();
         let text = drained
             .into_iter()
             .map(|m| m.text)
@@ -376,6 +378,7 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
             queued,
             user_id,
             name,
+            images,
         }
     })
 }
@@ -410,7 +413,7 @@ fn post_transition(
     let current_input = LLMInput::ConversationMessage(msg);
 
     effects.enqueue_external(get_llm_decision(
-        env.clone(),
+        Arc::clone(&env),
         current_input.clone(),
         recent_conversation.map(|(rc, _)| rc),
         0,

--- a/chatbot/src/types.rs
+++ b/chatbot/src/types.rs
@@ -1,1 +1,2 @@
 pub mod conversation;
+pub mod media;

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::sync::Arc;
 use strum::{EnumDiscriminants, EnumIter};
 
 pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 2000;
@@ -91,12 +92,28 @@ impl Default for ConversationState {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Image {
+    pub bytes: Arc<Vec<u8>>,
+    pub mime: String,
+}
+
+impl std::fmt::Debug for Image {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Image")
+            .field("mime", &self.mime)
+            .field("bytes", &format_args!("{} bytes", self.bytes.len()))
+            .finish()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationMessage {
     pub text: String,
     pub queued: bool,
         pub user_id: String,
         pub name: String,
+        pub images: Vec<Image>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -276,6 +293,7 @@ pub enum ConversationAction {
                 msg: String,
         user_id: String,
         name: String,
+        images: Vec<Image>,
     },
     Timeout,
     CommitResult(Result<(), String>),

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use crate::types::media::Image;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::sync::Arc;
 use strum::{EnumDiscriminants, EnumIter};
 
 pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 2000;
@@ -89,21 +89,6 @@ impl Default for ConversationState {
         ConversationState::Idle {
             recent_conversation: None,
         }
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Image {
-    pub bytes: Arc<Vec<u8>>,
-    pub mime: String,
-}
-
-impl std::fmt::Debug for Image {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Image")
-            .field("mime", &self.mime)
-            .field("bytes", &format_args!("{} bytes", self.bytes.len()))
-            .finish()
     }
 }
 

--- a/chatbot/src/types/media.rs
+++ b/chatbot/src/types/media.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Image {
+    pub bytes: Arc<Vec<u8>>,
+    pub mime: String,
+}
+
+impl std::fmt::Debug for Image {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Image")
+            .field("mime", &self.mime)
+            .field("bytes", &format_args!("{} bytes", self.bytes.len()))
+            .finish()
+    }
+}

--- a/probe/Cargo.toml
+++ b/probe/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.102"
 encoding_rs = "0.8.35"
-llama-cpp-2 = { version = "0.1.146", features = ["vulkan"] }
+llama-cpp-2 = { version = "0.1.146", features = ["vulkan", "mtmd"] }
 serde_json = "1.0.150"

--- a/probe/src/main.rs
+++ b/probe/src/main.rs
@@ -2,183 +2,103 @@ use llama_cpp_2::{
     context::params::LlamaContextParams,
     llama_backend::LlamaBackend,
     llama_batch::LlamaBatch,
-    model::{params::LlamaModelParams, AddBos, LlamaChatTemplate, LlamaModel},
-    openai::OpenAIChatTemplateParams,
+    model::{params::LlamaModelParams, LlamaModel},
+    mtmd::{MtmdBitmap, MtmdContext, MtmdContextParams, MtmdInputText},
     sampling::LlamaSampler,
     send_logs_to_tracing, LogOptions,
 };
 use std::{io::Write, num::NonZero};
 
 const MODEL: &str = "/home/zireael9797/Repos/bot/chatbot/models/Qwen3.6-27B-Q4_K_M.gguf";
+const MMPROJ: &str = "/home/zireael9797/Repos/bot/chatbot/models/mmproj-Qwen3.6-27B-BF16.gguf";
 const N_CTX: u32 = 8192;
-const MAX_TOKENS: usize = 1024;
-const REASONING_FORMAT: &str = "auto"; 
+const N_BATCH: i32 = 512;
+const MAX_TOKENS: usize = 512;
 
-const TOOLS: &str = r#"[{"type":"function","function":{
-  "name":"get_weather",
-  "description":"Get the current weather for a city",
-  "parameters":{"type":"object","properties":{
-    "city":{"type":"string","description":"City name, e.g. Paris"}},
-    "required":["city"]}}}]"#;
-
-struct Probe {
-    backend: LlamaBackend,
-    model: LlamaModel,
-    template: LlamaChatTemplate,
-}
-
-impl Probe {
-    fn load() -> anyhow::Result<Self> {
-        send_logs_to_tracing(LogOptions::default().with_logs_enabled(false));
-        let backend = LlamaBackend::init()?;
-        let model = LlamaModel::load_from_file(
-            &backend,
-            MODEL,
-            &LlamaModelParams::default().with_n_gpu_layers(999),
-        )?;
-        let template = model.chat_template(None)?;
-        Ok(Self { backend, model, template })
-    }
-
-        fn respond(&self, history: &serde_json::Value) -> anyhow::Result<serde_json::Value> {
-        let messages_json = history.to_string();
-        let params = OpenAIChatTemplateParams {
-            messages_json: &messages_json,
-            tools_json: Some(TOOLS),
-            tool_choice: None,
-            json_schema: None,
-            grammar: None,
-            reasoning_format: Some(REASONING_FORMAT),
-            chat_template_kwargs: None,
-            add_generation_prompt: true,
-            use_jinja: true,
-            parallel_tool_calls: false,
-            enable_thinking: true,
-            add_bos: false,
-            add_eos: false,
-            parse_tool_calls: true,
-        };
-        let rendered = self.model.apply_chat_template_oaicompat(&self.template, &params)?;
-        print!("{}\n<Prompt / Output>\n\n", rendered.prompt);
-        std::io::stdout().flush()?;
-        let raw = self.generate(&rendered.prompt)?;
-        let parsed = rendered.parse_response_oaicompat(&raw, false)?;
-        Ok(serde_json::from_str(&parsed)?)
-    }
-
-        fn generate(&self, prompt: &str) -> anyhow::Result<String> {
-        let mut ctx = self.model.new_context(
-            &self.backend,
-            LlamaContextParams::default().with_n_ctx(Some(NonZero::new(N_CTX).unwrap())),
-        )?;
-        let tokens = self.model.str_to_token(prompt, AddBos::Never)?;
-        let mut batch = LlamaBatch::new(N_CTX as usize, 1);
-        let last = tokens.len() - 1;
-        for (i, t) in tokens.iter().enumerate() {
-            batch.add(*t, i as i32, &[0], i == last)?;
-        }
-        ctx.decode(&mut batch)?;
-
-        let mut sampler = LlamaSampler::chain_simple([
-            LlamaSampler::temp(0.6),
-            LlamaSampler::top_k(20),
-            LlamaSampler::top_p(0.95, 1),
-            LlamaSampler::dist(0),
-        ]);
-
-        let mut decoder = encoding_rs::UTF_8.new_decoder();
-
-        let mut out = String::new();
-        let mut n_cur = tokens.len() as i32;
-        let mut last_idx = batch.n_tokens() - 1;
-        for _ in 0..MAX_TOKENS {
-            let tok = sampler.sample(&ctx, last_idx);
-            if self.model.is_eog_token(tok) {
-                break;
+fn make_image() -> (u32, u32, Vec<u8>) {
+    let (w, h) = (512u32, 512u32);
+    let (cx, cy, r) = (256.0f32, 256.0f32, 180.0f32);
+    let mut data = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let dx = x as f32 - cx;
+            let dy = y as f32 - cy;
+            if dx * dx + dy * dy <= r * r {
+                data.extend_from_slice(&[220, 20, 20]);
+            } else {
+                data.extend_from_slice(&[255, 255, 255]);
             }
-            let piece = self.model.token_to_piece(tok, &mut decoder, true, None)?;
-            print!("{piece}");
-            std::io::stdout().flush()?;
-            out.push_str(&piece);
-            batch.clear();
-            batch.add(tok, n_cur, &[0], true)?;
-            ctx.decode(&mut batch)?;
-            n_cur += 1;
-            last_idx = batch.n_tokens() - 1;
-        }
-        Ok(out)
-    }
-}
-
-fn push(history: &mut serde_json::Value, msg: serde_json::Value) {
-    history.as_array_mut().expect("history is an array").push(msg);
-}
-
-fn for_history(mut assistant: serde_json::Value) -> serde_json::Value {
-    if let Some(obj) = assistant.as_object_mut() {
-        obj.remove("reasoning_content");
-        if let Some(c) = obj.get("content").and_then(|v| v.as_str()) {
-            let cleaned = strip_think(c);
-            obj.insert("content".to_string(), serde_json::Value::String(cleaned));
         }
     }
-    assistant
-}
-
-fn strip_think(s: &str) -> String {
-    match (s.find("<think>"), s.find("</think>")) {
-        (Some(a), Some(b)) if b >= a => {
-            let end = b + "</think>".len();
-            format!("{}{}", &s[..a], &s[end..]).trim().to_string()
-        }
-        (None, Some(b)) => s[b + "</think>".len()..].trim().to_string(),
-        _ => s.trim().to_string(),
-    }
-}
-
-fn content_lower(msg: &serde_json::Value) -> String {
-    msg.get("content").and_then(|v| v.as_str()).unwrap_or("").to_lowercase()
+    (w, h, data)
 }
 
 fn main() -> anyhow::Result<()> {
-    let probe = Probe::load()?;
+    send_logs_to_tracing(LogOptions::default().with_logs_enabled(false));
+    let backend = LlamaBackend::init()?;
+    let model = LlamaModel::load_from_file(
+        &backend,
+        MODEL,
+        &LlamaModelParams::default().with_n_gpu_layers(999),
+    )?;
+    println!("model loaded");
 
-    let mut history = serde_json::json!([
-        {"role": "user", "content": "What's the capital of France"}
+    let mtmd = MtmdContext::init_from_file(MMPROJ, &model, &MtmdContextParams::default())?;
+    println!("mtmd loaded — support_vision={} support_audio={}", mtmd.support_vision(), mtmd.support_audio());
+    anyhow::ensure!(mtmd.support_vision(), "mmproj does not advertise vision support");
+
+    let (w, h, rgb) = make_image();
+    let bitmap = MtmdBitmap::from_image_data(w, h, &rgb)?;
+    println!("synthetic image: {}x{} red circle on white", bitmap.nx(), bitmap.ny());
+
+    let prompt = "<|im_start|>user\n<__media__>\nWhat is the main shape and color in this image? Answer in one short sentence.<|im_end|>\n<|im_start|>assistant\n";
+    let chunks = mtmd.tokenize(
+        MtmdInputText {
+            text: prompt.to_string(),
+            add_special: true,
+            parse_special: true,
+        },
+        &[&bitmap],
+    )?;
+    println!("tokenized: {} chunks, {} tokens", chunks.len(), chunks.total_tokens());
+
+    let mut ctx = model.new_context(
+        &backend,
+        LlamaContextParams::default().with_n_ctx(Some(NonZero::new(N_CTX).unwrap())),
+    )?;
+
+    let n_past = chunks.eval_chunks(&mtmd, &ctx, 0, 0, N_BATCH, true)?;
+    println!("\n<<< image + prompt evaluated (n_past={n_past}) >>>\n");
+
+    let mut sampler = LlamaSampler::chain_simple([
+        LlamaSampler::temp(0.6),
+        LlamaSampler::top_k(20),
+        LlamaSampler::top_p(0.95, 1),
+        LlamaSampler::dist(0),
     ]);
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+    let mut out = String::new();
+    let mut n_cur = n_past;
+    let mut tok = sampler.sample(&ctx, -1);
+    let mut batch = LlamaBatch::new(N_CTX as usize, 1);
+    for _ in 0..MAX_TOKENS {
+        if model.is_eog_token(tok) {
+            break;
+        }
+        let piece = model.token_to_piece(tok, &mut decoder, true, None)?;
+        print!("{piece}");
+        std::io::stdout().flush()?;
+        out.push_str(&piece);
+        batch.clear();
+        batch.add(tok, n_cur, &[0], true)?;
+        ctx.decode(&mut batch)?;
+        n_cur += 1;
+        tok = sampler.sample(&ctx, batch.n_tokens() - 1);
+    }
 
-    println!("\n################ TURN 1 ################\n");
-    let r1 = probe.respond(&history)?;
-    println!("\n--- parsed ---\n{r1}");
-    assert!(content_lower(&r1).contains("paris"), "TURN 1: expected 'paris', got: {r1}");
-    println!("\n✓ turn 1 response contains \"paris\"");
-    push(&mut history, for_history(r1));
-
-    println!("\n################ TURN 2 ################\n");
-    push(&mut history, serde_json::json!(
-        {"role": "user", "content": "What's the temparature there? say it like \"20 degree celsius\""}
-    ));
-    let r2 = probe.respond(&history)?;
-    println!("\n--- parsed ---\n{r2}");
-    let calls = r2.get("tool_calls").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let called_weather = calls
-        .iter()
-        .any(|c| c.pointer("/function/name").and_then(|n| n.as_str()) == Some("get_weather"));
-    assert!(called_weather, "TURN 2: expected a get_weather tool call, got: {r2}");
-    println!("\n✓ turn 2 called the get_weather tool");
-    let tool_id = calls[0].get("id").and_then(|v| v.as_str()).unwrap_or("call_0").to_string();
-    push(&mut history, for_history(r2));
-
-    push(&mut history, serde_json::json!(
-        {"role": "tool", "tool_call_id": tool_id, "content": "{\"temperature_celsius\": 25}"}
-    ));
-
-    println!("\n################ TURN 3 ################\n");
-    let r3 = probe.respond(&history)?;
-    println!("\n--- parsed ---\n{r3}");
-    assert!(content_lower(&r3).contains("degree celsius"), "TURN 3: expected 'degree celsius', got: {r3}");
-    println!("\n✓ turn 3 response contains \"degree celsius\"");
-
-    println!("\n✅ all 3 turns passed");
+    println!("\n\n--- check ---");
+    let low = out.to_lowercase();
+    anyhow::ensure!(low.contains("red"), "expected 'red' in description, got: {out}");
+    println!("✅ vision works: model saw the image and described it (mentions 'red')");
     Ok(())
 }

--- a/re_framework/Cargo.toml
+++ b/re_framework/Cargo.toml
@@ -9,3 +9,6 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 dashmap = "6"
+
+[lints]
+workspace = true

--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -43,7 +43,7 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
                 let (tx, rx) = mpsc::unbounded_channel();
                 let mut effects = Effects::new(id.clone());
                 let state = SM::construct(construction, &mut effects);
-                tokio::spawn(run_entity::<SM>(state, rx, self.env.clone(), id, effects));
+                tokio::spawn(run_entity::<SM>(state, rx, Arc::clone(&self.env), id, effects));
                 slot.insert(SoleMailboxHandle { sender: tx });
             }
         }

--- a/re_framework/src/smoke.rs
+++ b/re_framework/src/smoke.rs
@@ -109,7 +109,7 @@ impl StateMachine for CounterMachine {
 async fn smoke() {
     let obs = Arc::new(Mutex::new(Obs::default()));
     COUNTER
-        .set(StateMachineHandle::<CounterMachine>::new(CounterEnv { obs: obs.clone() }))
+        .set(StateMachineHandle::<CounterMachine>::new(CounterEnv { obs: Arc::clone(&obs) }))
         .ok()
         .expect("set COUNTER once");
     let sm = CounterMachine::handle();
@@ -244,11 +244,11 @@ impl StateMachine for PingerMachine {
 async fn outbound() {
     let received = Arc::new(Mutex::new(Vec::<i64>::new()));
     PONGER
-        .set(StateMachineHandle::<PongerMachine>::new(RtEnv { received: received.clone() }))
+        .set(StateMachineHandle::<PongerMachine>::new(RtEnv { received: Arc::clone(&received) }))
         .ok()
         .expect("set PONGER once");
     PINGER
-        .set(StateMachineHandle::<PingerMachine>::new(RtEnv { received: received.clone() }))
+        .set(StateMachineHandle::<PingerMachine>::new(RtEnv { received: Arc::clone(&received) }))
         .ok()
         .expect("set PINGER once");
     let ponger = PongerMachine::handle();


### PR DESCRIPTION
First slice of vision support. This wires images **in** end-to-end on the Discord side and loads the multimodal projector, but does **not** yet feed images to the model — that inference work is a deliberate follow-up PR. The seam is in place and logged.

## What's here

**Load the multimodal projector (`5ae1808`)**
- Load the `mmproj` GGUF into an `MtmdContext` at startup alongside the primary model; log `vision`/`audio` support. Held but unused for now (`#[allow(dead_code)]`).

**Stop the model claiming it was made by Google (`6176656`)**
- System-prompt hardening.

**Thread Discord image attachments to the LLM external (`1225b83`)**
- New `Image { bytes: Arc<Vec<u8>>, mime }` type (custom `Debug` prints mime + byte length, never raw bytes).
- Discord handler downloads `image/*` attachments and now proceeds on **image-only** messages (returns early only when both text and images are empty).
- Threaded `NewMessage { …, images }` → `ConversationMessage { …, images }` → `LLMInput` → `current_input`, arriving at `llama_cpp_external` where a count is logged. Images are **not** added to the OpenAI JSON, so the prompt is unchanged.
- `take_pending` flattens images across merged pending messages.
- Bytes are `Arc`-wrapped so the per-transition `state.clone()` stays O(1); needs serde's `rc` feature.

**Enforce `Arc::clone(&x)` for ref-counted pointers**
- `clippy::clone_on_ref_ptr = "deny"` defined in `[workspace.lints.clippy]`; `chatbot` and `re_framework` opt in via `[lints] workspace = true`. Existing `env`/handle Arc clones rewritten.

## Not in scope (follow-up PR)
- Feeding images to the model (mtmd tokenize + `eval_chunks`) — the working recipe lives in `probe/src/main.rs`.
- **Persistence:** images currently ride along in history and would be serialized into the long-term-memory commit. The feeding PR should strip them from stored history (only useful for the live turn).
- **Bundle the model + mtmd context:** `LlamaCppService` holds `Arc<LlamaModel>` and `Arc<MtmdContext>` as two independent fields. `MtmdContext` carries no lifetime, but the C context is initialized from the text model and retains its pointer — so the model **must outlive** the mtmd context, an invariant the Rust types don't encode (safe today only because both live in the long-lived service). When mtmd stops being dead code, bundle them so the invariant is explicit — e.g. one `Arc<Multimodal { model: Arc<LlamaModel>, mtmd: MtmdContext }>`, or have the mtmd owner hold its own `Arc<LlamaModel>`. Bonus: the multimodal blocking worker (which needs both) then clones one Arc instead of two; the text-only path pays nothing (Arc bump, no copy).

## Verification
- `cargo check --workspace` clean (pre-existing dead-code warnings only).
- `cargo clippy -p chatbot -p re_framework --tests` → 0 `clone_on_ref_ptr`, exit 0.
- `re_framework` smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
