### PR TITLE
chatbot: fix Dockerfile workspace COPY members

### DIFF
--- a/chatbot/Dockerfile
+++ b/chatbot/Dockerfile
@@ -22,7 +22,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY chatbot/src ./chatbot/src
 COPY chatbot/Cargo.toml ./chatbot/
 COPY re_framework ./re_framework
-COPY framework ./framework
+COPY sample_framework_project ./sample_framework_project
 COPY probe ./probe
 COPY extractor ./extractor
 COPY .git ./.git


### PR DESCRIPTION
The chatbot image build was broken on `main`: the builder stage COPYs each workspace member dir (cargo parses every member's `Cargo.toml` even for `--package chatbot`), but it still referenced `framework` — the dead member dropped in #187 — and never copied `sample_framework_project`, added in #188.

Result: `docker build` failed at `COPY framework ./framework: "/framework": not found`. Surfaced by running `just deploy_local` after the #188 merge.

Fix: drop `COPY framework`, add `COPY sample_framework_project`. Workspace members now match the Dockerfile.

Verified: `just deploy_local` gets past the COPY stage and into `cargo build --package chatbot` with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)