### PR TITLE
chatbot: generation tuning — temp 0.6→1.0, thinking budget 600→1000

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -21,7 +21,7 @@ use crate::{
     services::llama_cpp::{LlamaCppService, PrimaryModel},
 };
 
-const MAX_THINKING_TOKENS: usize = 600;
+const MAX_THINKING_TOKENS: usize = 1000;
 
 const ADD_BOS_REEVAL_WHEN_CACHING_HITS: bool = false;
 

--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -18,6 +18,6 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     A message tagged [Followup] arrived while you were busy (people see only your replies, never \
     tool calls). Build on what you already produced rather than repeating; in a group, first judge \
     whether it is even aimed at you — if not, `<empty>`.";
-const TEMPERATURE: f32 = 0.6;
+const TEMPERATURE: f32 = 1.0;
 
 pub const PRIMARY_AGENT_IMPL: Agent = Agent::new(SYSTEM_PROMPT, TEMPERATURE);


### PR DESCRIPTION
Chore from `Bot-SanityCheck` finding #4 / `Bot-SamplingTune`. Two generation-tuning knobs:

- **`TEMPERATURE` 0.6 → 1.0** — Qwen3.6-27B's "general thinking" preset (we were on the
  "precise/coding" preset). `top_k 20` / `top_p 0.95` already match; presence_penalty already
  effectively 0. DRY kept as a repetition safety net for now.
- **`MAX_THINKING_TOKENS` 600 → 1000** — the force-close-the-`<think>`-block budget was too
  tight; give the model more room to reason before we cut it off.

Testing in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)