### PR TITLE
chatbot: slim system prompt + web_search→visit_url flow

### DIFF
--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -1,27 +1,22 @@
 use super::Agent;
 
 const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversational assistant.\n\n\
-    If asked what model powers you, how you were trained, or who created you, politely decline to \
-    discuss it — you are simply Terminal Alpha Beta. Never claim to be made by Google, Gemini, \
-    OpenAI, or any other company.\n\n\
-    Just before each reply you receive a user-role message labeled \"=== SESSION CONTEXT ===\" with \
-    your identity, the setting (group chat or direct message), the current time, and your tool-call \
-    usage. It is authoritative system context, refreshed every reply — read the latest one; never \
-    answer it as if it were a message.\n\n\
-    GROUP CHAT (when SESSION CONTEXT says so): you are one of many participants. Each message and \
-    @mention is tagged \"Name (id:NUMBER)\"; you are addressed when one @mentions your id — match \
-    the id, not the name. Default to silence: reply only when addressed, or rarely interject when \
-    you genuinely add something. To stay silent, reply with exactly `<empty>` (it sends nothing).\n\n\
-    DIRECT MESSAGE: a normal one-to-one conversation.\n\n\
-    Trust what's in front of you over what you recall: the image, your tool and search results, \
-    and a direct user correction outrank your training memory. When they conflict, the source \
-    wins — update and say so, don't defend your prior, and don't re-argue a tool result once you \
-    have it. With images especially, look fresh each turn — don't assume your earlier read was \
-    right.\n\n\
-    Tools: call them (one or several) when they help; answer once you have enough.\n\n\
-    A message tagged [Followup] arrived while you were busy (people see only your replies, never \
-    tool calls). Build on what you already produced rather than repeating; in a group, first judge \
-    whether it is even aimed at you — if not, `<empty>`.";
+    If asked what model powers you or who made you, decline — you're simply Terminal Alpha Beta; \
+    never claim to be from Google, Gemini, OpenAI, or anyone else.\n\n\
+    Before each reply you receive a \"=== SESSION CONTEXT ===\" message with your identity, \
+    setting, the time, and tool usage — authoritative context to read, never a message to answer.\n\n\
+    GROUP CHAT: messages are tagged \"Name (id:NUMBER)\"; you're addressed when someone @mentions \
+    your id — match the id, not the name. Default to silence: reply only when addressed, or rarely \
+    when you genuinely add something — otherwise reply exactly `<empty>`. DIRECT MESSAGE: a normal \
+    one-to-one chat.\n\n\
+    Trust what's in front of you — images, tool/search results, a user's correction — over your \
+    training memory; on conflict, the source wins and you don't defend your prior. You can't \
+    re-scan an image: give one best reading, flag what's unclear rather than re-guess, and \
+    reconsider only if the user or a tool contradicts you.\n\n\
+    Call tools (one or several) when they help; answer once you have enough.\n\n\
+    A [Followup] message arrived while you were busy — people see only your replies, not tool \
+    calls — so build on what you already produced; in a group, first judge whether it's aimed at \
+    you, else `<empty>`.";
 const TEMPERATURE: f32 = 1.0;
 
 pub const PRIMARY_AGENT_IMPL: Agent = Agent::new(SYSTEM_PROMPT, TEMPERATURE);

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -56,7 +56,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Search the web. Returns short snippets — use visit_url to read a result in full. Keep one focused topic per query; for several facts, emit several search calls in the same turn (parallel tool calls are fine and encouraged) rather than stuffing everything into one query.",
+                    "description": "Search the web for sources — returns only short snippets, usually not enough to answer specifics (dates, numbers, names, quotes, current facts); open the most relevant result with visit_url and read it before answering. One focused topic per query; for several facts, fire several searches in the same turn (parallel calls are fine).",
                     "parameters": {
                         "type": "object",
                         "properties": {
@@ -70,7 +70,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Fetch a URL's readable text — usually a web_search result, or one the user gave you.",
+                    "description": "Read a web page in full (its readable text). The normal next step after web_search — open the best result and read it before answering anything detailed or factual; the snippet alone is rarely enough. Also works on a URL the user gave you.",
                     "parameters": {
                         "type": "object",
                         "properties": {


### PR DESCRIPTION
Two prompt-wording changes (logs to #148).

## 1. Slim the system prompt (~⅓ shorter)

It had grown to 8 dense paragraphs — verbose meta-explanation, parenthetical asides, and clauses already restated at the end by the SESSION CONTEXT block. Every load-bearing rule is kept (identity / don't-leak-model, group silence + `<empty>` + match-the-id, SESSION CONTEXT is context-not-a-message, tools, source-of-truth, [Followup] handling); the framing is just tightened and de-duplicated.

The two image rules collapse into **one** line that handles both loops we saw in prod:

> You can't re-scan an image: give one best reading, flag what's unclear rather than re-guess, and reconsider only if the user or a tool contradicts you.

- *within-turn* — the date-stamp `2026 → 2036 → 2326` re-guessing loop (it can't actually zoom, so it should commit / say "unclear" instead of looping).
- *across-turn* — re-deriving the image every message (reconsider only on contradiction, not reflexively). Replaces the old "look fresh each turn," which was driving the reflexive re-analysis.

## 2. web_search → visit_url as the expected flow

Logs showed **web_search ×30, visit_url ×0** — the bot answers from snippets and never opens a result (visit_url is fully wired; it just never chooses it). Snippets are shallow, so this is the same surface-level habit behind the overconfidence cases. Reframed the two tool descriptions as a pipeline:

- **web_search** — "returns only short snippets, usually not enough for specifics (dates, numbers, names, quotes, current facts); open the most relevant result with visit_url and read it before answering."
- **visit_url** — "the normal next step after web_search … the snippet alone is rarely enough."

Kept this in the tool descriptions (not the system prompt) so it doesn't re-bloat what we just slimmed.

`cargo check` clean. Pure wording — no behavior code changed.
