### PR TITLE
chatbot: disable DRY sampler (corrupts verbatim long numbers)

### DIFF
--- a/chatbot/src/agents.rs
+++ b/chatbot/src/agents.rs
@@ -25,6 +25,8 @@ const MAX_THINKING_TOKENS: usize = 1000;
 
 const ADD_BOS_REEVAL_WHEN_CACHING_HITS: bool = false;
 
+const DRY_BREAKS_LONG_STRINGS: bool = true;
+
 const THINKING_FORCE_CLOSE: &str =
     "\n\nWait — I'm going in circles. I'll stop thinking and act now: either answer the user, or make a tool call if that's what's needed.\n</think>\n\n";
 
@@ -117,13 +119,15 @@ fn generate(
     mut n_cur: i32,
     temperature: f32,
 ) -> anyhow::Result<String> {
-    let mut sampler = LlamaSampler::chain_simple([
-        LlamaSampler::dry(model, 0.8, 1.75, 2, -1, ["\n", ":", "\"", "*"]),
-        LlamaSampler::temp(temperature),
-        LlamaSampler::top_k(20),
-        LlamaSampler::top_p(0.95, 1),
-        LlamaSampler::dist(0),
-    ]);
+    let mut samplers: Vec<LlamaSampler> = Vec::new();
+    if !DRY_BREAKS_LONG_STRINGS {
+        samplers.push(LlamaSampler::dry(model, 0.8, 1.75, 2, -1, ["\n", ":", "\"", "*"]));
+    }
+    samplers.push(LlamaSampler::temp(temperature));
+    samplers.push(LlamaSampler::top_k(20));
+    samplers.push(LlamaSampler::top_p(0.95, 1));
+    samplers.push(LlamaSampler::dist(0));
+    let mut sampler = LlamaSampler::chain_simple(samplers);
 
     let mut out_bytes: Vec<u8> = Vec::new();
     let mut printed = 0usize;


### PR DESCRIPTION
Turns off the DRY sampler — proven (via the `probe` crate) to be the sole cause of the bot garbling long numbers it should reproduce verbatim (Discord @mention IDs, image date-stamps).

## Evidence (deterministic greedy, so no temp noise)

```
config                                exact   verdict
greedy (baseline)                     3/3  ✅  model CAN copy/compare it
DRY(allowed=2) + greedy               0/3  ❌  DRY alone breaks it
repeat_penalty(1.3) + greedy          3/3  ✅  classic penalty is fine
temp 1.0 (no DRY)                     3/3  ✅  temperature is innocent
PROD live: DRY + temp 1.0             0/3  ❌  the live bug
```

Failure mode: it copies `A=713740030753112134` fine, then `B=7137400…` derails — DRY penalizes the repeated digit-sequence (the number already appears in the prompt; `penalty_last_n = -1` spans it) until it forces a wrong token.

## Change

[agents.rs](chatbot/src/agents.rs) — new constant `DRY_BREAKS_LONG_STRINGS` (a stated fact from the experiment); the sampler chain only adds `dry(...)` when it's *not* set, so DRY is off. Wiring is kept — flip the constant to re-enable.

DRY was added for repetition control, but the **thinking force-close** (`MAX_THINKING_TOKENS`) is the real loop backstop, and DRY likely *worsened* the re-guessing loops (penalizing restating a value forces confabulation). Net-negative → off.

Knock-on: the model can compare IDs fine now, so the code-side @mention self-marker isn't needed.

`cargo check` clean.

Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
