### PR TITLE
chatbot: clarify image tool visibility (view_image vs send_image_to_user)

### DIFF
--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -310,7 +310,7 @@ async fn run_tool(conversation_id: &str, tool_type: ToolType) -> Result<ToolResu
         ToolType::ResetBashContainer => reset_bash(conversation_id).await,
         ToolType::ViewImage { path } => {
             let image = pull_image(conversation_id, &path).await?;
-            let note = format!("Image '{path}' loaded — shown below. Only you can see it; it is hidden from the user.");
+            let note = format!("Image '{path}' loaded — shown below. This is for your eyes only: the user has NOT seen this image.");
             Ok(ToolResultData {
                 actual: note.clone(),
                 simplified: note,
@@ -320,7 +320,7 @@ async fn run_tool(conversation_id: &str, tool_type: ToolType) -> Result<ToolResu
         }
         ToolType::SendImageToUser { path } => {
             let image = pull_image(conversation_id, &path).await?;
-            let note = format!("Image '{path}' sent to the user — they can see it in the chat, and you can see it too.");
+            let note = format!("Image '{path}' sent to the user — Both you and the user can see it.");
             Ok(ToolResultData {
                 actual: note.clone(),
                 simplified: note,

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -79,7 +79,7 @@ impl ToolKind {
                 json!({ "type": "object", "properties": {}, "required": [] }),
             ),
             ToolKind::ViewImage => (
-                "Look at an image file from your bash sandbox so you can see its contents. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). Only you see it — it is hidden from the user. Use it to inspect plots, screenshots, or downloaded images before deciding what to do next.",
+                "Privately inspect an image yourself — the user does NOT see it. To show or send an image to the user, use send_image_to_user instead. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). Use it to inspect plots, screenshots, or downloaded images before deciding what to do next.",
                 json!({
                     "type": "object",
                     "properties": {
@@ -89,7 +89,7 @@ impl ToolKind {
                 }),
             ),
             ToolKind::SendImageToUser => (
-                "Send an image file from your bash sandbox to the user in this chat. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). It goes to the user — they see it in the chat — and you see it too (it counts as a message you sent). Use it to deliver plots, generated images, or processed pictures.",
+                "Show an image to the user — send an image file from your bash sandbox into this chat so they can see it. This is how you display/share/show an image to the user; use it whenever they ask to see one. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). It goes to the user — they see it in the chat — and you see it too (it counts as a message you sent). Use it to deliver plots, generated images, or processed pictures.",
                 json!({
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
The model frequently picked `view_image` when asked to "show me the image" — which keeps the image private to the model and required a user correction ("only you can see the image with view image") before it switched to `send_image_to_user`. Both tools read the same bash sandbox, so the only deciding signal was the wording, and `view_image` led with *"Look at … so you can see its contents"*, matching "show me" better than the actual user-facing tool did.

This reworks both tool descriptions and both tool-result notes so visibility is explicit:
- `view_image` disclaims that the user sees it (private inspection only).
- `send_image_to_user` owns the show/share framing; its result note states both parties can see the image.

Wording-only; no behavior change. Log to #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)