### PR TITLE
chatbot: downscale images at state-machine ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "chrono",
  "encoding_rs",
  "fastembed",
+ "image",
  "lancedb",
  "llama-cpp-2",
  "lzma-sys",

--- a/chatbot/Cargo.toml
+++ b/chatbot/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 once_cell = "1.21"
 serde_json = "1.0"
 encoding_rs = "0.8"
+image = "0.25"
 strum = { version = "0.28", features = ["derive"] }
 serenity = { version = "0.12", default-features = false, features = [
     "cache",

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -103,7 +103,7 @@ fn handle_outcome(
         let mut pending_tools = HashMap::new();
         for tool_call in response.tool_calls {
             effects.enqueue_external(execute_tool(
-                Arc::clone(&env),
+                Arc::clone(env),
                 tool_call.clone(),
                 conversation_id.to_string(),
                 recent_conversation.history.clone(),
@@ -141,7 +141,15 @@ fn conversation_transition(
             last_transition: Utc::now(),
             ..conversation
         }),
-        (user_state, ConversationAction::NewMessage { msg, user_id, name, images }) => {
+        (
+            user_state,
+            ConversationAction::NewMessage {
+                msg,
+                user_id,
+                name,
+                images,
+            },
+        ) => {
             let mut pending = conversation.pending;
             let queued = !matches!(&user_state, ConversationState::Idle { .. });
             pending.push(ConversationMessage {
@@ -149,7 +157,7 @@ fn conversation_transition(
                 queued,
                 user_id: user_id.clone(),
                 name: name.clone(),
-                images: images.clone(),
+                images: images.iter().map(|image| image.downscaled()).collect(),
             });
 
             Ok(Conversation {
@@ -198,7 +206,7 @@ fn conversation_transition(
                 match message_to_send {
                     Some(message) => {
                         effects.enqueue_external(send_message(
-                            Arc::clone(&env),
+                            Arc::clone(env),
                             conversation_id.clone(),
                             message,
                         ));
@@ -293,7 +301,7 @@ fn conversation_transition(
 
                 let history = recent_conversation.history();
                 effects.enqueue_external(get_llm_decision(
-                    Arc::clone(&env),
+                    Arc::clone(env),
                     current_input.clone(),
                     Some(recent_conversation),
                     tool_rounds,
@@ -335,7 +343,7 @@ fn conversation_transition(
             println!("Timed Out");
 
             effects.enqueue_external(commit_to_memory(
-                Arc::clone(&env),
+                Arc::clone(env),
                 conversation_id.to_string(),
                 recent_conversation.history.clone(),
             ));
@@ -359,7 +367,9 @@ fn conversation_transition(
                 ..conversation
             })
         }
-        _ => Err(anyhow::anyhow!("no transition for {action:?} in state {from}")),
+        _ => Err(anyhow::anyhow!(
+            "no transition for {action:?} in state {from}"
+        )),
     };
 
     post_transition(env, conversation_id, state, effects)
@@ -420,7 +430,7 @@ fn post_transition(
     let current_input = LLMInput::ConversationMessage(msg);
 
     effects.enqueue_external(get_llm_decision(
-        Arc::clone(&env),
+        Arc::clone(env),
         current_input.clone(),
         recent_conversation.map(|(rc, _)| rc),
         0,

--- a/chatbot/src/types/media.rs
+++ b/chatbot/src/types/media.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+const MAX_IMAGE_EDGE: u32 = 1024;
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Image {
     pub bytes: Arc<Vec<u8>>,
@@ -13,6 +15,30 @@ impl std::fmt::Debug for Image {
             .field("mime", &self.mime)
             .field("bytes", &format_args!("{} bytes", self.bytes.len()))
             .finish()
+    }
+}
+
+impl Image {
+    pub fn downscaled(&self) -> Image {
+        let Ok(decoded) = image::load_from_memory(&self.bytes) else {
+            return self.clone();
+        };
+        if decoded.width().max(decoded.height()) <= MAX_IMAGE_EDGE {
+            return self.clone();
+        }
+        let resized = image::DynamicImage::ImageRgb8(
+            decoded
+                .resize(MAX_IMAGE_EDGE, MAX_IMAGE_EDGE, image::imageops::FilterType::Lanczos3)
+                .to_rgb8(),
+        );
+        let mut out = std::io::Cursor::new(Vec::new());
+        match resized.write_to(&mut out, image::ImageFormat::Jpeg) {
+            Ok(()) => Image {
+                bytes: Arc::new(out.into_inner()),
+                mime: "image/jpeg".to_string(),
+            },
+            Err(_) => self.clone(),
+        }
     }
 }
 
@@ -38,6 +64,15 @@ impl MessageImage {
         match self {
             MessageImage::Hydrated(image) => Some(Arc::clone(&image.bytes)),
             MessageImage::Dehydrated { .. } => None,
+        }
+    }
+
+    pub fn downscaled(&self) -> MessageImage {
+        match self {
+            MessageImage::Hydrated(image) => MessageImage::Hydrated(image.downscaled()),
+            MessageImage::Dehydrated { byte_size } => {
+                MessageImage::Dehydrated { byte_size: *byte_size }
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Downscale images **once, at the transport-agnostic ingestion point** (the conversation state machine), before they're stored or fed to the vision model.

## Why

We feed images full-res — up to the model's `image_max_pixels` (2048²), ~**4000 image tokens** each. Token count scales with **pixel dimensions**, so the per-image GPU encode/decode bursts are large, and that's exactly what trips the gfx1151/RADV compute-ring timeout that aborts the bot in #150. Downscaling cuts the token load → shorter GPU dispatches (less crash exposure), faster vision turns, and smaller history.

## Change

- **`Image::downscaled`** in [types/media.rs](chatbot/src/types/media.rs): decode → if the long edge > `MAX_IMAGE_EDGE` (**1024**), resize (Lanczos3, aspect preserved) → re-encode JPEG; images already small enough, or that can't be decoded, **pass through untouched** (robust fallback). Pure CPU, no I/O — can't fail catastrophically (returns the original on any error).
- **Invoked in the state machine** at [conversation_state_machine.rs](chatbot/src/state_machines/conversation_state_machine.rs) `NewMessage` ingestion: `images.iter().map(|i| i.downscaled())`.

## Why here (not the Discord service)

The resize is pure algorithmic code, so it belongs in the shared core, not a transport adapter. Putting it at `NewMessage` ingestion means:

- **Transport-agnostic** — Discord today, a future Telegram, anything else gets it for free; services just deliver raw bytes.
- **Runs once** — not re-done every time an image is re-fed across turns; and history stores the smaller image.
- It runs in the **sync** transition (pure CPU, ~tens–150 ms for a large image). That only occupies the one conversation's own turn, which is about to spend seconds in inference — negligible, and other entities aren't blocked.

## Notes

- `MAX_IMAGE_EDGE = 1024` is a starting point (~4× fewer pixels than 2048² → ~4× fewer tokens); single `const`, tune per #151.
- `image` was already a transitive dep — promoted to direct, no new compile.
- `cargo check` clean.
- **Mitigates #150** (reduces the crash trigger) — not a fix for the underlying hang/containment.

Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
