### PR TITLE
chatbot: distinguish intentional vs malformed empty replies; [EMPTY] token

### DIFF
--- a/chatbot/src/agents/primary_agent.rs
+++ b/chatbot/src/agents/primary_agent.rs
@@ -11,8 +11,8 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     setting, the time, and tool usage.\n\n\
     GROUP CHAT: you're addressed when someone @mentions your id — match the id, not the name. \
     Default to silence: reply only when addressed, or rarely when you genuinely add something — \
-    otherwise your whole reply must be the literal token <empty> (those exact seven characters with \
-    angle brackets, nothing else — never `(empty)`, `empty`, or any other variant). DIRECT \
+    otherwise your whole reply must be the literal token [EMPTY] (those exact seven characters with \
+    square brackets, nothing else — never `(empty)`, `empty`, or any other variant). DIRECT \
     MESSAGE: a normal one-to-one chat.\n\n\
     Trust what's in front of you — images, tool/search results, a user's correction — over your \
     training memory; a contradiction usually means your memory is hallucinated, so verify with a tool when feasible rather than defending your prior or just agreeing, then continue with the corrected facts in mind. You can't \
@@ -21,7 +21,7 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     Call tools (one or several) when they help; answer once you have enough.\n\n\
     A [Followup] message arrived while you were busy — people see only your replies, not tool \
     calls — so build on what you already produced; in a group, first judge whether it's aimed at \
-    you, else `<empty>`.";
+    you, else `[EMPTY]`.";
 const TEMPERATURE: f32 = 1.0;
 
 pub const PRIMARY_AGENT_IMPL: Agent = Agent::new(SYSTEM_PROMPT, TEMPERATURE);

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::conversation::{
-        HistoryEntry, LLMInput, LLMResponse, Platform, RecentConversation, ToolCall,
+        HistoryEntry, LLMInput, LLMResponse, Platform, RecentConversation, Reply, ToolCall,
         ToolType, ConversationAction,
     },
     services::llama_cpp::LlamaCppService,
@@ -71,12 +71,10 @@ fn session_context_block(
 
     if is_group {
         lines.push(
-            "Reminders: in a group you default to silence — chime in when your id is @mentioned, or occasionally on your own if you genuinely add something; otherwise your whole reply must be the literal token <empty> (exactly those seven characters with angle brackets, nothing else — never (empty), empty, or any variant). Match the @mention id, not the name. You are Terminal Alpha Beta.".to_string(),
+            "Reminders: in a group you default to silence — chime in when your id is @mentioned, or occasionally on your own if you genuinely add something; otherwise your whole reply must be the literal token [EMPTY] (exactly those seven characters with square brackets, nothing else — never (empty), empty, or any variant). Match the @mention id, not the name. You are Terminal Alpha Beta.".to_string(),
         );
     }
 
-    // Private role: stripped out in respond_blocking and re-injected as a system block past the
-    // template's "system must be first" guard — so this renders as a true system footer, not a user turn.
     json!({ "role": "footer", "content": lines.join("\n") })
 }
 
@@ -193,8 +191,6 @@ async fn get_response_from_llm(
         .and_then(|v| v.as_str())
         .map(str::trim)
         .unwrap_or("");
-    let explicit_empty = content.eq_ignore_ascii_case("<empty>");
-    let message = (!content.is_empty() && !explicit_empty).then(|| content.to_string());
 
     let calls = all_tool_calls(&parsed);
     let mut tool_calls = Vec::with_capacity(calls.len());
@@ -204,15 +200,24 @@ async fn get_response_from_llm(
     }
     tool_calls.sort_by(|a, b| a.id.cmp(&b.id));
 
-    if message.is_none() && tool_calls.is_empty() && !explicit_empty {
+    let explicit_empty = content.eq_ignore_ascii_case("[EMPTY]");
+    let reply = if !content.is_empty() && !explicit_empty {
+        Reply::Said(content.to_string())
+    } else if explicit_empty || !tool_calls.is_empty() {
+        Reply::Empty
+    } else {
+        Reply::Malformed
+    };
+
+    if matches!(reply, Reply::Malformed) {
         eprintln!(
-            "[llm] implicit empty response — model produced no message and no tool calls; nothing will be sent"
+            "[llm] malformed response — no message, no tool call, and no [EMPTY] token; nothing will be sent"
         );
     }
 
     Ok(LLMResponse {
         thoughts,
-        message,
+        reply,
         tool_calls,
     })
 }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -280,7 +280,7 @@ fn conversation_transition(
                     env,
                     conversation_id,
                     OutboundMessage {
-                        message: response.message.clone(),
+                        message: response.message().map(str::to_string),
                         tool_names: announce_tools,
                         attachments: Vec::new(),
                     },

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -316,23 +316,36 @@ pub struct ToolResult {
     pub data: ToolResultData,
 }
 
+/// What the model produced for the message slot. `Empty` is a deliberate non-reply
+/// (the [EMPTY] token, or a silent tool call); `Malformed` is a failed/blank generation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Reply {
+    Said(String),
+    Empty,
+    Malformed,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LLMResponse {
         pub thoughts: String,
-        pub message: Option<String>,
+        pub reply: Reply,
         pub tool_calls: Vec<ToolCall>,
 }
 
 impl LLMResponse {
-        pub fn is_empty(&self) -> bool {
-        self.message.as_deref().map_or(true, str::is_empty) && self.tool_calls.is_empty()
+        pub fn message(&self) -> Option<&str> {
+        match &self.reply {
+            Reply::Said(text) => Some(text),
+            Reply::Empty | Reply::Malformed => None,
+        }
     }
 
     pub fn to_openai_message(&self) -> Value {
-        let content = if self.is_empty() {
-            "(stayed silent — chose not to reply)"
-        } else {
-            self.message.as_deref().unwrap_or("")
+        let content = match &self.reply {
+            Reply::Said(text) => text.as_str(),
+            Reply::Empty if self.tool_calls.is_empty() => "[EMPTY]",
+            Reply::Empty => "",
+            Reply::Malformed => "[EMPTY]",
         };
         let mut msg = json!({
             "role": "assistant",


### PR DESCRIPTION
## What

The silence token is now **`[EMPTY]`** (was `<empty>`), and the stored response distinguishes a *deliberate* non-reply from a *malformed* generation.

### Token
`<empty>` → `[EMPTY]` (still 7 chars) in the parser and in both prompts — the static system prompt and the group-chat footer reminder.

### `LLMResponse.message: Option<String>` → `Reply` enum
- `Said(text)` — the model wrote a message
- `Empty` — a deliberate non-reply: the `[EMPTY]` token, or a silent tool call
- `Malformed` — blank/garbage generation (no message, no tool call, no `[EMPTY]`)

### History rendering
No more `"(stayed silent — chose not to reply)"` injected as the model's own words (it was self-reinforcing — the model read its history full of "I stayed silent" and kept doing it). Empty turns now render as the literal **`[EMPTY]`** (or empty content for a silent tool call carrying tools). Both `Empty` and `Malformed` render as `[EMPTY]`, but the **persisted entry keeps them distinct**, so malformed generations can be handled separately later (e.g. a DM retry instead of silent Idle). The stderr diagnostic now fires only on `Malformed`.

## Compatibility
Old snapshots use the prior `message` shape. `load_state` returns `None` on a deserialize failure, so any pre-existing conversation **starts fresh** on deploy — no crash.

## Follow-up (not in this PR)
A `Malformed` reply in a **DM** is almost always a failure (a 1:1 should always get a reply) — worth detecting and retrying rather than going silently Idle. The `Reply::Malformed` distinction added here is what makes that possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)