### PR TITLE
Fix post-tool-call silences: context bloat + n_ctx headroom

### DIFF
--- a/chatbot/models/qwen-qwen3-6-35b-a3b/manifest.toml
+++ b/chatbot/models/qwen-qwen3-6-35b-a3b/manifest.toml
@@ -7,7 +7,7 @@ top_k = 20
 top_p = 0.95
 
 [context]
-n_ctx = 32768
+n_ctx = 196608
 n_batch = 4096
 batch_chunk = 2048
 max_generation_tokens = 8192

--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -86,10 +86,15 @@ async fn spawn_worker(name: &str) -> Result<(), String> {
     ))
 }
 
-pub(crate) fn clip(s: &str) -> String {
-    const MAX: usize = 20_000;
-    if s.chars().count() > MAX {
-        let head: String = s.chars().take(MAX).collect();
+/// Truncation cap for a tool result's full `actual` form (rendered for the live turn).
+pub(crate) const ACTUAL_MAX: usize = 20_000;
+/// Truncation cap for the compact `simplified` form. Older tool results in history fall back
+/// to `simplified`; only the live turn keeps `actual`.
+pub(crate) const SIMPLIFIED_MAX: usize = 2_000;
+
+pub(crate) fn clip_to(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let head: String = s.chars().take(max).collect();
         format!("{head}\n…[output truncated]")
     } else {
         s.to_string()
@@ -101,12 +106,13 @@ pub async fn run_bash(conversation_id: &str, command: &str) -> Result<ToolResult
     ensure_worker(&name).await?;
 
     let out = docker(&["exec", &name, "bash", "-c", command]).await?;
-    let stdout = clip(&String::from_utf8_lossy(&out.stdout));
-    let stderr = clip(&String::from_utf8_lossy(&out.stderr));
+    let stdout = clip_to(&String::from_utf8_lossy(&out.stdout), ACTUAL_MAX);
+    let stderr = clip_to(&String::from_utf8_lossy(&out.stderr), ACTUAL_MAX);
     let code = out.status.code().unwrap_or(-1);
 
     let body = format!("exit code: {code}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
-    Ok(ToolResultData::text(body.clone(), body))
+    let simplified = clip_to(&body, SIMPLIFIED_MAX);
+    Ok(ToolResultData::text(body, simplified))
 }
 
 pub async fn pull_image(conversation_id: &str, path: &str) -> Result<MessageImage, String> {

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -99,7 +99,7 @@ fn build_conversation(
     for entry in &history {
         match entry {
             HistoryEntry::Input(input) => {
-                let (msgs, bytes) = input.messages_and_media(marker);
+                let (msgs, bytes) = input.messages_and_media(marker, false);
                 messages.extend(msgs);
                 images.extend(bytes);
             }
@@ -107,7 +107,7 @@ fn build_conversation(
         }
     }
 
-    let (live_msgs, live_bytes) = new_input.messages_and_media(marker);
+    let (live_msgs, live_bytes) = new_input.messages_and_media(marker, true);
     messages.extend(live_msgs);
     images.extend(live_bytes);
 

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -1,7 +1,7 @@
 use crate::{
     configuration::client_tokens::{BRAVE_SEARCH_TOKEN, SEARXNG_URL},
     externals::bash_container_external::{
-        clip, pull_image, read_file, reset_bash, run_bash, write_file,
+        clip_to, pull_image, read_file, reset_bash, run_bash, write_file, ACTUAL_MAX, SIMPLIFIED_MAX,
     },
     types::conversation::{
         ToolCall, ToolResultData, ToolType, ConversationAction,
@@ -410,11 +410,11 @@ async fn run_tool(
             let body = if numbered.is_empty() {
                 format!("(file '{path}' is empty, or the requested line range has no lines)")
             } else {
-                clip(&numbered)
+                clip_to(&numbered, ACTUAL_MAX)
             };
             Ok(ToolResultData {
-                actual: body.clone(),
-                simplified: body,
+                simplified: clip_to(&body, SIMPLIFIED_MAX),
+                actual: body,
                 image_for_assistant: None,
                 image_for_user: None,
                 metadata: HashMap::from([("file_hash".to_string(), hash)]),
@@ -445,8 +445,8 @@ async fn run_tool(
             write_file(conversation_id, &path, &updated).await?;
             let body = format!("Edited '{path}':\n{}", render_diff(&content, &old_string, &new_string));
             Ok(ToolResultData {
-                actual: body.clone(),
-                simplified: body,
+                simplified: clip_to(&body, SIMPLIFIED_MAX),
+                actual: body,
                 image_for_assistant: None,
                 image_for_user: None,
                 metadata: HashMap::from([("file_hash".to_string(), content_hash(&updated))]),

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -236,7 +236,11 @@ impl LLMInput {
         }
     }
 
-    pub fn messages_and_media(&self, marker: &str) -> (Vec<ChatMessage>, Vec<Arc<Vec<u8>>>) {
+    pub fn messages_and_media(
+        &self,
+        marker: &str,
+        full: bool,
+    ) -> (Vec<ChatMessage>, Vec<Arc<Vec<u8>>>) {
         match self {
             LLMInput::ConversationMessage(msg) => {
                 let (content, bytes) = msg.content_and_media(marker);
@@ -249,8 +253,9 @@ impl LLMInput {
 
                 for r in results {
                     let mut parts: Vec<String> = Vec::new();
-                    if !r.data.actual.is_empty() {
-                        parts.push(r.data.actual.clone());
+                    let text = if full { &r.data.actual } else { &r.data.simplified };
+                    if !text.is_empty() {
+                        parts.push(text.clone());
                     }
                     if let Some(image) = &r.data.image_for_user {
                         match image.hydrated_bytes() {


### PR DESCRIPTION
## Problem

The bot would call a tool (e.g. `run_bash_command`) and then go **dead silent** — users saw it fire a tool, then nothing (*"Are you not getting tool results?"*).

Root cause, from the live logs:
1. **`simplified` tool results were never used.** `ToolResultData.simplified` was written by every tool but read by nothing — `messages_and_media` always emitted `actual` (full). So every bash dump / page fetch stayed full-size in the prompt forever, and a tool-heavy turn accumulated unbounded context.
2. That bloat eventually blew the input budget (24,576 tokens at the old 32K `n_ctx`) → llama.cpp `NoKvCacheSlot` / `Eval failed` decode errors.
3. The decode error hit a **silent, lossy error path** ([conversation_state_machine.rs:308](../blob/main/chatbot/src/state_machines/conversation_state_machine.rs#L308)) that reverts history to the pre-tool-result snapshot and sends nothing — so the bot dropped the result and went quiet.

## Changes

- **Render `simplified` for history, `full` only for the live turn.** `messages_and_media` takes a `full` flag; `build_conversation` passes `true` for the live input and `false` for everything already in history. Older tool rounds now collapse to their compact form while the model still sees the current result in full.
- **Give bash/read_file/edit_file a real `simplified`.** They had `simplified == actual`; now truncated via `clip_to(.., SIMPLIFIED_MAX=2000)`. Generalized `clip` → `clip_to(s, max)`; `actual` uses `ACTUAL_MAX=20000`.
- **Bump `n_ctx` 32768 → 196608** (75% of the model's native 256K). The iGPU has a 103 GB unified-memory carveout (~66 GB free after the 37 GB model); a measured 196K context adds only ~5 GB KV+compute. Input budget is now ~188K.

`metadata.file_hash` is untouched (it lives on `ToolResultData`, not the rendered text), so edit_file's read-before-edit/staleness logic still works when a read_file result renders simplified.

## Verification
- `cargo check` clean.
- 196K context verified live: inference ran without OOM, VRAM peaked 42.8 GB (of 103 GB), ~5 GB for the cache.

## Follow-ups (not in this PR)
- The silent lossy error handler should speak + not drop history on a decode error.
- Per-request `new_context` re-tokenizes/reallocates every call — a context-reuse refactor would cut latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)