### PR TITLE
chore: get arrow types from lance::deps instead of a pinned arrow-array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,11 +808,11 @@ name = "chatbot"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array",
  "chrono",
  "encoding_rs",
  "fastembed",
  "image",
+ "lance",
  "lancedb",
  "llama-cpp-2",
  "lzma-sys",
@@ -4004,9 +4004,9 @@ name = "lancedb_playground"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array",
  "fastembed",
  "futures",
+ "lance",
  "lancedb",
  "lzma-sys",
  "tokio",

--- a/chatbot/Cargo.toml
+++ b/chatbot/Cargo.toml
@@ -35,7 +35,7 @@ scraper = "0.27"
 readability = "0.3.0"
 lancedb = { version = "=0.30", default-features = false }
 lzma-sys = { version = "*", features = ["static"] } # static recommended by lance
-arrow-array = "=58.3.0" # must match lancedb internal version, use `cargo tree | grep arrow` to see
+lance = { version = "7", default-features = false } # arrow types via lance::deps::arrow_array — always matches lancedb's arrow
 fastembed = "5.8"
 
 [lints]

--- a/chatbot/src/externals/long_term_memory_external.rs
+++ b/chatbot/src/externals/long_term_memory_external.rs
@@ -3,7 +3,7 @@ use crate::{
     services::lance_db::LanceService,
     Env,
 };
-use arrow_array::{
+use lance::deps::arrow_array::{
     FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator, RecordBatchReader,
     StringArray,
 };

--- a/chatbot/src/externals/recall_long_term_external.rs
+++ b/chatbot/src/externals/recall_long_term_external.rs
@@ -1,6 +1,6 @@
 use std::{ops::Add, sync::Arc};
 
-use arrow_array::{Array, StringArray};
+use lance::deps::arrow_array::{Array, StringArray};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use lancedb::query::{ExecutableQuery, QueryBase};
 use serenity::futures::TryStreamExt;

--- a/lancedb_playground/Cargo.toml
+++ b/lancedb_playground/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 lancedb = { version = "=0.30", default-features = false }
 lzma-sys = { version = "*", features = ["static"] } # static recommended by lance
-arrow-array = "=58.3.0"
+lance = { version = "7", default-features = false } # for lance::deps::arrow_array — always matches lancedb's arrow
 fastembed = "5.8"
 tokio = { version = "1.48", features = ["full"] }
 anyhow = "1.0"

--- a/lancedb_playground/src/main.rs
+++ b/lancedb_playground/src/main.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use arrow_array::{
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use futures::TryStreamExt;
+use lance::deps::arrow_array::{
     Array, FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator, RecordBatchReader,
     StringArray,
 };
-use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
-use futures::TryStreamExt;
-use lancedb::arrow::arrow_schema::{DataType, Field, Schema};
+use lance::deps::arrow_schema::{DataType, Field, Schema};
 use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::{connect, Table};
 


### PR DESCRIPTION
## Why
The direct `arrow-array = "=58.3.0"` dep existed only so our arrow types (`RecordBatch`, `FixedSizeListArray`, …) matched the **exact** arrow version LanceDB compiles against. A mismatch dual-versions arrow and fails at the API boundary:
```
expected `arrow_schema::Field`, found `lancedb::arrow::arrow_schema::Field`
the trait `Scannable` is not implemented for `Box<dyn arrow_array::RecordBatchReader + Send>`
```
Keeping that pin in sync by hand is brittle (verified: `arrow-array = "*"` immediately resolves to 59.0.0 while lance stays on 58.3.0 → 4 compile errors).

## Fix
`lance` (which lancedb hard-pins to `=7.0.0`) re-exports its own arrow under `lance::deps::arrow_array` / `arrow_schema` **specifically so downstreams stay pinned to the same version automatically** (per lance's own doc comment). Depend on `lance` directly, import arrow types from `lance::deps`, drop the manual `arrow-array` pin.

## Why this can't drift like the `*` case
- `lance = "7"` is **major-bounded** — it can never leap to an incompatible new major the way unbounded `"*"` jumped 58→59.
- lancedb **hard-pins** `lance = "=7.0.0"`, so cargo is forced to unify to a single lance within the major; `lance::deps::arrow_array` is *that* lance's arrow by construction.
- If a future lancedb ever needs lance 8, our `"7"` produces a **loud resolver error** ("can't select a version for lance"), not a silent type mismatch — a one-char bump to `"8"` fixes it.

Verified: single `arrow-array v58.3.0` in the tree, `arrow-array` no longer a direct dep, workspace compiles. Applied to both `chatbot` and `lancedb_playground`.