### PR TITLE
chatbot: image tool results (view_image / send_image_to_user)

### DIFF
--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -1,12 +1,9 @@
 use crate::types::conversation::ToolResultData;
+use crate::types::media::{Image, MessageImage};
+use std::sync::Arc;
 use tokio::process::Command;
 
-// One sandbox container per conversation. The bot never sees the name — the harness derives it
-// from the conversation id. The container has no host mounts and no docker socket (default Docker
-// capability set + no-new-privileges); the model-authored bash inside it can reach the network but
-// not this host.
 const WORKER_IMAGE: &str = "bot-worker:latest";
-// The bot image ships the worker Dockerfile here; the image is built from it on first use.
 const WORKER_BUILD_CONTEXT: &str = "/app/worker";
 
 fn worker_name(conversation_id: &str) -> String {
@@ -32,28 +29,22 @@ async fn is_running(name: &str) -> bool {
     }
 }
 
-// Reuse the conversation's existing sandbox whenever possible so its filesystem/packages persist:
-// running -> reuse as-is; stopped -> restart it; absent/unrecoverable -> spawn fresh.
 async fn ensure_worker(name: &str) -> Result<(), String> {
     match docker(&["inspect", "-f", "{{.State.Running}}", name]).await {
         Ok(out) if out.status.success() => {
             if String::from_utf8_lossy(&out.stdout).trim() == "true" {
-                return Ok(()); // already live — reuse
+                return Ok(()); 
             }
-            // exists but stopped — restart, preserving its state
             if docker(&["start", name]).await.map(|o| o.status.success()).unwrap_or(false) {
                 return Ok(());
             }
-            let _ = docker(&["rm", "-f", name]).await; // dead/unrecoverable — recreate
+            let _ = docker(&["rm", "-f", name]).await; 
         }
-        _ => {} // doesn't exist — create
+        _ => {} 
     }
     spawn_worker(name).await
 }
 
