### PR TITLE
chatbot: context-overflow hard guard (Tier 2, text path)

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -38,7 +38,20 @@ fn run_generation_text(
 ) -> anyhow::Result<String> {
     let mut ctx = model.new_context(backend, ctx_params)?;
 
-    let tokens = model.str_to_token(prompt, if ADD_BOS_REEVAL_WHEN_CACHING_HITS { AddBos::Always } else { AddBos::Never })?;
+    let mut tokens = model.str_to_token(prompt, if ADD_BOS_REEVAL_WHEN_CACHING_HITS { AddBos::Always } else { AddBos::Never })?;
+    let max_input = LlamaCppService::get_context_size() - LlamaCppService::get_max_generation_tokens();
+    if tokens.len() > max_input {
+        let head = (max_input / 4).min(2048);
+        let tail = max_input - head;
+        let dropped = tokens.len() - max_input;
+        eprintln!(
+            "[ctx] prompt {} tokens exceeds budget {max_input}; dropping {dropped} middle tokens",
+            tokens.len()
+        );
+        let mut trimmed = tokens[..head].to_vec();
+        trimmed.extend_from_slice(&tokens[tokens.len() - tail..]);
+        tokens = trimmed;
+    }
     let mut batch = LlamaCppService::new_batch();
     let last = tokens.len() - 1;
     for (i, t) in tokens.iter().enumerate() {

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -31,6 +31,10 @@ impl LlamaCppService {
         Self::MAX_GENERATION_TOKENS
     }
 
+    pub const fn get_context_size() -> usize {
+        Self::CONTEXT_SIZE.get() as usize
+    }
+
     fn primary_model(
         backend: &LlamaBackend,
         model_params: &LlamaModelParams,


### PR DESCRIPTION
Chore from `Bot-SanityCheck` finding #2 / `Bot-ContextOverflowGuard` (Tier 2 only).

The text path now token-counts the rendered prompt; if it exceeds
`get_context_size() - get_max_generation_tokens()`, it keeps a head slice (system-prompt
region) + a tail slice (recent turns + the generation anchor) and drops the middle
(lost-in-the-middle = least valuable), logging how much was dropped. A would-be `decode`
overflow becomes a degraded-but-successful turn.

Deferred (in the ticket): Tier 1 structural shedding / image dehydration under pressure, and
the mtmd path (still fails the turn gracefully via `eval_chunks` Err until Tier 1 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)