### PR TITLE
fix: Dockerfile copies lancedb_playground, not the dropped kameo_playground

### DIFF
--- a/chatbot/Dockerfile
+++ b/chatbot/Dockerfile
@@ -23,11 +23,11 @@ COPY Cargo.toml Cargo.lock ./
 COPY chatbot/src ./chatbot/src
 COPY chatbot/Cargo.toml ./chatbot/
 COPY re_framework ./re_framework
-# framework, probe, and kameo_playground are non-compiled workspace members; cargo needs their
+# framework, probe, and lancedb_playground are non-compiled workspace members; cargo needs their
 # manifests to load the workspace, but they are not built (we build --package chatbot).
 COPY framework ./framework
 COPY probe ./probe
-COPY kameo_playground ./kameo_playground
+COPY lancedb_playground ./lancedb_playground
 COPY .git ./.git
 
 RUN cargo build --release --package chatbot


### PR DESCRIPTION
#157 removed the `kameo_playground` crate but left [chatbot/Dockerfile](chatbot/Dockerfile) `COPY`ing it, so **every docker build from `main` fails**:
```
COPY kameo_playground ./kameo_playground
ERROR: "/kameo_playground": not found
```
Swap it for `lancedb_playground` (added in #158) — the current non-compiled workspace member cargo needs present to resolve the workspace before `cargo build --package chatbot`.

Verified locally: `deploy_local` now builds and swaps the container cleanly.