### PR TITLE
chatbot: surface malformed past turns in history, not just storage

### DIFF
--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -345,7 +345,7 @@ impl LLMResponse {
             Reply::Said(text) => text.as_str(),
             Reply::Empty if self.tool_calls.is_empty() => "[EMPTY]",
             Reply::Empty => "",
-            Reply::Malformed => "[EMPTY]",
+            Reply::Malformed => "[MALFORMED — assistant generated no usable output: no message and no tool call]",
         };
         let mut msg = json!({
             "role": "assistant",


### PR DESCRIPTION
Follow-up to #174.

A `Reply::Malformed` turn was rendered as `[EMPTY]` in the prompt — indistinguishable from an intentional silence, even though the persisted entry already kept them distinct. This surfaces the distinction **to the model** too:

- `Reply::Malformed` → `[MALFORMED — assistant generated no usable output: no message and no tool call]`
- `Reply::Empty` → `[EMPTY]` (unchanged)

So in its own history the model can tell a glitched generation apart from a deliberate non-reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)