### PR TITLE
chatbot: bump A3B to Q8_0 + platform-aware (dynamic) footer note

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ just deploy_local
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PRIMARY_MODEL_PATH` | Path to GGUF model | `models/Qwen3.6-35B-A3B-Q4_K_M.gguf` |
+| `PRIMARY_MODEL_PATH` | Path to GGUF model | `models/Qwen3.6-35B-A3B-Q8_0.gguf` |
 | `RUST_LOG` | Log level | `info` |
 
 ## Dependencies

--- a/chatbot/Dockerfile.base
+++ b/chatbot/Dockerfile.base
@@ -6,8 +6,8 @@ FROM debian:trixie-slim
 WORKDIR /app
 
 # Copy model file (large, rarely changes)
-COPY models/Qwen3.6-35B-A3B-Q4_K_M.gguf /app/models/
-ENV PRIMARY_MODEL_PATH=/app/models/Qwen3.6-35B-A3B-Q4_K_M.gguf
+COPY models/Qwen3.6-35B-A3B-Q8_0.gguf /app/models/
+ENV PRIMARY_MODEL_PATH=/app/models/Qwen3.6-35B-A3B-Q8_0.gguf
 
 # Copy FastEmbed cache
 COPY .fastembed_cache* /app/.fastembed_cache

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -4,7 +4,7 @@
 
 Bot Hive is a Discord chatbot powered by a local Large Language Model (LLM) that provides conversational AI capabilities with tool calling support. It uses a type-safe state machine framework (`framework`) to manage user interactions through distinct states and transitions.
 
-The bot uses **Qwen3.6-35B-A3B** (quantized Q4_K_M) running locally via `llama-cpp-2`, enabling private, offline AI conversations without relying on external APIs.
+The bot uses **Qwen3.6-35B-A3B** (quantized Q8_0) running locally via `llama-cpp-2`, enabling private, offline AI conversations without relying on external APIs.
 
 ## Features
 
@@ -72,7 +72,7 @@ docker run -d \
 ## Configuration
 
 ### Environment Variables
-- `PRIMARY_MODEL_PATH`: Path to the primary LLM model file inside the container (default: `/app/models/Qwen3.6-35B-A3B-Q4_K_M.gguf`).
+- `PRIMARY_MODEL_PATH`: Path to the primary LLM model file inside the container (default: `/app/models/Qwen3.6-35B-A3B-Q8_0.gguf`).
 - `RUST_LOG`: Log level (default: `info`).
 
 ### Session File Caching

--- a/chatbot/model_reference/qwen.md
+++ b/chatbot/model_reference/qwen.md
@@ -12,9 +12,9 @@ llama.cpp applies at runtime.
 
 ---
 
-## Model in use: Qwen3.6-35B-A3B-Q4_K_M
+## Model in use: Qwen3.6-35B-A3B-Q8_0
 
-- File: `chatbot/models/Qwen3.6-35B-A3B-Q4_K_M.gguf` (also in LM Studio cache).
+- File: `chatbot/models/Qwen3.6-35B-A3B-Q8_0.gguf` (also in LM Studio cache).
 - Base format: **ChatML**. Turn delimiters `<|im_start|>{role}\n … <|im_end|>\n`.
 - **EOS / end-of-turn token: `<|im_end|>`** — this is what stops generation (no grammar cap needed).
 - **Reasoning model:** has a `<think> … </think>` channel. `add_generation_prompt` opens

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::conversation::{
-        HistoryEntry, LLMInput, LLMResponse, RecentConversation, ToolCall,
+        HistoryEntry, LLMInput, LLMResponse, Platform, RecentConversation, ToolCall,
         ToolType, ConversationAction,
     },
     services::llama_cpp::LlamaCppService,
@@ -38,6 +38,7 @@ fn budget_note(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
 fn session_context_block(
     is_group: bool,
     bot_identity: &str,
+    platform: &Platform,
     tool_rounds: usize,
     max_tool_rounds: usize,
 ) -> Value {
@@ -53,6 +54,7 @@ fn session_context_block(
         format!("Your username in this conversation: {bot_identity}"),
         format!("Setting: {setting}"),
         format!("Current time: {now}"),
+        platform.formatting_note().to_string(),
     ];
     if let Some(note) = budget_note(tool_rounds, max_tool_rounds) {
         lines.push(note);
@@ -84,6 +86,7 @@ fn build_conversation(
     max_tool_rounds: usize,
     is_group: bool,
     bot_identity: &str,
+    platform: &Platform,
 ) -> (Value, Vec<Arc<Vec<u8>>>) {
     let history = maybe_recent_conversation
         .map(|rc| rc.history)
@@ -111,6 +114,7 @@ fn build_conversation(
     messages.push(session_context_block(
         is_group,
         bot_identity,
+        platform,
         tool_rounds,
         max_tool_rounds,
     ));
@@ -151,6 +155,7 @@ async fn get_response_from_llm(
     allow_tools: bool,
     is_group: bool,
     bot_identity: &str,
+    platform: &Platform,
 ) -> anyhow::Result<LLMResponse> {
     let (conversation, images) = build_conversation(
         current_input,
@@ -159,6 +164,7 @@ async fn get_response_from_llm(
         max_tool_rounds,
         is_group,
         bot_identity,
+        platform,
     );
 
     println!("\n\n------------------------ NEW ITERATION ------------------------\n\n");
@@ -218,6 +224,7 @@ pub async fn get_llm_decision(
     max_tool_rounds: usize,
     is_group: bool,
     bot_identity: String,
+    platform: Platform,
 ) -> ConversationAction {
     let allow_tools = tool_rounds < max_tool_rounds;
     println!(
@@ -234,6 +241,7 @@ pub async fn get_llm_decision(
         allow_tools,
         is_group,
         &bot_identity,
+        &platform,
     )
     .await;
 

--- a/chatbot/src/services/llama_cpp.rs
+++ b/chatbot/src/services/llama_cpp.rs
@@ -40,7 +40,7 @@ impl LlamaCppService {
         model_params: &LlamaModelParams,
     ) -> anyhow::Result<LlamaModel> {
         let primary_model_path = std::env::var("PRIMARY_MODEL_PATH")
-            .unwrap_or_else(|_| "./models/Qwen3.6-35B-A3B-Q4_K_M.gguf".to_string());
+            .unwrap_or_else(|_| "./models/Qwen3.6-35B-A3B-Q8_0.gguf".to_string());
         println!("Loading primary model from: {}", primary_model_path);
 
         let model = LlamaModel::load_from_file(backend, &primary_model_path, model_params)?;

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -308,6 +308,7 @@ fn conversation_transition(
                     MAX_TOOL_ROUNDS,
                     is_group,
                     bot_identity.clone(),
+                    conversation_id.0.clone(),
                 ));
 
                 Ok(Conversation {
@@ -402,7 +403,7 @@ fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMe
 
 fn post_transition(
     env: &Arc<Env>,
-    _conversation_id: &ConversationId,
+    conversation_id: &ConversationId,
     result: ConversationTransitionResult,
     effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
@@ -437,6 +438,7 @@ fn post_transition(
         MAX_TOOL_ROUNDS,
         is_group,
         bot_identity.clone(),
+        conversation_id.0.clone(),
     ));
 
     Ok(Conversation {

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -32,6 +32,14 @@ impl Platform {
             Platform::Discord => "Discord",
         }
     }
+
+    // Platform-specific rendering note for the conversation footer.
+    pub fn formatting_note(&self) -> &'static str {
+        match self {
+            Platform::Discord => "Platform: Discord — renders basic markdown but NOT tables. For tabular data use an aligned monospace table inside a ```code block```, never bare `| ... |` (it won't align).",
+            Platform::Telegram => "Platform: Telegram — supports a limited markdown subset (bold, italic, `code`, links); no tables, headers, or bullet lists. For tabular data use a ```code block```.",
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]

--- a/probe/src/main.rs
+++ b/probe/src/main.rs
@@ -9,7 +9,7 @@ use llama_cpp_2::{
 };
 use std::{io::Write, num::NonZero};
 
-const MODEL: &str = "/home/zireael9797/Repos/bot/chatbot/models/Qwen3.6-35B-A3B-Q4_K_M.gguf";
+const MODEL: &str = "/home/zireael9797/Repos/bot/chatbot/models/Qwen3.6-35B-A3B-Q8_0.gguf";
 const MMPROJ: &str = "/home/zireael9797/Repos/bot/chatbot/models/mmproj-Qwen3.6-35B-A3B-BF16.gguf";
 const N_CTX: u32 = 8192;
 const N_BATCH: i32 = 512;


### PR DESCRIPTION
## Q8_0 quant bump
Baked-in model goes from Qwen3.6-35B-A3B **Q4_K_M → Q8_0** (~35GB; fits comfortably in 96GB unified memory, higher precision at the cost of more memory bandwidth per token). Repointed: [Dockerfile.base](chatbot/Dockerfile.base), code default ([llama_cpp.rs](chatbot/src/services/llama_cpp.rs)), [probe](probe/src/main.rs), and docs. Q4 dropped from `chatbot/models/` (still in the LMStudio folder for revert). Base image rebuilt locally.

## Platform-aware footer note
The bot was emitting **raw markdown tables**, which Discord renders as misaligned garbage. Added a per-turn footer line describing the platform's markdown capabilities and steering tabular data into an aligned monospace code block.

Crucially it's **dynamic, not hardcoded**:
- `Platform::formatting_note()` helper on the enum ([types/conversation.rs](chatbot/src/types/conversation.rs)) — Discord and Telegram each return their own accurate note.
- The platform is threaded from the conversation's `ConversationId(Platform, _)` through `get_llm_decision` → `build_conversation` → `session_context_block`, mirroring how `bot_identity`/`is_group` already flow. No new struct field; sourced from `conversation_id.0`.

## Notes
- `.gguf` files are gitignored, so the quant swap is path/doc-only in the diff — a fresh `build_base` elsewhere needs the Q8 file present locally (same constraint as before).
- Verified locally: compiles, base rebuilt, Q8 loads from the baked-in path without OOM.