### PR TITLE
chatbot: soften the group silence reminder

### DIFF
--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -60,7 +60,7 @@ fn session_context_block(
 
     if is_group {
         lines.push(
-            "Reminders: reply only if your id is @mentioned — otherwise reply with exactly `<empty>`; match the @mention id, not the name. You are Terminal Alpha Beta.".to_string(),
+            "Reminders: in a group you default to silence — chime in when your id is @mentioned, or occasionally on your own if you genuinely add something; otherwise reply with exactly `<empty>`. Match the @mention id, not the name. You are Terminal Alpha Beta.".to_string(),
         );
     } else {
         lines.push("Reminder: you are Terminal Alpha Beta.".to_string());


### PR DESCRIPTION
Follow-up to #142 (`Bot-CoreRulesReinforcement`).

The reminder I added shipped as "reply only if your id is @mentioned" — too aggressive: it
forbids implicit chime-ins, which the **system prompt explicitly allows** ("Default to
silence: reply only when addressed, **or rarely interject when you genuinely add
something**"). A reminder must mirror the source rule, not a stricter paraphrase.

Softened to: "in a group you default to silence — chime in when your id is @mentioned, or
occasionally on your own if you genuinely add something; otherwise reply with exactly
`<empty>`. Match the @mention id, not the name. You are Terminal Alpha Beta."

🤖 Generated with [Claude Code](https://claude.com/claude-code)