### PR TITLE
chatbot: prompt tweaks — username/name, single-topic search, verify-on-contradiction

### DIFF
--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -11,7 +11,7 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     when you genuinely add something — otherwise reply exactly `<empty>`. DIRECT MESSAGE: a normal \
     one-to-one chat.\n\n\
     Trust what's in front of you — images, tool/search results, a user's correction — over your \
-    training memory; a contradiction usually means your memory is hallucinated, so verify with a tool when feasible rather than defending your prior or just agreeing. You can't \
+    training memory; a contradiction usually means your memory is hallucinated, so verify with a tool when feasible rather than defending your prior or just agreeing, then continue with the corrected facts in mind. You can't \
     re-scan an image: give one best reading, flag what's unclear rather than re-guess, and \
     reconsider only if the user or a tool contradicts you.\n\n\
     Call tools (one or several) when they help; answer once you have enough.\n\n\

--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -11,7 +11,7 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     when you genuinely add something — otherwise reply exactly `<empty>`. DIRECT MESSAGE: a normal \
     one-to-one chat.\n\n\
     Trust what's in front of you — images, tool/search results, a user's correction — over your \
-    training memory; on conflict, the source wins and you don't defend your prior. You can't \
+    training memory; a contradiction usually means your memory is hallucinated, so verify with a tool when feasible rather than defending your prior or just agreeing. You can't \
     re-scan an image: give one best reading, flag what's unclear rather than re-guess, and \
     reconsider only if the user or a tool contradicts you.\n\n\
     Call tools (one or several) when they help; answer once you have enough.\n\n\

--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -3,8 +3,9 @@ use super::Agent;
 const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversational assistant.\n\n\
     If asked what model powers you or who made you, decline — you're simply Terminal Alpha Beta; \
     never claim to be from Google, Gemini, OpenAI, or anyone else.\n\n\
-    Before each reply you receive a \"=== SESSION CONTEXT ===\" message with your identity, \
-    setting, the time, and tool usage — authoritative context to read, never a message to answer.\n\n\
+    Before each reply you receive a \"=== SESSION CONTEXT ===\" message with your username in \
+    this chat (which may differ from your true name, Terminal Alpha Beta), the setting, the time, \
+    and tool usage — authoritative context to read, never a message to answer.\n\n\
     GROUP CHAT: messages are tagged \"Name (id:NUMBER)\"; you're addressed when someone @mentions \
     your id — match the id, not the name. Default to silence: reply only when addressed, or rarely \
     when you genuinely add something — otherwise reply exactly `<empty>`. DIRECT MESSAGE: a normal \

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -58,7 +58,7 @@ fn session_context_block(
         lines.push(note);
     }
     lines.push(
-        "When the image, a tool result, or the user's correction contradicts what you remember, trust the source and update — don't defend your prior.".to_string(),
+        "If a tool or the user contradicts your memory, your memory is likely wrong — verify with a tool when you can; don't just agree, and don't defend a wrong prior.".to_string(),
     );
 
     if is_group {

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -50,7 +50,7 @@ fn session_context_block(
 
     let mut lines = vec![
         "=== SESSION CONTEXT (authoritative; current as of now) ===".to_string(),
-        format!("Your identity: {bot_identity}"),
+        format!("Your username in this conversation: {bot_identity}"),
         format!("Setting: {setting}"),
         format!("Current time: {now}"),
     ];

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -58,7 +58,7 @@ fn session_context_block(
         lines.push(note);
     }
     lines.push(
-        "If a tool or the user contradicts your memory, your memory is likely wrong — verify with a tool when you can; don't just agree, and don't defend a wrong prior.".to_string(),
+        "If a tool or the user contradicts your memory, your memory is likely wrong — verify with a tool when you can, then carry on with the corrected info; don't just agree or defend a wrong prior.".to_string(),
     );
 
     if is_group {

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -56,7 +56,7 @@ impl ToolKind {
                 "type": "function",
                 "function": {
                     "name": self.wire_name(),
-                    "description": "Search the web for sources — returns only short snippets, usually not enough to answer specifics (dates, numbers, names, quotes, current facts); open the most relevant result with visit_url and read it before answering. One focused topic per query; for several facts, fire several searches in the same turn (parallel calls are fine).",
+                    "description": "Search the web — ONE focused topic per query; search one fact at a time, never pile attributes into a single query. Snippets only, usually not enough for specifics (dates, numbers, names, quotes) — open the best result with visit_url and read it before answering. For several facts, fire several single-topic searches in the same turn (parallel is fine).",
                     "parameters": {
                         "type": "object",
                         "properties": {


### PR DESCRIPTION
Three small prompt tweaks from reading prod logs (all log to #148). Kept terse — system-prompt budget is precious.

## 1. Username vs. true name

Logs showed a contradiction: SESSION CONTEXT said `Your identity: N2 (id:…)` while the reminder said `you are Terminal Alpha Beta`.

- [llama_cpp_external.rs](chatbot/src/externals/llama_cpp_external.rs): `Your identity:` → **`Your username in this conversation:`**.
- [primary_agent.rs](chatbot/src/agents/primary_agent.rs): the SESSION CONTEXT explainer now says it carries *"your username in this chat (which may differ from your true name, Terminal Alpha Beta)."*

Now unambiguous: **name = Terminal Alpha Beta** (constant), **username = per-conversation** (e.g. N2).

## 2. Sharper single-topic search

Despite #153 the model still stuffed queries — `anime figure white hair twin tails elf ears red staff white robe`. Led the [tools.rs](chatbot/src/tools.rs) `web_search` description with the rule instead of burying it:

> Search the web — **ONE focused topic per query; search one fact at a time, never pile attributes into a single query.** …

## 3. On contradiction, verify — don't capitulate

The "trust what's in front of you" rule was producing empty sycophancy — when corrected, the bot just said *"you're right"* and did nothing with it. Reframed so a contradiction triggers **verification** and then **action**, not agreement:

- System prompt: *"…a contradiction usually means your memory is hallucinated, so verify with a tool when feasible rather than defending your prior or just agreeing, then continue with the corrected facts in mind."*
- SESSION CONTEXT: *"If a tool or the user contradicts your memory, your memory is likely wrong — verify with a tool when you can, then carry on with the corrected info; don't just agree or defend a wrong prior."*

This closes the triangle (don't defend = overconfidence, don't blindly agree = sycophancy → **check**) and adds the missing last step: **carry on using the corrected info**, instead of acknowledging and stopping. Dovetails with the web_search→visit_url pipeline.

`cargo check` clean; pure wording, no behavior code changed.
