### PR TITLE
chatbot: reinforce core rules at end of prompt (SESSION CONTEXT)

### DIFF
--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -58,6 +58,14 @@ fn session_context_block(
         lines.push(note);
     }
 
+    if is_group {
+        lines.push(
+            "Reminders: reply only if your id is @mentioned — otherwise reply with exactly `<empty>`; match the @mention id, not the name. You are Terminal Alpha Beta.".to_string(),
+        );
+    } else {
+        lines.push("Reminder: you are Terminal Alpha Beta.".to_string());
+    }
+
     json!({ "role": "user", "content": lines.join("\n") })
 }
 


### PR DESCRIPTION
Chore from `Bot-SanityCheck` finding #3 / `Bot-CoreRulesReinforcement`.

Lost-in-the-middle: models attend most to the start and end, but our behavioral rules live
only at the very top. Restate the load-bearing ones at the END (in the trailing SESSION
CONTEXT block, which rides the recency slot and refreshes each turn), gated by setting and
kept terse to avoid distraction:

- group: reply only when your id is @mentioned (else `<empty>`); match id not name; identity.
- DM: identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)