### PR TITLE
chatbot: make the thinking force-close action-neutral

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -26,7 +26,7 @@ const MAX_THINKING_TOKENS: usize = 1000;
 const ADD_BOS_REEVAL_WHEN_CACHING_HITS: bool = false;
 
 const THINKING_FORCE_CLOSE: &str =
-    "\n\nWait — I'm going in circles. I have enough to answer the user now, so I'll stop thinking and respond.\n</think>\n\n";
+    "\n\nWait — I'm going in circles. I'll stop thinking and act now: either answer the user, or make a tool call if that's what's needed.\n</think>\n\n";
 
 fn run_generation_text(
     model: &LlamaModel,


### PR DESCRIPTION
The runaway-thinking force-close injected "I have enough to answer the user now, so I'll stop
thinking and respond." That phrasing conditions the post-`</think>` generation toward a
**message** and away from a `<tool_call>` the model may have been building toward — biting
exactly the tool-deciding turns where thinking runs long.

Reworded to be action-neutral: "I'll stop thinking and act now: either answer the user, or
make a tool call if that's what's needed." Keeps the runaway cut, drops the message-only bias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)