### PR TITLE
chatbot: read_file/edit_file tools with optimistic concurrency

### DIFF
--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -1,6 +1,8 @@
 use crate::types::conversation::ToolResultData;
 use crate::types::media::{Image, MessageImage};
+use std::process::Stdio;
 use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 const WORKER_IMAGE: &str = "bot-worker:latest";
@@ -84,7 +86,7 @@ async fn spawn_worker(name: &str) -> Result<(), String> {
     ))
 }
 
-fn clip(s: &str) -> String {
+pub(crate) fn clip(s: &str) -> String {
     const MAX: usize = 20_000;
     if s.chars().count() > MAX {
         let head: String = s.chars().take(MAX).collect();
@@ -127,6 +129,57 @@ pub async fn pull_image(conversation_id: &str, path: &str) -> Result<MessageImag
         mime: format.to_mime_type().to_string(),
     };
     Ok(MessageImage::Hydrated(image).downscaled())
+}
+
+/// Read a text file from the sandbox, returning its raw contents (lossy UTF-8). The tool layer
+/// adds line numbers, slicing, and the content hash.
+pub async fn read_file(conversation_id: &str, path: &str) -> Result<String, String> {
+    let name = worker_name(conversation_id);
+    ensure_worker(&name).await?;
+
+    let out = docker(&["exec", &name, "cat", "--", path]).await?;
+    if !out.status.success() {
+        return Err(format!(
+            "could not read '{path}': {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Overwrite a file in the sandbox with `content` (creates or truncates). Used by edit_file once
+/// it has applied the replacement in memory.
+pub async fn write_file(conversation_id: &str, path: &str, content: &str) -> Result<(), String> {
+    let name = worker_name(conversation_id);
+    ensure_worker(&name).await?;
+
+    let mut child = Command::new("docker")
+        .args(["exec", "-i", &name, "tee", "--", path])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to invoke docker: {e}"))?;
+
+    child
+        .stdin
+        .take()
+        .expect("stdin was piped")
+        .write_all(content.as_bytes())
+        .await
+        .map_err(|e| format!("failed to stream '{path}' to sandbox: {e}"))?;
+
+    let out = child
+        .wait_with_output()
+        .await
+        .map_err(|e| format!("failed to write '{path}': {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "could not write '{path}': {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(())
 }
 
 pub async fn reset_bash(conversation_id: &str) -> Result<ToolResultData, String> {

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -1,6 +1,8 @@
 use crate::{
     configuration::client_tokens::{BRAVE_SEARCH_TOKEN, SEARXNG_URL},
-    externals::bash_container_external::{pull_image, reset_bash, run_bash},
+    externals::bash_container_external::{
+        clip, pull_image, read_file, reset_bash, run_bash, write_file,
+    },
     types::conversation::{
         ToolCall, ToolResultData, ToolType, ConversationAction,
         MAX_SEARCH_DESCRIPTION_LENGTH,
@@ -8,6 +10,9 @@ use crate::{
 };
 use rs_trafilatura::extract;
 use serde::Deserialize;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
 #[derive(Deserialize)]
 struct SearxngResponse {
@@ -302,7 +307,42 @@ async fn fetch_url_content(url: &str) -> anyhow::Result<ToolResultData> {
     Ok(ToolResultData::text(actual, simplified))
 }
 
-async fn run_tool(conversation_id: &str, tool_type: ToolType) -> Result<ToolResultData, String> {
+/// A stable content fingerprint for optimistic concurrency: `read_file` stamps it into
+/// `metadata["file_hash"]`, and a later `edit_file` checks the live file against the version that
+/// was last read. Non-cryptographic (std SipHash) — change-detection only, not integrity.
+fn content_hash(content: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Render `count` lines starting at 1-based `from` with absolute line-number prefixes
+/// (`<n>\t<line>`), mirroring the Read convention so `edit_file`'s exact-string matching can strip
+/// the prefix. Numbers reflect true file position even when a slice is requested.
+fn number_lines(content: &str, from: usize, count: usize) -> String {
+    content
+        .lines()
+        .enumerate()
+        .skip(from.saturating_sub(1))
+        .take(count)
+        .map(|(i, line)| format!("{}\t{}", i + 1, line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A git-style diff of an exact-string replacement: removed text as `-` lines, new text as `+`
+/// lines. `old_string` already carries the context the model chose, so no extra context is added.
+fn render_diff(old: &str, new: &str) -> String {
+    let removed = old.lines().map(|l| format!("- {l}"));
+    let added = new.lines().map(|l| format!("+ {l}"));
+    removed.chain(added).collect::<Vec<_>>().join("\n")
+}
+
+async fn run_tool(
+    conversation_id: &str,
+    tool_type: ToolType,
+    expected_file_hash: Option<String>,
+) -> Result<ToolResultData, String> {
     match tool_type {
         ToolType::WebSearch { query } => fetch_web_search(&query).await.map_err(|e| e.to_string()),
         ToolType::VisitUrl { url } => fetch_url_content(&url).await.map_err(|e| e.to_string()),
@@ -316,6 +356,7 @@ async fn run_tool(conversation_id: &str, tool_type: ToolType) -> Result<ToolResu
                 simplified: note,
                 image_for_assistant: Some(image),
                 image_for_user: None,
+                metadata: HashMap::new(),
             })
         }
         ToolType::SendImageToUser { path } => {
@@ -326,14 +367,70 @@ async fn run_tool(conversation_id: &str, tool_type: ToolType) -> Result<ToolResu
                 simplified: note,
                 image_for_assistant: None,
                 image_for_user: Some(image),
+                metadata: HashMap::new(),
+            })
+        }
+        ToolType::ReadFile { path, offset, limit } => {
+            let content = read_file(conversation_id, &path).await?;
+            let hash = content_hash(&content);
+            let from = offset.unwrap_or(1).max(1);
+            let count = limit.unwrap_or(usize::MAX);
+            let numbered = number_lines(&content, from, count);
+            let body = if numbered.is_empty() {
+                format!("(file '{path}' is empty, or the requested line range has no lines)")
+            } else {
+                clip(&numbered)
+            };
+            Ok(ToolResultData {
+                actual: body.clone(),
+                simplified: body,
+                image_for_assistant: None,
+                image_for_user: None,
+                metadata: HashMap::from([("file_hash".to_string(), hash)]),
+            })
+        }
+        ToolType::EditFile { path, old_string, new_string } => {
+            let content = read_file(conversation_id, &path).await?;
+            let live_hash = content_hash(&content);
+            match expected_file_hash {
+                None => return Err(format!(
+                    "'{path}' hasn't been read yet — call read_file on it before editing."
+                )),
+                Some(h) if h != live_hash => return Err(format!(
+                    "'{path}' has changed since you last read it — call read_file on it again before editing."
+                )),
+                Some(_) => {}
+            }
+            match content.matches(&old_string).count() {
+                0 => return Err(format!(
+                    "old_string was not found in '{path}'. Copy it exactly from read_file output (without the line-number prefixes)."
+                )),
+                1 => {}
+                n => return Err(format!(
+                    "old_string appears {n} times in '{path}' — include more surrounding context so it matches exactly once."
+                )),
+            }
+            let updated = content.replacen(&old_string, &new_string, 1);
+            write_file(conversation_id, &path, &updated).await?;
+            let body = format!("Edited '{path}':\n{}", render_diff(&old_string, &new_string));
+            Ok(ToolResultData {
+                actual: body.clone(),
+                simplified: body,
+                image_for_assistant: None,
+                image_for_user: None,
+                metadata: HashMap::from([("file_hash".to_string(), content_hash(&updated))]),
             })
         }
     }
 }
 
-pub async fn execute_tool(conversation_id: String, tool_call: ToolCall) -> ConversationAction {
+pub async fn execute_tool(
+    conversation_id: String,
+    tool_call: ToolCall,
+    expected_file_hash: Option<String>,
+) -> ConversationAction {
     let tool_name = tool_call.tool_type.wire_name().to_string();
-    let result = run_tool(&conversation_id, tool_call.tool_type).await;
+    let result = run_tool(&conversation_id, tool_call.tool_type, expected_file_hash).await;
     if let Err(err) = &result {
         eprintln!("[tool {tool_name} id {}] failed: {err}", tool_call.id);
     }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -3,7 +3,9 @@ use crate::externals::{
     message_external::{send_message, Attachment, OutboundMessage},
     tool_call_external::execute_tool,
 };
-use crate::types::conversation::{ToolResult, ToolResultData, MAX_TOOL_ROUNDS};
+use crate::types::conversation::{
+    latest_file_hash, ToolResult, ToolResultData, ToolType, MAX_TOOL_ROUNDS,
+};
 use crate::{
     types::conversation::{
         Conversation, ConversationAction, ConversationConstructor, ConversationId,
@@ -144,9 +146,20 @@ fn apply_post_send(
             tool_rounds,
             tool_calls,
         } => {
+            let history = recent_conversation.history();
             let mut pending_tools = HashMap::new();
             for tool_call in tool_calls {
-                effects.enqueue_external(execute_tool(conversation_id.to_string(), tool_call.clone()));
+                let expected_file_hash = match &tool_call.tool_type {
+                    ToolType::EditFile { path, .. } => {
+                        latest_file_hash(&history, path).map(str::to_string)
+                    }
+                    _ => None,
+                };
+                effects.enqueue_external(execute_tool(
+                    conversation_id.to_string(),
+                    tool_call.clone(),
+                    expected_file_hash,
+                ));
                 pending_tools.insert(tool_call.id.clone(), tool_call);
             }
 
@@ -349,10 +362,7 @@ fn conversation_transition(
 
                 let results = completed_tools
                     .into_iter()
-                    .map(|(tool_call, data)| ToolResult {
-                        id: tool_call.id,
-                        data,
-                    })
+                    .map(|(call, data)| ToolResult { call, data })
                     .collect();
 
                 let mut pending = conversation.pending;

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -117,7 +117,7 @@ impl ToolKind {
                 }),
             ),
             ToolKind::ReadFile => (
-                "Read a text file from your bash sandbox — the SAME private Linux environment as run_bash_command. Returns the file's contents with line numbers. Reads the whole file by default; for a large file, pass offset and/or limit to read a slice. You must read a file with this tool before you can change it with edit_file.",
+                "Read a text file from your bash sandbox — the SAME private Linux environment as run_bash_command. Returns the file's contents with line numbers. Reads the whole file by default; for a large file, pass offset and/or limit to read a slice.",
                 json!({
                     "type": "object",
                     "properties": {
@@ -129,7 +129,7 @@ impl ToolKind {
                 }),
             ),
             ToolKind::EditFile => (
-                "Edit a text file in your bash sandbox by replacing an exact string. `old_string` must appear EXACTLY ONCE in the current file — include enough surrounding context to make it unique — and is replaced with `new_string`. You MUST read_file the file first, and it must not have changed since you read it (e.g. via run_bash_command); otherwise the edit is rejected and you must read_file it again. Returns a diff of the change.",
+                "Edit a text file in your bash sandbox by replacing an exact string. `old_string` must appear EXACTLY ONCE in the current file — include enough surrounding context to make it unique — and is replaced with `new_string`. Returns a diff of the change.",
                 json!({
                     "type": "object",
                     "properties": {

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -25,6 +25,22 @@ struct PathArgs {
     path: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct ReadFileArgs {
+    path: String,
+    #[serde(default)]
+    offset: Option<usize>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EditFileArgs {
+    path: String,
+    old_string: String,
+    new_string: String,
+}
+
 fn parse_args<T: serde::de::DeserializeOwned>(name: &str, arguments: &str) -> anyhow::Result<T> {
     serde_json::from_str(arguments)
         .map_err(|e| anyhow::anyhow!("{name} arguments failed to bind: {e} — raw: {arguments}"))
@@ -39,6 +55,8 @@ impl ToolKind {
             ToolKind::ResetBashContainer => "reset_bash_container",
             ToolKind::ViewImage => "view_image",
             ToolKind::SendImageToUser => "send_image_to_user",
+            ToolKind::ReadFile => "read_file",
+            ToolKind::EditFile => "edit_file",
         }
     }
 
@@ -98,6 +116,30 @@ impl ToolKind {
                     "required": ["path"]
                 }),
             ),
+            ToolKind::ReadFile => (
+                "Read a text file from your bash sandbox — the SAME private Linux environment as run_bash_command. Returns the file's contents with line numbers. Reads the whole file by default; for a large file, pass offset and/or limit to read a slice. You must read a file with this tool before you can change it with edit_file.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Path to the file inside your bash sandbox, e.g. \"/home/user/app/main.py\" or \"notes.txt\" (relative to the sandbox working directory)." },
+                        "offset": { "type": "integer", "description": "1-based line number to start reading from. Defaults to the first line." },
+                        "limit": { "type": "integer", "description": "Maximum number of lines to read, starting at offset. Defaults to the rest of the file." }
+                    },
+                    "required": ["path"]
+                }),
+            ),
+            ToolKind::EditFile => (
+                "Edit a text file in your bash sandbox by replacing an exact string. `old_string` must appear EXACTLY ONCE in the current file — include enough surrounding context to make it unique — and is replaced with `new_string`. You MUST read_file the file first, and it must not have changed since you read it (e.g. via run_bash_command); otherwise the edit is rejected and you must read_file it again. Returns a diff of the change.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string", "description": "Path to the file inside your bash sandbox (the same one you read_file'd)." },
+                        "old_string": { "type": "string", "description": "The exact text to replace, copied from read_file output WITHOUT the line-number prefixes. Must match the file exactly (whitespace included) and be unique." },
+                        "new_string": { "type": "string", "description": "The text to put in its place. Use an empty string to delete the matched text." }
+                    },
+                    "required": ["path", "old_string", "new_string"]
+                }),
+            ),
         };
         ToolDefinition {
             kind: "function",
@@ -119,8 +161,8 @@ impl ToolType {
         ToolKind::from(self).wire_name()
     }
 
-    /// Argument values as an order-preserving map of stringified values, ready to splice into a
-    /// rendered tool call. (All current tools take single string args.)
+    /// Argument values as an order-preserving map, ready to splice into a rendered tool call.
+    /// Most tools take a single string arg; read_file also carries optional integer offset/limit.
     pub fn arguments_map(&self) -> Map<String, Value> {
         match self {
             ToolType::WebSearch { query } => {
@@ -137,6 +179,29 @@ impl ToolType {
             ToolType::SendImageToUser { path } => {
                 [("path".to_string(), json!(path))].into_iter().collect()
             }
+            ToolType::ReadFile {
+                path,
+                offset,
+                limit,
+            } => [
+                Some(("path".to_string(), json!(path))),
+                offset.as_ref().map(|n| ("offset".to_string(), json!(n))),
+                limit.as_ref().map(|n| ("limit".to_string(), json!(n))),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+            ToolType::EditFile {
+                path,
+                old_string,
+                new_string,
+            } => [
+                ("path".to_string(), json!(path)),
+                ("old_string".to_string(), json!(old_string)),
+                ("new_string".to_string(), json!(new_string)),
+            ]
+            .into_iter()
+            .collect(),
         }
     }
 
@@ -162,6 +227,22 @@ impl ToolType {
             ToolKind::SendImageToUser => Ok(ToolType::SendImageToUser {
                 path: parse_args::<PathArgs>(name, arguments)?.path,
             }),
+            ToolKind::ReadFile => {
+                let args = parse_args::<ReadFileArgs>(name, arguments)?;
+                Ok(ToolType::ReadFile {
+                    path: args.path,
+                    offset: args.offset,
+                    limit: args.limit,
+                })
+            }
+            ToolKind::EditFile => {
+                let args = parse_args::<EditFileArgs>(name, arguments)?;
+                Ok(ToolType::EditFile {
+                    path: args.path,
+                    old_string: args.old_string,
+                    new_string: args.new_string,
+                })
+            }
         }
     }
 }

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -274,7 +274,7 @@ impl LLMInput {
                             ),
                         }
                     }
-                    messages.push(ChatMessage::tool(r.id.clone(), parts.join("\n")));
+                    messages.push(ChatMessage::tool(r.call.id.clone(), parts.join("\n")));
                 }
 
                 if !delivered.is_empty() {
@@ -306,6 +306,16 @@ pub enum ToolType {
     ResetBashContainer,
     ViewImage { path: String },
     SendImageToUser { path: String },
+    ReadFile {
+        path: String,
+        offset: Option<usize>,
+        limit: Option<usize>,
+    },
+    EditFile {
+        path: String,
+        old_string: String,
+        new_string: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -316,7 +326,9 @@ pub struct ToolCall {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
-    pub id: String,
+    /// The originating call, carried into history so a result can be matched back to the tool and
+    /// its arguments (e.g. the `path` an `EditFile`/`ReadFile` acted on) without parsing prose.
+    pub call: ToolCall,
     pub data: ToolResultData,
 }
 
@@ -380,6 +392,26 @@ pub enum HistoryEntry {
     Output(LLMResponse),
 }
 
+/// The most recently observed content hash for `path`, scanning history newest-first for a
+/// `read_file`/`edit_file` result on that path. This is the optimistic-concurrency token: an edit
+/// is valid only if the live file still matches it. `None` means the path hasn't been read within
+/// the recent window — the model must read it first.
+pub fn latest_file_hash<'a>(history: &'a [HistoryEntry], path: &str) -> Option<&'a str> {
+    history.iter().rev().find_map(|entry| match entry {
+        HistoryEntry::Input(LLMInput::ToolResults(results, _)) => {
+            results.iter().rev().find_map(|r| match &r.call.tool_type {
+                ToolType::ReadFile { path: p, .. } | ToolType::EditFile { path: p, .. }
+                    if p == path =>
+                {
+                    r.data.metadata.get("file_hash").map(String::as_str)
+                }
+                _ => None,
+            })
+        }
+        _ => None,
+    })
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub enum ConversationAction {
     ForceReset,
@@ -405,16 +437,21 @@ pub struct ToolResultData {
     pub image_for_assistant: Option<MessageImage>,
     /// Image delivered straight to the chat, bypassing the model.
     pub image_for_user: Option<MessageImage>,
+    /// Structured side-channel for data the model doesn't read but the system uses. Kept in
+    /// history, never rendered into the prompt. E.g. `read_file`/`edit_file` set `"file_hash"`
+    /// so a later edit can be checked against the version that was last observed.
+    pub metadata: HashMap<String, String>,
 }
 
 impl ToolResultData {
-    /// Text-only result — no images for either side. The common case.
+    /// Text-only result — no images for either side, no metadata. The common case.
     pub fn text(actual: String, simplified: String) -> Self {
         ToolResultData {
             actual,
             simplified,
             image_for_assistant: None,
             image_for_user: None,
+            metadata: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
Adds two sandbox file tools modelled on the Claude Code Read/Edit pair, with read-before-edit optimistic concurrency.

## Tools
- **`read_file { path, offset?, limit? }`** — `cat`s the file from the per-conversation bash sandbox, renders it line-numbered (`<n>\t<line>`, absolute numbers even when sliced via `offset`/`limit`), clips at 20k chars, and stamps the content hash.
- **`edit_file { path, old_string, new_string }`** — exact-string replacement that must match **exactly once** (0/>1 → instructive error); returns a git-style `-`/`+` diff. `new_string=""` deletes.

## Optimistic concurrency
Derived purely from **structured history** (no prose parsing):
- `ToolResult` now carries its originating `ToolCall`, and `ToolResultData` gains a `metadata: HashMap<String,String>` side-channel (sibling to the image fields, never rendered into the prompt). `read_file`/`edit_file` set `metadata["file_hash"]`.
- `latest_file_hash()` scans history newest-first for the last read/edit of a path.
- At **dispatch**, the state machine computes the expected hash for an `EditFile` call and passes it into the tool. `edit_file` rejects when the path was never read (`None` → "read it first") or the live file no longer matches (changed via `run_bash_command` etc. → "read it again"); otherwise it applies the edit and stamps the new hash, which flows back into history as the new latest.

Hash is std SipHash (`DefaultHasher`) — change-detection only, no new deps.

## Deferred
Two `edit_file` calls to the same path in one parallel round both pass the same pre-round hash and race on the write. Known, intentionally left for a later pass.

Verified: `cargo check` clean (pre-existing config warnings only). Not yet exercised against a live sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)