### PR TITLE
re_framework: use DashMap Entry in act, matching maybe_construct

### DIFF
--- a/re_framework/src/handle.rs
+++ b/re_framework/src/handle.rs
@@ -51,9 +51,10 @@ impl<SM: StateMachine> StateMachineHandle<SM> {
     }
 
     pub fn act(&self, id: SM::Id, action: SM::Action) {
-        match self.entities.get(&id.get_id_string()) {
-            Some(mailbox) => mailbox.deliver(action),
-            None => eprintln!(
+        use dashmap::mapref::entry::Entry as DEntry;
+        match self.entities.entry(id.get_id_string()) {
+            DEntry::Occupied(slot) => slot.get().deliver(action),
+            DEntry::Vacant(_) => eprintln!(
                 "[warn] action {action:?} for unconstructed entity {}; dropping (maybe_construct must precede act)",
                 id.get_id_string()
             ),


### PR DESCRIPTION
Switch `act` from `.get()` to `.entry()` so both `act` and `maybe_construct` use the same `Occupied`/`Vacant` matching against the entity registry.

Trades the read lock for a write lock on the DashMap shard; acceptable since per-entity transitions are already serialized through the mailbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)