### PR TITLE
Image support, part 2: feed images to the model (mtmd vision inference)

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -6,23 +6,27 @@ use std::{
 };
 
 use llama_cpp_2::{
-    context::params::LlamaContextParams,
+    context::{params::LlamaContextParams, LlamaContext},
     llama_backend::LlamaBackend,
     model::{AddBos, LlamaModel},
+    mtmd::{MtmdBitmap, MtmdInputText},
     openai::OpenAIChatTemplateParams,
     sampling::LlamaSampler,
 };
 pub use primary_agent::*;
 use tokio::task::spawn_blocking;
 
-use crate::{configuration::debug::DEBUG_LIVE_LLM_OUTPUT, services::llama_cpp::LlamaCppService};
+use crate::{
+    configuration::debug::DEBUG_LIVE_LLM_OUTPUT,
+    services::llama_cpp::{LlamaCppService, PrimaryModel},
+};
 
-const MAX_THINKING_TOKENS: usize = 2048;
+const MAX_THINKING_TOKENS: usize = 600;
 
 const THINKING_FORCE_CLOSE: &str =
     "\n\nWait — I'm going in circles. I have enough to answer the user now, so I'll stop thinking and respond.\n</think>\n\n";
 
-fn run_generation(
+fn run_generation_text(
     model: &LlamaModel,
     backend: &LlamaBackend,
     ctx_params: LlamaContextParams,
@@ -33,25 +37,73 @@ fn run_generation(
     let mut ctx = model.new_context(backend, ctx_params)?;
 
     let tokens = model.str_to_token(prompt, AddBos::Never)?;
-
     let mut batch = LlamaCppService::new_batch();
     let last = tokens.len() - 1;
-    let mut last_idx = 0;
     for (i, t) in tokens.iter().enumerate() {
         batch.add(*t, i as i32, &[0], i == last)?;
         if batch.n_tokens() >= batch_chunk_size as i32 {
             ctx.decode(&mut batch)?;
-            last_idx = batch.n_tokens() - 1;
             batch.clear();
         }
     }
     if batch.n_tokens() > 0 {
         ctx.decode(&mut batch)?;
-        last_idx = batch.n_tokens() - 1;
     }
-    let mut n_cur = tokens.len() as i32;
 
+    log_prompt(prompt);
+    generate(model, &mut ctx, tokens.len() as i32, temperature)
+}
+
+fn log_prompt(prompt: &str) {
+    if DEBUG_LIVE_LLM_OUTPUT {
+        print!("{prompt}\n<<< generation >>>\n");
+        let _ = io::stdout().flush();
+    }
+}
+
+fn run_generation_mtmd(
+    primary: &PrimaryModel,
+    backend: &LlamaBackend,
+    ctx_params: LlamaContextParams,
+    batch_chunk_size: usize,
+    prompt: &str,
+    images: &[Arc<Vec<u8>>],
+    temperature: f32,
+) -> anyhow::Result<String> {
+    let model = primary.model.as_ref();
+    let mtmd = &primary.mtmd;
+
+    let bitmaps = images
+        .iter()
+        .map(|bytes| MtmdBitmap::from_buffer(mtmd, bytes))
+        .collect::<Result<Vec<_>, _>>()?;
+    let bitmap_refs: Vec<&MtmdBitmap> = bitmaps.iter().collect();
+
+    let mut ctx = model.new_context(backend, ctx_params)?;
+
+    let chunks = mtmd.tokenize(
+        MtmdInputText {
+            text: prompt.to_string(),
+            add_special: false,
+            parse_special: true,
+        },
+        &bitmap_refs,
+    )?;
+
+    let n_past = chunks.eval_chunks(mtmd, &ctx, 0, 0, batch_chunk_size as i32, true)?;
+
+    log_prompt(prompt);
+    generate(model, &mut ctx, n_past, temperature)
+}
+
+fn generate(
+    model: &LlamaModel,
+    ctx: &mut LlamaContext,
+    mut n_cur: i32,
+    temperature: f32,
+) -> anyhow::Result<String> {
     let mut sampler = LlamaSampler::chain_simple([
+        LlamaSampler::dry(model, 0.8, 1.75, 2, -1, ["\n", ":", "\"", "*"]),
         LlamaSampler::temp(temperature),
         LlamaSampler::top_k(20),
         LlamaSampler::top_p(0.95, 1),
@@ -61,6 +113,7 @@ fn run_generation(
     let mut out_bytes: Vec<u8> = Vec::new();
     let mut printed = 0usize;
     let max_generation_tokens = LlamaCppService::get_max_generation_tokens();
+    let mut batch = LlamaCppService::new_batch();
 
     let mut thinking_closed = false;
 
@@ -83,7 +136,6 @@ fn run_generation(
             batch.add(tok, n_cur, &[0], true)?;
             ctx.decode(&mut batch)?;
             n_cur += 1;
-            last_idx = batch.n_tokens() - 1;
         }};
     }
 
@@ -95,7 +147,7 @@ fn run_generation(
             thinking_closed = true;
         }
 
-        let token = sampler.sample(&ctx, last_idx);
+        let token = sampler.sample(ctx, -1);
         if model.is_eog_token(token) {
             break;
         }
@@ -112,12 +164,14 @@ fn run_generation(
 fn respond_blocking(
     agent: &'static Agent,
     ctx_params: LlamaContextParams,
-    model: Arc<LlamaModel>,
+    primary: Arc<PrimaryModel>,
     backend: Arc<LlamaBackend>,
     batch_chunk_size: usize,
     conversation: serde_json::Value,
+    images: Vec<Arc<Vec<u8>>>,
     allow_tools: bool,
 ) -> anyhow::Result<serde_json::Value> {
+    let model = primary.model.as_ref();
     let mut messages = vec![serde_json::json!({
         "role": "system",
         "content": agent.system_content(),
@@ -151,19 +205,26 @@ fn respond_blocking(
     };
     let rendered = model.apply_chat_template_oaicompat(&template, &params)?;
 
-    if DEBUG_LIVE_LLM_OUTPUT {
-        print!("{}\n<<< generation >>>\n", rendered.prompt);
-        let _ = io::stdout().flush();
-    }
-
-    let raw = run_generation(
-        model.as_ref(),
-        backend.as_ref(),
-        ctx_params,
-        batch_chunk_size,
-        &rendered.prompt,
-        agent.temperature(),
-    )?;
+    let raw = if images.is_empty() {
+        run_generation_text(
+            model,
+            backend.as_ref(),
+            ctx_params,
+            batch_chunk_size,
+            &rendered.prompt,
+            agent.temperature(),
+        )?
+    } else {
+        run_generation_mtmd(
+            primary.as_ref(),
+            backend.as_ref(),
+            ctx_params,
+            batch_chunk_size,
+            &rendered.prompt,
+            &images,
+            agent.temperature(),
+        )?
+    };
 
     let parsed = rendered.parse_response_oaicompat(&raw, false)?;
     Ok(serde_json::from_str(&parsed)?)
@@ -193,20 +254,22 @@ impl Agent {
     pub async fn respond(
         &'static self,
         ctx_params: LlamaContextParams,
-        model: Arc<LlamaModel>,
+        primary: Arc<PrimaryModel>,
         backend: Arc<LlamaBackend>,
         batch_chunk_size: usize,
         conversation: serde_json::Value,
+        images: Vec<Arc<Vec<u8>>>,
         allow_tools: bool,
     ) -> anyhow::Result<serde_json::Value> {
         let task = spawn_blocking(move || {
             respond_blocking(
                 self,
                 ctx_params,
-                model,
+                primary,
                 backend,
                 batch_chunk_size,
                 conversation,
+                images,
                 allow_tools,
             )
         });

--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -23,6 +23,8 @@ use crate::{
 
 const MAX_THINKING_TOKENS: usize = 600;
 
+const ADD_BOS_REEVAL_WHEN_CACHING_HITS: bool = false;
+
 const THINKING_FORCE_CLOSE: &str =
     "\n\nWait — I'm going in circles. I have enough to answer the user now, so I'll stop thinking and respond.\n</think>\n\n";
 
@@ -36,7 +38,7 @@ fn run_generation_text(
 ) -> anyhow::Result<String> {
     let mut ctx = model.new_context(backend, ctx_params)?;
 
-    let tokens = model.str_to_token(prompt, AddBos::Never)?;
+    let tokens = model.str_to_token(prompt, if ADD_BOS_REEVAL_WHEN_CACHING_HITS { AddBos::Always } else { AddBos::Never })?;
     let mut batch = LlamaCppService::new_batch();
     let last = tokens.len() - 1;
     for (i, t) in tokens.iter().enumerate() {
@@ -84,7 +86,7 @@ fn run_generation_mtmd(
     let chunks = mtmd.tokenize(
         MtmdInputText {
             text: prompt.to_string(),
-            add_special: false,
+            add_special: ADD_BOS_REEVAL_WHEN_CACHING_HITS,
             parse_special: true,
         },
         &bitmap_refs,

--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -13,6 +13,7 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     the id, not the name. Default to silence: reply only when addressed, or rarely interject when \
     you genuinely add something. To stay silent, reply with exactly `<empty>` (it sends nothing).\n\n\
     DIRECT MESSAGE: a normal one-to-one conversation.\n\n\
+    With images, look fresh each turn — don't assume your earlier description of one was right.\n\n\
     Tools: call them (one or several) when they help; answer once you have enough.\n\n\
     A message tagged [Followup] arrived while you were busy (people see only your replies, never \
     tool calls). Build on what you already produced rather than repeating; in a group, first judge \

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -7,6 +7,7 @@ use crate::{
     Env,
 };
 use chrono::Utc;
+use llama_cpp_2::mtmd::mtmd_default_marker;
 use serde_json::{json, Value};
 
 use std::sync::Arc;
@@ -67,21 +68,29 @@ fn build_conversation(
     max_tool_rounds: usize,
     is_group: bool,
     bot_identity: &str,
-) -> Value {
+) -> (Value, Vec<Arc<Vec<u8>>>) {
     let history = maybe_recent_conversation
         .map(|rc| rc.history)
         .unwrap_or_default();
 
+    let marker = mtmd_default_marker();
     let mut messages: Vec<Value> = Vec::new();
+    let mut images: Vec<Arc<Vec<u8>>> = Vec::new();
 
     for entry in &history {
         match entry {
-            HistoryEntry::Input(input) => messages.extend(input.to_openai_messages()),
+            HistoryEntry::Input(input) => {
+                let (msgs, bytes) = input.messages_and_media(marker);
+                messages.extend(msgs);
+                images.extend(bytes);
+            }
             HistoryEntry::Output(response) => messages.push(response.to_openai_message()),
         }
     }
 
-    messages.extend(new_input.to_openai_messages());
+    let (live_msgs, live_bytes) = new_input.messages_and_media(marker);
+    messages.extend(live_msgs);
+    images.extend(live_bytes);
 
     messages.push(session_context_block(
         is_group,
@@ -90,7 +99,7 @@ fn build_conversation(
         max_tool_rounds,
     ));
 
-    Value::Array(messages)
+    (Value::Array(messages), images)
 }
 
 fn all_tool_calls(parsed: &Value) -> Vec<(String, String, String)> {
@@ -127,7 +136,7 @@ async fn get_response_from_llm(
     is_group: bool,
     bot_identity: &str,
 ) -> anyhow::Result<LLMResponse> {
-    let conversation = build_conversation(
+    let (conversation, images) = build_conversation(
         current_input,
         maybe_recent_conversation,
         tool_rounds,
@@ -142,16 +151,12 @@ async fn get_response_from_llm(
         serde_json::to_string_pretty(&conversation).unwrap_or_default()
     );
 
-    let image_count = match current_input {
-        LLMInput::ConversationMessage(m) => m.images.len(),
-        LLMInput::ToolResults(_, user_msg) => user_msg.as_ref().map_or(0, |m| m.images.len()),
-    };
-    if image_count > 0 {
-        println!("[image] {image_count} image(s) reached the LLM external (not yet fed to the model)");
+    if !images.is_empty() {
+        println!("[image] feeding {} image(s) to the model", images.len());
     }
 
     let parsed = llama_cpp
-        .get_primary_response(conversation, allow_tools)
+        .get_primary_response(conversation, images, allow_tools)
         .await?;
 
     let thoughts = parsed

--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -5,7 +5,7 @@ use serenity::{async_trait, model::channel::Message as DMessage, prelude::*};
 use crate::{
     state_machines::conversation_state_machine::ConversationMachine,
     types::conversation::{ConversationAction, ConversationConstructor, ConversationId, Platform},
-    types::media::Image,
+    types::media::{Image, MessageImage},
 };
 
 pub async fn prepare_discord_client(discord_token: &str) -> anyhow::Result<Client> {
@@ -91,7 +91,7 @@ impl EventHandler for Handler {
     }
 }
 
-async fn download_images(message: &DMessage) -> Vec<Image> {
+async fn download_images(message: &DMessage) -> Vec<MessageImage> {
     let mut images = Vec::new();
     for attachment in &message.attachments {
         let Some(mime) = attachment.content_type.clone() else {
@@ -101,10 +101,10 @@ async fn download_images(message: &DMessage) -> Vec<Image> {
             continue;
         }
         match attachment.download().await {
-            Ok(bytes) => images.push(Image {
+            Ok(bytes) => images.push(MessageImage::Hydrated(Image {
                 bytes: std::sync::Arc::new(bytes),
                 mime,
-            }),
+            })),
             Err(err) => eprintln!(
                 "[discord] failed to download image {}: {err}",
                 attachment.filename

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -11,10 +11,16 @@ use tokio::task::{spawn_blocking, JoinHandle};
 
 use crate::agents::{Agent, PRIMARY_AGENT_IMPL};
 
+/// Text model paired with its multimodal projector. `mtmd` is declared first so it
+/// drops before `model`: the C `mtmd_context` retains a pointer to the text model and
+/// must not outlive it.
+pub struct PrimaryModel {
+    pub mtmd: MtmdContext,
+    pub model: Arc<LlamaModel>,
+}
+
 pub struct LlamaCppService {
-    #[allow(dead_code)]
-    mtmd: Arc<MtmdContext>,
-    primary_model: Arc<LlamaModel>,
+    primary: Arc<PrimaryModel>,
     backend: Arc<LlamaBackend>,
     primary_agent: &'static Agent,
 }
@@ -64,21 +70,20 @@ impl LlamaCppService {
 
         let backend_arc = Arc::new(backend);
 
-        let primary_task: JoinHandle<anyhow::Result<(Arc<LlamaModel>, Arc<MtmdContext>)>> = {
+        let primary_task: JoinHandle<anyhow::Result<Arc<PrimaryModel>>> = {
             let backend = Arc::clone(&backend_arc);
             spawn_blocking(move || {
                 let model_params = LlamaModelParams::default();
-                let model = Self::primary_model(backend.as_ref(), &model_params)?;
+                let model = Arc::new(Self::primary_model(backend.as_ref(), &model_params)?);
                 let mtmd = Self::mtmd_context(&model)?;
-                Ok((Arc::new(model), Arc::new(mtmd)))
+                Ok(Arc::new(PrimaryModel { mtmd, model }))
             })
         };
 
-        let (primary_model, mtmd) = primary_task.await??;
+        let primary = primary_task.await??;
 
         Ok(Self {
-            mtmd,
-            primary_model,
+            primary,
             backend: backend_arc,
             primary_agent,
         })
@@ -99,15 +104,17 @@ impl LlamaCppService {
     pub async fn get_primary_response(
         &self,
         conversation: serde_json::Value,
+        images: Vec<Arc<Vec<u8>>>,
         allow_tools: bool,
     ) -> anyhow::Result<serde_json::Value> {
         self.primary_agent
             .respond(
                 Self::context_params(),
-                Arc::clone(&self.primary_model),
+                Arc::clone(&self.primary),
                 Arc::clone(&self.backend),
                 Self::BATCH_CHUNK_SIZE,
                 conversation,
+                images,
                 allow_tools,
             )
             .await

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -11,9 +11,6 @@ use tokio::task::{spawn_blocking, JoinHandle};
 
 use crate::agents::{Agent, PRIMARY_AGENT_IMPL};
 
-/// Text model paired with its multimodal projector. `mtmd` is declared first so it
-/// drops before `model`: the C `mtmd_context` retains a pointer to the text model and
-/// must not outlive it.
 pub struct PrimaryModel {
     pub mtmd: MtmdContext,
     pub model: Arc<LlamaModel>,

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -19,6 +19,11 @@ use std::sync::{Arc, OnceLock};
 type ConversationTransitionResult = anyhow::Result<Conversation>;
 type ConversationEffects = Effects<ConversationMachine>;
 
+/// When true, images are dehydrated (dropped to a note) before entering history. When false
+/// they stay hydrated and are re-fed to the model every turn — experimental, grows context
+/// and VRAM with each turn that carries an image.
+const REDACT_HISTORY_IMAGES: bool = false;
+
 static CONVERSATION: OnceLock<StateMachineHandle<ConversationMachine>> = OnceLock::new();
 
 pub struct ConversationMachine;
@@ -165,8 +170,13 @@ fn conversation_transition(
             ConversationAction::LLMDecisionResult(res),
         ) => match res {
             Ok(response) => {
+                let recorded_input = if REDACT_HISTORY_IMAGES {
+                    current_input.redacted()
+                } else {
+                    current_input
+                };
                 let mut updated_history = history;
-                updated_history.push(HistoryEntry::Input(current_input));
+                updated_history.push(HistoryEntry::Input(recorded_input));
                 updated_history.push(HistoryEntry::Output(response.clone()));
 
                 let updated_conversation = RecentConversation {

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -19,9 +19,6 @@ use std::sync::{Arc, OnceLock};
 type ConversationTransitionResult = anyhow::Result<Conversation>;
 type ConversationEffects = Effects<ConversationMachine>;
 
-/// When true, images are dehydrated (dropped to a note) before entering history. When false
-/// they stay hydrated and are re-fed to the model every turn — experimental, grows context
-/// and VRAM with each turn that carries an image.
 const REDACT_HISTORY_IMAGES: bool = false;
 
 static CONVERSATION: OnceLock<StateMachineHandle<ConversationMachine>> = OnceLock::new();

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use crate::types::media::Image;
+use crate::types::media::MessageImage;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::sync::Arc;
 use strum::{EnumDiscriminants, EnumIter};
 
 pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 2000;
@@ -98,7 +99,7 @@ pub struct ConversationMessage {
     pub queued: bool,
         pub user_id: String,
         pub name: String,
-        pub images: Vec<Image>,
+        pub images: Vec<MessageImage>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,6 +124,45 @@ impl ConversationMessage {
             self.text.clone()
         }
     }
+
+    pub fn redacted(&self) -> ConversationMessage {
+        ConversationMessage {
+            images: self.images.iter().map(MessageImage::dehydrated).collect(),
+            ..self.clone()
+        }
+    }
+
+    /// Content for the model plus the ordered bytes of any hydrated images. Each hydrated
+    /// image contributes one `marker` line (the LLM layer splices its bitmap there) and its
+    /// bytes; dehydrated images contribute a note explaining they were seen earlier.
+    pub fn content_and_media(&self, marker: &str) -> (String, Vec<Arc<Vec<u8>>>) {
+        let mut parts: Vec<String> = Vec::new();
+        let base = self.to_content();
+        if !base.is_empty() {
+            parts.push(base);
+        }
+
+        let mut bytes = Vec::new();
+        let mut dehydrated = 0usize;
+        for image in &self.images {
+            match image.hydrated_bytes() {
+                Some(b) => {
+                    parts.push(marker.to_string());
+                    bytes.push(b);
+                }
+                None => dehydrated += 1,
+            }
+        }
+        if dehydrated > 0 {
+            parts.push(format!(
+                "[{dehydrated} image{} from earlier in the conversation — you saw {} at the time, not re-attached here]",
+                if dehydrated == 1 { "" } else { "s" },
+                if dehydrated == 1 { "it" } else { "them" }
+            ));
+        }
+
+        (parts.join("\n"), bytes)
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -141,18 +181,35 @@ pub enum LLMInput {
 }
 
 impl LLMInput {
-    pub fn to_openai_messages(&self) -> Vec<Value> {
+    pub fn redacted(&self) -> LLMInput {
         match self {
-            LLMInput::ConversationMessage(msg) => vec![json!({ "role": "user", "content": msg.to_content() })],
+            LLMInput::ConversationMessage(m) => LLMInput::ConversationMessage(m.redacted()),
+            LLMInput::ToolResults(results, user) => {
+                LLMInput::ToolResults(results.clone(), user.as_ref().map(ConversationMessage::redacted))
+            }
+        }
+    }
+
+    /// OpenAI-shaped messages plus the ordered bytes of any hydrated images they carry.
+    /// `marker` is the media marker spliced in for each hydrated image.
+    pub fn messages_and_media(&self, marker: &str) -> (Vec<Value>, Vec<Arc<Vec<u8>>>) {
+        match self {
+            LLMInput::ConversationMessage(msg) => {
+                let (content, bytes) = msg.content_and_media(marker);
+                (vec![json!({ "role": "user", "content": content })], bytes)
+            }
             LLMInput::ToolResults(results, user_msg) => {
                 let mut messages: Vec<Value> = results
                     .iter()
                     .map(|r| json!({ "role": "tool", "tool_call_id": r.id, "content": r.data.actual }))
                     .collect();
+                let mut bytes = Vec::new();
                 if let Some(msg) = user_msg {
-                    messages.push(json!({ "role": "user", "content": msg.to_content() }));
+                    let (content, b) = msg.content_and_media(marker);
+                    messages.push(json!({ "role": "user", "content": content }));
+                    bytes = b;
                 }
-                messages
+                (messages, bytes)
             }
         }
     }
@@ -278,7 +335,7 @@ pub enum ConversationAction {
                 msg: String,
         user_id: String,
         name: String,
-        images: Vec<Image>,
+        images: Vec<MessageImage>,
     },
     Timeout,
     CommitResult(Result<(), String>),

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -132,9 +132,6 @@ impl ConversationMessage {
         }
     }
 
-    /// Content for the model plus the ordered bytes of any hydrated images. Each hydrated
-    /// image contributes one `marker` line (the LLM layer splices its bitmap there) and its
-    /// bytes; dehydrated images contribute a note explaining they were seen earlier.
     pub fn content_and_media(&self, marker: &str) -> (String, Vec<Arc<Vec<u8>>>) {
         let mut parts: Vec<String> = Vec::new();
         let base = self.to_content();
@@ -190,8 +187,6 @@ impl LLMInput {
         }
     }
 
-    /// OpenAI-shaped messages plus the ordered bytes of any hydrated images they carry.
-    /// `marker` is the media marker spliced in for each hydrated image.
     pub fn messages_and_media(&self, marker: &str) -> (Vec<Value>, Vec<Arc<Vec<u8>>>) {
         match self {
             LLMInput::ConversationMessage(msg) => {

--- a/chatbot/src/types/media.rs
+++ b/chatbot/src/types/media.rs
@@ -16,8 +16,6 @@ impl std::fmt::Debug for Image {
     }
 }
 
-/// An image that is either carrying its bytes (live, fed to the model) or has been
-/// reduced to its size (persisted in history — never holds bytes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MessageImage {
     Hydrated(Image),

--- a/chatbot/src/types/media.rs
+++ b/chatbot/src/types/media.rs
@@ -15,3 +15,31 @@ impl std::fmt::Debug for Image {
             .finish()
     }
 }
+
+/// An image that is either carrying its bytes (live, fed to the model) or has been
+/// reduced to its size (persisted in history — never holds bytes).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MessageImage {
+    Hydrated(Image),
+    Dehydrated { byte_size: usize },
+}
+
+impl MessageImage {
+    pub fn dehydrated(&self) -> MessageImage {
+        match self {
+            MessageImage::Hydrated(image) => MessageImage::Dehydrated {
+                byte_size: image.bytes.len(),
+            },
+            MessageImage::Dehydrated { byte_size } => {
+                MessageImage::Dehydrated { byte_size: *byte_size }
+            }
+        }
+    }
+
+    pub fn hydrated_bytes(&self) -> Option<Arc<Vec<u8>>> {
+        match self {
+            MessageImage::Hydrated(image) => Some(Arc::clone(&image.bytes)),
+            MessageImage::Dehydrated { .. } => None,
+        }
+    }
+}


### PR DESCRIPTION
Builds on #138 (which threaded Discord images as far as the LLM external). This part runs **actual multimodal inference** on them.

## Inference
- **Bundle model + mtmd** — `Arc<PrimaryModel> { mtmd, model }`; `mtmd` is declared first so it drops before the model (the C `mtmd_context` retains a pointer to the text model and must not outlive it — resolves the lifetime note flagged in #138).
- **mtmd path** — build bitmaps from encoded bytes via `MtmdBitmap::from_buffer` (no manual RGB decode), inject `<__media__>` markers via `mtmd_default_marker()`, `tokenize`, `eval_chunks(logits_last=true)`, then a **sampling loop shared with the text path**. Only prefill differs (text: `str_to_token`+decode; image: `eval_chunks`).
- **`add_special = false`** — matches the existing text path (`AddBos::Never`); the chat template already frames the prompt. Verified against llama.cpp's `mtmd-cli` (its `true`-on-first-message is an incremental-KV artifact; we re-prefill the whole conversation each call).

## Hydration as a type
- `MessageImage::Hydrated(Image)` carries bytes (→ one marker + bitmap, fed to the model); `MessageImage::Dehydrated { byte_size }` carries only the size (→ a "seen earlier" note, no bytes). Same message type can hold a mix.
- **Per-message media rendering** (`content_and_media(marker)`): each hydrated image contributes a marker + its bytes in order; `build_conversation` walks history *and* live, so markers and bitmaps stay aligned across the whole conversation.
- **Redaction wiring kept, gated off** — `REDACT_HISTORY_IMAGES = false`, so images currently **stay hydrated in history and are re-fed every turn** (experimental, to evaluate multi-turn image grounding). Flip the const to `true` to dehydrate into history instead.

## Generation tuning
- **DRY** repetition sampler (`dry(model, 0.8, 1.75, 2, -1, ["\n", ":", "\"", "*"])`) — params match llama.cpp canon, placed first in the chain per its order. Classic `penalties` deliberately not stacked (ships disabled upstream; demotes common tokens).
- **`MAX_THINKING_TOKENS` 2048 → 600** — force-close the `<think>` block ~3× sooner.
- **Slight system-prompt nudge** — reconsider images fresh each turn rather than trusting prior descriptions.
- Image encode/decode now logs **before** the rendered prompt.

## Known tradeoffs / follow-ups
- **Re-feeding cost:** with redaction off, every image-bearing turn re-encodes all prior images — context/VRAM/latency grow with the conversation. That's exactly what the redaction toggle exists to cap.
- **Within-turn tool flows:** if redaction is later turned on, an image is fed only on the first decision of a turn; post-tool synthesis sees the "seen earlier" note, not the image.
- **Downscaling:** deferred. Our pinned crate's `MtmdContextParams` has no `image_max_tokens`, so if large uploads balloon tokens/latency, a threshold-gated downscale at ingestion would be the lever.

## Verification
- `cargo check` / `cargo clippy -p chatbot -p re_framework` clean (0 `clone_on_ref_ptr`).
- Deployed locally; model + mmproj load (`vision=true`) and the mtmd path runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)