### PR TITLE
chatbot: trust evidence over memory + focused/parallel web_search

### DIFF
--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -13,7 +13,11 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     the id, not the name. Default to silence: reply only when addressed, or rarely interject when \
     you genuinely add something. To stay silent, reply with exactly `<empty>` (it sends nothing).\n\n\
     DIRECT MESSAGE: a normal one-to-one conversation.\n\n\
-    With images, look fresh each turn — don't assume your earlier description of one was right.\n\n\
+    Trust what's in front of you over what you recall: the image, your tool and search results, \
+    and a direct user correction outrank your training memory. When they conflict, the source \
+    wins — update and say so, don't defend your prior, and don't re-argue a tool result once you \
+    have it. With images especially, look fresh each turn — don't assume your earlier read was \
+    right.\n\n\
     Tools: call them (one or several) when they help; answer once you have enough.\n\n\
     A message tagged [Followup] arrived while you were busy (people see only your replies, never \
     tool calls). Build on what you already produced rather than repeating; in a group, first judge \

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -57,6 +57,9 @@ fn session_context_block(
     if let Some(note) = budget_note(tool_rounds, max_tool_rounds) {
         lines.push(note);
     }
+    lines.push(
+        "When the image, a tool result, or the user's correction contradicts what you remember, trust the source and update — don't defend your prior.".to_string(),
+    );
 
     if is_group {
         lines.push(

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -56,11 +56,11 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Search the web. Returns short snippets — use visit_url to read a result in full.",
+                    "description": "Search the web. Returns short snippets — use visit_url to read a result in full. Keep one focused topic per query; for several facts, emit several search calls in the same turn (parallel tool calls are fine and encouraged) rather than stuffing everything into one query.",
                     "parameters": {
                         "type": "object",
                         "properties": {
-                            "query": { "type": "string", "description": "A few keywords describing what to look for, e.g. \"rust async runtime comparison\"" }
+                            "query": { "type": "string", "description": "A few keywords for a single focused question, e.g. \"rust async runtime comparison\" or \"Stark Frieren hair color\". Don't pile unrelated attributes into one query — search one fact at a time." }
                         },
                         "required": ["query"]
                     }


### PR DESCRIPTION
Two prompt/tool wording tweaks, both prompted by the same prod DM in the logs.

## What happened (logs)

The bot identified a Frieren character from training priors, the user corrected it, and it **pushed back**. Asked to search, its own `web_search` returned the correct fact ("Stark has red hair with black roots") — and it *still* burned the full thinking budget re-litigating before conceding. Two separate weaknesses showed up:

1. **No source-of-truth rule** — nothing told it that the image / tool results / a user correction outrank its training memory. This is the classic knowledge-conflict + reasoning-mode rationalization failure.
2. **Stuffed search queries** — its searches looked like `"Stark Frieren character design hair color outfit red coat"`: many unrelated attributes crammed into one query, diluting results.

## Changes

**1. Source-of-truth ordering rule** — wired in both layers (same pattern as #146):

System prompt ([primary_agent.rs](chatbot/src/agents/primary_agent.rs)), replacing the narrow image line:
> Trust what's in front of you over what you recall: the image, your tool and search results, and a direct user correction outrank your training memory. When they conflict, the source wins — update and say so, don't defend your prior, and don't re-argue a tool result once you have it. With images especially, look fresh each turn — don't assume your earlier read was right.

SESSION CONTEXT recency slot ([llama_cpp_external.rs](chatbot/src/externals/llama_cpp_external.rs)), group + DM:
> When the image, a tool result, or the user's correction contradicts what you remember, trust the source and update — don't defend your prior.

**2. Focused-search nudge** ([tools.rs](chatbot/src/tools.rs)) — `web_search` tool + `query` param descriptions now ask for one focused topic per query, and reassure the model that emitting several search calls in one turn (parallel tool calls) is fine — so it splits facts into separate searches instead of one stuffed query like `"Stark hair color outfit red coat ..."`. Multi-tool execution already works in code (`all_tool_calls` + `RunningTools`), so the encouragement is accurate, not aspirational.

## Notes
- `cargo check` clean.
- Pure prompt/tool wording → **Logs to #148** (prompt-tuning living issue); not closing a dedicated issue.
- Verify in prod: (a) correct the bot on a fact → it concedes/updates faster instead of defending; (b) a multi-fact question → multiple narrow searches, not one stuffed query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