-// Build the sandbox image from the Dockerfile shipped in the bot image, if not already present.
-// Runs on the host daemon over the mounted socket; built once, then cached across calls/restarts.
-// Called at startup (so the first command isn't slow) and again before spawning (idempotent).
 pub(crate) async fn ensure_worker_image() -> Result<(), String> {
     let present = docker(&["image", "inspect", WORKER_IMAGE])
         .await
@@ -72,7 +63,6 @@ pub(crate) async fn ensure_worker_image() -> Result<(), String> {
     Ok(())
 }
 
-// Spawn flags are the security boundary — fixed here, never influenced by the model.
 async fn spawn_worker(name: &str) -> Result<(), String> {
     ensure_worker_image().await?;
     let out = docker(&[
@@ -85,7 +75,6 @@ async fn spawn_worker(name: &str) -> Result<(), String> {
     if out.status.success() {
         return Ok(());
     }
-    // A concurrent tool call in the same round may have created it first — that's fine.
     if is_running(name).await {
         return Ok(());
     }
@@ -115,12 +104,34 @@ pub async fn run_bash(conversation_id: &str, command: &str) -> Result<ToolResult
     let code = out.status.code().unwrap_or(-1);
 
     let body = format!("exit code: {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
-    Ok(ToolResultData { actual: body.clone(), simplified: body })
+    Ok(ToolResultData::text(body.clone(), body))
+}
+
+pub async fn pull_image(conversation_id: &str, path: &str) -> Result<MessageImage, String> {
+    let name = worker_name(conversation_id);
+    ensure_worker(&name).await?;
+
+    let out = docker(&["exec", &name, "cat", "--", path]).await?;
+    if !out.status.success() {
+        return Err(format!(
+            "could not read '{path}': {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    let bytes = out.stdout;
+    let format = image::guess_format(&bytes)
+        .map_err(|_| format!("'{path}' is not a valid image (expected PNG, JPEG, GIF, or WebP)"))?;
+    let image = Image {
+        bytes: Arc::new(bytes),
+        mime: format.to_mime_type().to_string(),
+    };
+    Ok(MessageImage::Hydrated(image).downscaled())
 }
 
 pub async fn reset_bash(conversation_id: &str) -> Result<ToolResultData, String> {
     let name = worker_name(conversation_id);
     let _ = docker(&["rm", "-f", &name]).await;
     let msg = "Sandbox reset — a fresh environment starts on the next command.".to_string();
-    Ok(ToolResultData { actual: msg.clone(), simplified: msg })
+    Ok(ToolResultData::text(msg.clone(), msg))
 }

--- a/chatbot/src/externals/message_external.rs
+++ b/chatbot/src/externals/message_external.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 
 use crate::{
     types::conversation::{ConversationAction, Platform, ConversationId},
+    types::media::MessageImage,
     Env,
 };
-use serenity::all::CreateMessage;
+use serenity::all::{CreateAttachment, CreateMessage};
 
 const DISCORD_MESSAGE_LIMIT: usize = 2000;
 
@@ -33,8 +34,6 @@ fn split_for_discord(content: &str) -> Vec<String> {
     chunks
 }
 
-// Compose the user-facing text from semantic pieces, styled for the platform.
-// message → as-is; announced tools → de-emphasized subtext footer underneath.
 fn compose(platform: &Platform, message: Option<String>, tool_names: &[String]) -> String {
     let mut parts: Vec<String> = Vec::new();
     if let Some(m) = message {
@@ -50,13 +49,49 @@ fn compose(platform: &Platform, message: Option<String>, tool_names: &[String]) 
     parts.join("\n")
 }
 
+/// Everything that gets delivered to a conversation in one send. `message` and
+/// `tool_names` compose into the text body; `attachments` ride alongside as files.
+/// Text and attachments may both be present — the type models that even though no
+/// current flow produces both at once.
+pub struct OutboundMessage {
+    pub message: Option<String>,
+    pub tool_names: Vec<String>,
+    pub attachments: Vec<Attachment>,
+}
+
+pub enum Attachment {
+    Image(MessageImage),
+}
+
+impl OutboundMessage {
+    pub fn is_empty(&self) -> bool {
+        self.message.is_none() && self.tool_names.is_empty() && self.attachments.is_empty()
+    }
+}
+
+fn discord_attachment(attachment: &Attachment, index: usize) -> Option<CreateAttachment> {
+    let image = match attachment {
+        Attachment::Image(image) => image,
+    };
+    let MessageImage::Hydrated(image) = image else {
+        return None; 
+    };
+    let ext = match image.mime.as_str() {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        _ => "bin",
+    };
+    Some(CreateAttachment::bytes((*image.bytes).clone(), format!("attachment_{index}.{ext}")))
+}
+
 pub async fn send_message(
     env: Arc<Env>,
     conversation_id: ConversationId,
-    message: Option<String>,
-    tool_names: Vec<String>,
+    outbound: OutboundMessage,
 ) -> ConversationAction {
-    let message = compose(&conversation_id.0, message, &tool_names);
+    let text = compose(&conversation_id.0, outbound.message, &outbound.tool_names);
     match conversation_id.0 {
         Platform::Discord => {
             let channel = match conversation_id.1.parse::<u64>() {
@@ -67,11 +102,38 @@ pub async fn send_message(
                 }
             };
 
-            for chunk in split_for_discord(&message) {
-                if let Err(err) = channel
-                    .send_message(&env.discord_http, CreateMessage::new().content(&chunk))
-                    .await
-                {
+            let files: Vec<CreateAttachment> = outbound
+                .attachments
+                .iter()
+                .enumerate()
+                .filter_map(|(i, a)| discord_attachment(a, i))
+                .collect();
+
+            let chunks = split_for_discord(&text);
+
+            if chunks.is_empty() {
+                if !files.is_empty() {
+                    if let Err(err) = channel
+                        .send_message(&env.discord_http, CreateMessage::new().files(files))
+                        .await
+                    {
+                        eprintln!("[send] Discord send failed: {err}");
+                        return ConversationAction::MessageSent(Err(err.to_string()));
+                    }
+                }
+                return ConversationAction::MessageSent(Ok(()));
+            }
+
+            let last = chunks.len() - 1;
+            let mut files = Some(files);
+            for (i, chunk) in chunks.into_iter().enumerate() {
+                let mut builder = CreateMessage::new().content(&chunk);
+                if i == last {
+                    if let Some(files) = files.take().filter(|f| !f.is_empty()) {
+                        builder = builder.files(files);
+                    }
+                }
+                if let Err(err) = channel.send_message(&env.discord_http, builder).await {
                     eprintln!("[send] Discord send failed: {err}");
                     return ConversationAction::MessageSent(Err(err.to_string()));
                 }

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -1,6 +1,6 @@
 use crate::{
     configuration::client_tokens::{BRAVE_SEARCH_TOKEN, SEARXNG_URL},
-    externals::bash_container_external::{reset_bash, run_bash},
+    externals::bash_container_external::{pull_image, reset_bash, run_bash},
     types::conversation::{
         ToolCall, ToolResultData, ToolType, ConversationAction,
         MAX_SEARCH_DESCRIPTION_LENGTH,
@@ -133,7 +133,7 @@ async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
 
     let actual = format!("{simplified}\n{}", secondary.join("\n"));
 
-    Ok(ToolResultData { actual, simplified })
+    Ok(ToolResultData::text(actual, simplified))
 }
 
 #[allow(dead_code)]
@@ -232,7 +232,7 @@ async fn fetch_web_search_brave(query: &str) -> anyhow::Result<ToolResultData> {
 
     let actual = format!("{simplified}\n{}", secondary.join("\n"));
 
-    Ok(ToolResultData { actual, simplified })
+    Ok(ToolResultData::text(actual, simplified))
 }
 
 #[allow(dead_code)]
@@ -299,7 +299,7 @@ async fn fetch_url_content(url: &str) -> anyhow::Result<ToolResultData> {
     let actual = format!("Content of {url}:\n{actual_content}");
     let simplified = format!("Content of {url}:\n{simplified_content}");
 
-    Ok(ToolResultData { actual, simplified })
+    Ok(ToolResultData::text(actual, simplified))
 }
 
 async fn run_tool(conversation_id: &str, tool_type: ToolType) -> Result<ToolResultData, String> {
@@ -308,6 +308,26 @@ async fn run_tool(conversation_id: &str, tool_type: ToolType) -> Result<ToolResu
         ToolType::VisitUrl { url } => fetch_url_content(&url).await.map_err(|e| e.to_string()),
         ToolType::RunBashCommand { command } => run_bash(conversation_id, &command).await,
         ToolType::ResetBashContainer => reset_bash(conversation_id).await,
+        ToolType::ViewImage { path } => {
+            let image = pull_image(conversation_id, &path).await?;
+            let note = format!("Image '{path}' loaded — shown below. Only you can see it; it is hidden from the user.");
+            Ok(ToolResultData {
+                actual: note.clone(),
+                simplified: note,
+                image_for_assistant: Some(image),
+                image_for_user: None,
+            })
+        }
+        ToolType::SendImageToUser { path } => {
+            let image = pull_image(conversation_id, &path).await?;
+            let note = format!("Image '{path}' sent to the user — they can see it in the chat, and you can see it too.");
+            Ok(ToolResultData {
+                actual: note.clone(),
+                simplified: note,
+                image_for_assistant: None,
+                image_for_user: Some(image),
+            })
+        }
     }
 }
 

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -1,12 +1,14 @@
 use crate::externals::{
-    llama_cpp_external::get_llm_decision, message_external::send_message,
+    llama_cpp_external::get_llm_decision,
+    message_external::{send_message, Attachment, OutboundMessage},
     tool_call_external::execute_tool,
 };
-use crate::types::conversation::{LLMResponse, ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
+use crate::types::conversation::{ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
 use crate::{
     types::conversation::{
         Conversation, ConversationAction, ConversationConstructor, ConversationId,
-        ConversationMessage, ConversationState, HistoryEntry, LLMInput, RecentConversation,
+        ConversationMessage, ConversationState, HistoryEntry, LLMInput, PostSend,
+        RecentConversation,
     },
     Env,
 };
@@ -76,18 +78,60 @@ fn state_label(state: &ConversationState) -> &'static str {
     }
 }
 
-fn handle_outcome(
+fn send_then(
+    env: &Arc<Env>,
     conversation_id: &ConversationId,
-    response: LLMResponse,
+    outbound: OutboundMessage,
+    post_send: PostSend,
     recent_conversation: RecentConversation,
     pending: Vec<ConversationMessage>,
-    tool_rounds: usize,
     is_group: bool,
     bot_identity: String,
     effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
-    if response.tool_calls.is_empty() {
-        Ok(Conversation {
+    if outbound.is_empty() {
+        return apply_post_send(
+            env,
+            conversation_id,
+            post_send,
+            recent_conversation,
+            pending,
+            is_group,
+            bot_identity,
+            effects,
+        );
+    }
+
+    effects.enqueue_external(send_message(
+        Arc::clone(env),
+        conversation_id.clone(),
+        outbound,
+    ));
+
+    Ok(Conversation {
+        state: ConversationState::SendingMessage {
+            recent_conversation,
+            post_send,
+        },
+        last_transition: Utc::now(),
+        pending,
+        is_group,
+        bot_identity,
+    })
+}
+
+fn apply_post_send(
+    env: &Arc<Env>,
+    conversation_id: &ConversationId,
+    post_send: PostSend,
+    recent_conversation: RecentConversation,
+    pending: Vec<ConversationMessage>,
+    is_group: bool,
+    bot_identity: String,
+    effects: &mut ConversationEffects,
+) -> ConversationTransitionResult {
+    match post_send {
+        PostSend::Nothing => Ok(Conversation {
             state: ConversationState::Idle {
                 recent_conversation,
             },
@@ -95,26 +139,60 @@ fn handle_outcome(
             pending,
             is_group,
             bot_identity,
-        })
-    } else {
-        let mut pending_tools = HashMap::new();
-        for tool_call in response.tool_calls {
-            effects.enqueue_external(execute_tool(conversation_id.to_string(), tool_call.clone()));
-            pending_tools.insert(tool_call.id.clone(), tool_call);
-        }
+        }),
+        PostSend::CallTools {
+            tool_rounds,
+            tool_calls,
+        } => {
+            let mut pending_tools = HashMap::new();
+            for tool_call in tool_calls {
+                effects.enqueue_external(execute_tool(conversation_id.to_string(), tool_call.clone()));
+                pending_tools.insert(tool_call.id.clone(), tool_call);
+            }
 
-        Ok(Conversation {
-            state: ConversationState::RunningTools {
-                recent_conversation,
-                tool_rounds: tool_rounds + 1,
-                pending_tools,
-                completed_tools: Vec::new(),
-            },
-            last_transition: Utc::now(),
-            pending,
-            is_group,
-            bot_identity,
-        })
+            Ok(Conversation {
+                state: ConversationState::RunningTools {
+                    recent_conversation,
+                    tool_rounds: tool_rounds + 1,
+                    pending_tools,
+                    completed_tools: Vec::new(),
+                },
+                last_transition: Utc::now(),
+                pending,
+                is_group,
+                bot_identity,
+            })
+        }
+        PostSend::SendToolResponse {
+            tool_rounds,
+            results,
+            followup,
+        } => {
+            let current_input = LLMInput::ToolResults(results, followup);
+            let history = recent_conversation.history();
+            effects.enqueue_external(get_llm_decision(
+                Arc::clone(env),
+                current_input.clone(),
+                Some(recent_conversation),
+                tool_rounds,
+                MAX_TOOL_ROUNDS,
+                is_group,
+                bot_identity.clone(),
+                conversation_id.0.clone(),
+            ));
+
+            Ok(Conversation {
+                state: ConversationState::AwaitingLLMDecision {
+                    history,
+                    current_input,
+                    tool_rounds,
+                },
+                last_transition: Utc::now(),
+                pending,
+                is_group,
+                bot_identity,
+            })
+        }
     }
 }
 
@@ -179,7 +257,6 @@ fn conversation_transition(
                 let updated_conversation =
                     RecentConversation::new(response.thoughts.clone(), updated_history);
 
-                // Semantic pieces only — the send layer composes + styles them per platform.
                 let announce_tools: Vec<String> = if env.announce_tool_use {
                     response
                         .tool_calls
@@ -190,37 +267,31 @@ fn conversation_transition(
                     Vec::new()
                 };
 
-                if response.message.is_some() || !announce_tools.is_empty() {
-                    effects.enqueue_external(send_message(
-                        Arc::clone(env),
-                        conversation_id.clone(),
-                        response.message.clone(),
-                        announce_tools,
-                    ));
-
-                    Ok(Conversation {
-                        state: ConversationState::SendingMessage {
-                            outcome: response.clone(),
-                            recent_conversation: updated_conversation,
-                            tool_rounds,
-                        },
-                        last_transition: Utc::now(),
-                        ..conversation
-                    })
+                let post_send = if response.tool_calls.is_empty() {
+                    PostSend::Nothing
                 } else {
-                    handle_outcome(
-                        conversation_id,
-                        response.clone(),
-                        updated_conversation,
-                        conversation.pending,
+                    PostSend::CallTools {
                         tool_rounds,
-                        conversation.is_group,
-                        conversation.bot_identity.clone(),
-                        effects,
-                    )
-                }
+                        tool_calls: response.tool_calls.clone(),
+                    }
+                };
+
+                send_then(
+                    env,
+                    conversation_id,
+                    OutboundMessage {
+                        message: response.message.clone(),
+                        tool_names: announce_tools,
+                        attachments: Vec::new(),
+                    },
+                    post_send,
+                    updated_conversation,
+                    conversation.pending,
+                    conversation.is_group,
+                    conversation.bot_identity.clone(),
+                    effects,
+                )
             }
-            // LLM failed — keep the rolling window so a transient error doesn't wipe memory.
             Err(_) => Ok(Conversation {
                 state: ConversationState::Idle {
                     recent_conversation: RecentConversation::new(String::new(), history),
@@ -231,17 +302,16 @@ fn conversation_transition(
         },
         (
             ConversationState::SendingMessage {
-                outcome,
                 recent_conversation,
-                tool_rounds,
+                post_send,
             },
             ConversationAction::MessageSent(_res),
-        ) => handle_outcome(
+        ) => apply_post_send(
+            env,
             conversation_id,
-            outcome,
+            post_send,
             recent_conversation,
             conversation.pending,
-            tool_rounds,
             conversation.is_group,
             conversation.bot_identity.clone(),
             effects,
@@ -260,10 +330,7 @@ fn conversation_transition(
                     Ok(data) => data.clone(),
                     Err(error_msg) => {
                         let msg = format!("Tool execution failed: {error_msg}");
-                        ToolResultData {
-                            actual: msg.clone(),
-                            simplified: msg,
-                        }
+                        ToolResultData::text(msg.clone(), msg)
                     }
                 };
                 completed_tools.push((tool_call, data));
@@ -273,6 +340,13 @@ fn conversation_transition(
 
             if pending_tools.is_empty() {
                 completed_tools.sort_by(|(a, _), (b, _)| a.id.cmp(&b.id));
+
+                let attachments: Vec<Attachment> = completed_tools
+                    .iter()
+                    .filter_map(|(_, data)| data.image_for_user.clone())
+                    .map(Attachment::Image)
+                    .collect();
+
                 let results = completed_tools
                     .into_iter()
                     .map(|(tool_call, data)| ToolResult {
@@ -280,34 +354,29 @@ fn conversation_transition(
                         data,
                     })
                     .collect();
+
                 let mut pending = conversation.pending;
-                let current_input = LLMInput::ToolResults(results, take_pending(&mut pending));
-                let is_group = conversation.is_group;
-                let bot_identity = conversation.bot_identity.clone();
+                let followup = take_pending(&mut pending);
 
-                let history = recent_conversation.history();
-                effects.enqueue_external(get_llm_decision(
-                    Arc::clone(env),
-                    current_input.clone(),
-                    Some(recent_conversation),
-                    tool_rounds,
-                    MAX_TOOL_ROUNDS,
-                    is_group,
-                    bot_identity.clone(),
-                    conversation_id.0.clone(),
-                ));
-
-                Ok(Conversation {
-                    state: ConversationState::AwaitingLLMDecision {
-                        history,
-                        current_input,
-                        tool_rounds,
+                send_then(
+                    env,
+                    conversation_id,
+                    OutboundMessage {
+                        message: None,
+                        tool_names: Vec::new(),
+                        attachments,
                     },
-                    last_transition: Utc::now(),
+                    PostSend::SendToolResponse {
+                        tool_rounds,
+                        results,
+                        followup,
+                    },
+                    recent_conversation,
                     pending,
-                    is_group,
-                    bot_identity,
-                })
+                    conversation.is_group,
+                    conversation.bot_identity.clone(),
+                    effects,
+                )
             } else {
                 Ok(Conversation {
                     state: ConversationState::RunningTools {
@@ -406,7 +475,6 @@ fn post_transition(
 
 fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<ConversationAction>> {
     match conversation.state {
-        // No idle timeout — the rolling window is the memory and persists. Idle just waits.
         ConversationState::Idle { .. } => None,
         ConversationState::AwaitingLLMDecision { .. }
         | ConversationState::SendingMessage { .. }

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -19,6 +19,11 @@ struct RunBashArgs {
     command: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct PathArgs {
+    path: String,
+}
+
 fn parse_args<T: serde::de::DeserializeOwned>(name: &str, arguments: &str) -> anyhow::Result<T> {
     serde_json::from_str(arguments)
         .map_err(|e| anyhow::anyhow!("{name} arguments failed to bind: {e} — raw: {arguments}"))
@@ -31,6 +36,8 @@ impl ToolKind {
             ToolKind::VisitUrl => "visit_url",
             ToolKind::RunBashCommand => "run_bash_command",
             ToolKind::ResetBashContainer => "reset_bash_container",
+            ToolKind::ViewImage => "view_image",
+            ToolKind::SendImageToUser => "send_image_to_user",
         }
     }
 
@@ -86,6 +93,34 @@ impl ToolKind {
                     "parameters": { "type": "object", "properties": {}, "required": [] }
                 }
             })),
+            ToolKind::ViewImage => Some(json!({
+                "type": "function",
+                "function": {
+                    "name": self.wire_name(),
+                    "description": "Look at an image file from your bash sandbox so you can see its contents. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). Only you see it — it is hidden from the user. Use it to inspect plots, screenshots, or downloaded images before deciding what to do next.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string", "description": "Path to the image file inside your bash sandbox, e.g. \"/tmp/plot.png\" or \"chart.png\" (relative to the sandbox working directory)." }
+                        },
+                        "required": ["path"]
+                    }
+                }
+            })),
+            ToolKind::SendImageToUser => Some(json!({
+                "type": "function",
+                "function": {
+                    "name": self.wire_name(),
+                    "description": "Send an image file from your bash sandbox to the user in this chat. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). It goes to the user — they see it in the chat — and you see it too (it counts as a message you sent). Use it to deliver plots, generated images, or processed pictures.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string", "description": "Path to the image file inside your bash sandbox, e.g. \"/tmp/plot.png\" or \"chart.png\" (relative to the sandbox working directory)." }
+                        },
+                        "required": ["path"]
+                    }
+                }
+            })),
         }
     }
 }
@@ -106,6 +141,8 @@ impl ToolType {
             ToolType::VisitUrl { url } => json!({ "url": url }),
             ToolType::RunBashCommand { command } => json!({ "command": command }),
             ToolType::ResetBashContainer => json!({}),
+            ToolType::ViewImage { path } => json!({ "path": path }),
+            ToolType::SendImageToUser { path } => json!({ "path": path }),
         }
         .to_string()
     }
@@ -126,6 +163,12 @@ impl ToolType {
                 command: parse_args::<RunBashArgs>(name, arguments)?.command,
             }),
             ToolKind::ResetBashContainer => Ok(ToolType::ResetBashContainer),
+            ToolKind::ViewImage => Ok(ToolType::ViewImage {
+                path: parse_args::<PathArgs>(name, arguments)?.path,
+            }),
+            ToolKind::SendImageToUser => Ok(ToolType::SendImageToUser {
+                path: parse_args::<PathArgs>(name, arguments)?.path,
+            }),
         }
     }
 }

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -33,7 +33,6 @@ impl Platform {
         }
     }
 
-    // Platform-specific rendering note for the conversation footer.
     pub fn formatting_note(&self) -> &'static str {
         match self {
             Platform::Discord => "Platform: Discord — renders basic markdown but NOT tables. For tabular data use an aligned monospace table inside a ```code block```, never bare `| ... |` (it won't align).",
@@ -41,7 +40,6 @@ impl Platform {
         }
     }
 
-    // Render `text` as de-emphasized subtext in this platform's markup.
     pub fn subtext(&self, text: &str) -> String {
         match self {
             Platform::Discord => format!("-# *{text}*"),
@@ -103,9 +101,8 @@ pub enum ConversationState {
                 tool_rounds: usize,
     },
     SendingMessage {
-        outcome: LLMResponse,
         recent_conversation: RecentConversation,
-        tool_rounds: usize,
+        post_send: PostSend,
     },
     RunningTools {
         recent_conversation: RecentConversation,
@@ -120,6 +117,25 @@ impl Default for ConversationState {
             recent_conversation: RecentConversation::empty(),
         }
     }
+}
+
+/// What `SendingMessage` does once its in-flight send is confirmed. Each variant
+/// carries exactly what its continuation needs — nothing more.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum PostSend {
+    /// Nothing follows — go Idle.
+    Nothing,
+    /// The message was delivered; now run these tools.
+    CallTools {
+        tool_rounds: usize,
+        tool_calls: Vec<ToolCall>,
+    },
+    /// The user-facing part was delivered; now relay the results to the LLM.
+    SendToolResponse {
+        tool_rounds: usize,
+        results: Vec<ToolResult>,
+        followup: Option<ConversationMessage>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -223,16 +239,52 @@ impl LLMInput {
                 (vec![json!({ "role": "user", "content": content })], bytes)
             }
             LLMInput::ToolResults(results, user_msg) => {
-                let mut messages: Vec<Value> = results
-                    .iter()
-                    .map(|r| json!({ "role": "tool", "tool_call_id": r.id, "content": r.data.actual }))
-                    .collect();
-                let mut bytes = Vec::new();
+                let mut messages: Vec<Value> = Vec::new();
+                let mut bytes: Vec<Arc<Vec<u8>>> = Vec::new();
+                let mut delivered: Vec<Arc<Vec<u8>>> = Vec::new();
+
+                for r in results {
+                    let mut parts: Vec<String> = Vec::new();
+                    if !r.data.actual.is_empty() {
+                        parts.push(r.data.actual.clone());
+                    }
+                    if let Some(image) = &r.data.image_for_user {
+                        match image.hydrated_bytes() {
+                            Some(b) => {
+                                parts.push("[The image you produced was delivered to the user as your message — shown below.]".to_string());
+                                delivered.push(b);
+                            }
+                            None => parts.push(
+                                "[An image was delivered to the user as your message earlier in the conversation.]".to_string(),
+                            ),
+                        }
+                    }
+                    if let Some(image) = &r.data.image_for_assistant {
+                        match image.hydrated_bytes() {
+                            Some(b) => {
+                                parts.push(marker.to_string());
+                                bytes.push(b);
+                            }
+                            None => parts.push(
+                                "[A tool-result image from earlier in the conversation — you saw it at the time, not re-attached here.]".to_string(),
+                            ),
+                        }
+                    }
+                    messages.push(json!({ "role": "tool", "tool_call_id": r.id, "content": parts.join("\n") }));
+                }
+
+                if !delivered.is_empty() {
+                    let content = vec![marker.to_string(); delivered.len()].join("\n");
+                    messages.push(json!({ "role": "assistant", "content": content }));
+                    bytes.extend(delivered);
+                }
+
                 if let Some(msg) = user_msg {
                     let (content, b) = msg.content_and_media(marker);
                     messages.push(json!({ "role": "user", "content": content }));
-                    bytes = b;
+                    bytes.extend(b);
                 }
+
                 (messages, bytes)
             }
         }
@@ -248,6 +300,8 @@ pub enum ToolType {
     VisitUrl { url: String },
     RunBashCommand { command: String },
     ResetBashContainer,
+    ViewImage { path: String },
+    SendImageToUser { path: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -330,6 +384,17 @@ pub enum ConversationAction {
 pub struct ToolResultData {
     pub actual: String,
     pub simplified: String,
+    /// Image fed back into the model alongside `actual` (multimodal tool result).
+    pub image_for_assistant: Option<MessageImage>,
+    /// Image delivered straight to the chat, bypassing the model.
+    pub image_for_user: Option<MessageImage>,
+}
+
+impl ToolResultData {
+    /// Text-only result — no images for either side. The common case.
+    pub fn text(actual: String, simplified: String) -> Self {
+        ToolResultData { actual, simplified, image_for_assistant: None, image_for_user: None }
+    }
 }
 
 impl std::fmt::Debug for ConversationAction {


### PR DESCRIPTION
Closes #172.

Tools can now return images on two channels, and two tools expose this to the model.

## Changes

- **`ToolResultData`** gains `image_for_assistant` (model-only) and `image_for_user` (delivered to chat; model also sees it). Both dehydrate on persist — history never stores image bytes.
- **State machine** — `SendingMessage.outcome` → `PostSend` enum (`Nothing` / `CallTools` / `SendToolResponse`); a `send_then` helper centralizes "send first, then continue". A tool that emits a user-facing image is delivered to the chat, then its results are relayed to the LLM.
- **Send layer** — `send_message` takes an `OutboundMessage { message, tool_names, attachments }`; images attach on Discord.
- **Rendering** — `image_for_assistant` inline on the tool turn (private); `image_for_user` as a trailing assistant turn + tool-result note, so the model reads "I already sent this". `tool_call → tool_result` adjacency preserved; byte order matches marker order for mtmd.
- **Tools** — shared `pull_image` (`docker exec cat` → magic-byte validate → downscale) from the per-conversation bash sandbox:
  - `view_image(path)` — only the model sees it.
  - `send_image_to_user(path)` — the user sees it, and so does the model.

Descriptions and result notes both echo the visibility distinction.

## Notes / follow-ups
- `image_for_user` renders in an **assistant**-role turn (off-distribution for Qwen) — deliberate, worth a live check.
- `OutboundMessage` models text + attachments coexisting, though no current flow produces both.
- Telegram send path unchanged (still unimplemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)