### PR TITLE
Memory manager entity + compaction skeleton (#199)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "tokio",
  "toml",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/chatbot/Cargo.toml
+++ b/chatbot/Cargo.toml
@@ -28,6 +28,7 @@ serenity = { version = "0.12", default-features = false, features = [
     "cache",
 ] }
 regex = "1.12"
+uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.13", features = ["json"] }
 urlencoding = "2.1"

--- a/chatbot/models/qwen3-4b/chat_template.jinja
+++ b/chatbot/models/qwen3-4b/chat_template.jinja
@@ -1,0 +1,89 @@
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if loop.last or (not loop.last and reasoning_content) %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}

--- a/chatbot/models/qwen3-4b/manifest.toml
+++ b/chatbot/models/qwen3-4b/manifest.toml
@@ -1,0 +1,20 @@
+model    = "Qwen3-4B-Q6_K.gguf"
+template = "chat_template.jinja"
+
+[sampling]
+top_k = 20
+top_p = 0.8
+
+[context]
+n_ctx = 32768
+n_batch = 2048
+batch_chunk = 512
+max_generation_tokens = 2048
+
+[format]
+enable_thinking       = false
+add_generation_prompt = true
+parser                = "qwen"
+
+[thinking]
+close_marker = "</think>"

--- a/chatbot/src/externals.rs
+++ b/chatbot/src/externals.rs
@@ -1,4 +1,5 @@
 pub mod bash_container_external;
 pub mod llama_cpp_external;
 pub mod message_external;
+pub mod summarize_external;
 pub mod tool_call_external;

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -2,7 +2,7 @@ use crate::{
     chat_format::ChatMessage,
     roles::{PrimaryRole, RenderInputs, Role},
     types::conversation::{
-        ConversationAction, HistoryEntry, InterruptionReason, LLMInput, LLMResponse, Platform,
+        ConversationAction, HistoryEntryKind, InterruptionReason, LLMInput, LLMResponse, Platform,
         RecentConversation, Reply, ToolCall, ToolType,
     },
     Env,
@@ -97,17 +97,17 @@ fn build_conversation(
     let mut images: Vec<Arc<Vec<u8>>> = Vec::new();
 
     for entry in &history {
-        match entry {
-            HistoryEntry::Input(input) => {
+        match &entry.kind {
+            HistoryEntryKind::Input(input) => {
                 let (msgs, bytes) = input.messages_and_media(marker, false);
                 messages.extend(msgs);
                 images.extend(bytes);
             }
-            HistoryEntry::Output(response) => messages.push(response.to_chat_message()),
-            HistoryEntry::OutputInterrupted(reason) => {
+            HistoryEntryKind::Output(response) => messages.push(response.to_chat_message()),
+            HistoryEntryKind::OutputInterrupted(reason) => {
                 messages.push(ChatMessage::assistant(reason.note()))
             }
-            HistoryEntry::Summary(summary) => messages.push(ChatMessage::assistant(format!(
+            HistoryEntryKind::Summary(summary) => messages.push(ChatMessage::assistant(format!(
                 "[Summary of earlier conversation, condensed to save context]\n{summary}"
             ))),
         }

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -107,6 +107,9 @@ fn build_conversation(
             HistoryEntry::OutputInterrupted(reason) => {
                 messages.push(ChatMessage::assistant(reason.note()))
             }
+            HistoryEntry::Summary(summary) => messages.push(ChatMessage::assistant(format!(
+                "[Summary of earlier conversation, condensed to save context]\n{summary}"
+            ))),
         }
     }
 

--- a/chatbot/src/externals/summarize_external.rs
+++ b/chatbot/src/externals/summarize_external.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use crate::chat_format::ChatMessage;
 use crate::roles::{RenderInputs, Role};
-use crate::types::conversation::{ConversationMessage, HistoryEntry, InterruptionReason, LLMInput};
+use crate::types::conversation::{
+    CompactionOutput, ConversationMessage, HistoryEntry, HistoryEntryKind, InterruptionReason,
+    LLMInput,
+};
 use crate::types::memory::MemoryManagerAction;
 use crate::Env;
 
@@ -20,14 +23,14 @@ fn render_message(msg: &ConversationMessage) -> String {
 fn history_to_transcript(history: &[HistoryEntry]) -> String {
     let mut lines: Vec<String> = Vec::new();
     for entry in history {
-        match entry {
-            HistoryEntry::Summary(summary) => {
+        match &entry.kind {
+            HistoryEntryKind::Summary(summary) => {
                 lines.push(format!("Summary of earlier conversation:\n{summary}"))
             }
-            HistoryEntry::Input(LLMInput::ConversationMessage(msg)) => {
+            HistoryEntryKind::Input(LLMInput::ConversationMessage(msg)) => {
                 lines.push(render_message(msg))
             }
-            HistoryEntry::Input(LLMInput::ToolResults(results, followup)) => {
+            HistoryEntryKind::Input(LLMInput::ToolResults(results, followup)) => {
                 for result in results {
                     let mut line = format!(
                         "Tool result [{}]: {}",
@@ -46,7 +49,7 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
                     lines.push(render_message(msg));
                 }
             }
-            HistoryEntry::Output(response) => {
+            HistoryEntryKind::Output(response) => {
                 if let Some(message) = response.message() {
                     lines.push(format!("Assistant: {message}"));
                 }
@@ -54,7 +57,7 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
                     lines.push(format!("Assistant called tool: {}", call.tool_type.wire_name()));
                 }
             }
-            HistoryEntry::OutputInterrupted(reason) => {
+            HistoryEntryKind::OutputInterrupted(reason) => {
                 lines.push(format!("Assistant: {}", reason.note()))
             }
         }
@@ -65,6 +68,11 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
 pub async fn summarize(env: Arc<Env>, history: Vec<HistoryEntry>) -> MemoryManagerAction {
     let Some(utility) = env.utility.clone() else {
         eprintln!("[compact] utility model unavailable — skipping compaction");
+        return MemoryManagerAction::CompactionDone(Err(InterruptionReason::Failed));
+    };
+
+    let Some(through) = history.last().map(|entry| entry.id.clone()) else {
+        eprintln!("[compact] empty history — nothing to compact");
         return MemoryManagerAction::CompactionDone(Err(InterruptionReason::Failed));
     };
 
@@ -89,7 +97,7 @@ pub async fn summarize(env: Arc<Env>, history: Vec<HistoryEntry>) -> MemoryManag
                 .map_or(raw.as_str(), |(_, after)| after)
                 .trim()
                 .to_string();
-            MemoryManagerAction::CompactionDone(Ok(summary))
+            MemoryManagerAction::CompactionDone(Ok(CompactionOutput { summary, through }))
         }
         Err(e) => {
             eprintln!("[compact] summarization failed: {e:#}");

--- a/chatbot/src/externals/summarize_external.rs
+++ b/chatbot/src/externals/summarize_external.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use crate::chat_format::ChatMessage;
+use crate::roles::{RenderInputs, Role};
+use crate::types::conversation::{HistoryEntry, InterruptionReason, LLMInput};
+use crate::types::memory::MemoryManagerAction;
+use crate::Env;
+
+fn history_to_transcript(history: &[HistoryEntry]) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for entry in history {
+        match entry {
+            HistoryEntry::Summary(summary) => {
+                lines.push(format!("Summary of earlier conversation:\n{summary}"))
+            }
+            HistoryEntry::Input(LLMInput::ConversationMessage(msg)) => {
+                lines.push(format!("{}: {}", msg.name, msg.to_content()))
+            }
+            HistoryEntry::Input(LLMInput::ToolResults(results, followup)) => {
+                for result in results {
+                    lines.push(format!(
+                        "Tool result [{}]: {}",
+                        result.call.tool_type.wire_name(),
+                        result.data.simplified
+                    ));
+                }
+                if let Some(msg) = followup {
+                    lines.push(format!("{}: {}", msg.name, msg.to_content()));
+                }
+            }
+            HistoryEntry::Output(response) => {
+                if let Some(message) = response.message() {
+                    lines.push(format!("Assistant: {message}"));
+                }
+                for call in &response.tool_calls {
+                    lines.push(format!("Assistant called tool: {}", call.tool_type.wire_name()));
+                }
+            }
+            HistoryEntry::OutputInterrupted(reason) => {
+                lines.push(format!("Assistant: {}", reason.note()))
+            }
+        }
+    }
+    lines.join("\n")
+}
+
+pub async fn summarize(env: Arc<Env>, history: Vec<HistoryEntry>) -> MemoryManagerAction {
+    let Some(utility) = env.utility.clone() else {
+        eprintln!("[compact] utility model unavailable — skipping compaction");
+        return MemoryManagerAction::CompactionDone(Err(InterruptionReason::Failed));
+    };
+
+    let transcript = history_to_transcript(&history);
+    let prompt = match utility.render_prompt(&RenderInputs {
+        messages: &[ChatMessage::user(transcript)],
+        tools: None,
+        footer: None,
+    }) {
+        Ok(prompt) => prompt,
+        Err(e) => {
+            eprintln!("[compact] prompt render failed: {e:#}");
+            return MemoryManagerAction::CompactionDone(Err(InterruptionReason::Failed));
+        }
+    };
+
+    let close_marker = utility.thinking().close_marker;
+    match Arc::clone(&utility).generate(prompt, Vec::new()).await {
+        Ok(raw) => {
+            let summary = raw
+                .split_once(&close_marker)
+                .map_or(raw.as_str(), |(_, after)| after)
+                .trim()
+                .to_string();
+            MemoryManagerAction::CompactionDone(Ok(summary))
+        }
+        Err(e) => {
+            eprintln!("[compact] summarization failed: {e:#}");
+            MemoryManagerAction::CompactionDone(Err(InterruptionReason::Failed))
+        }
+    }
+}

--- a/chatbot/src/externals/summarize_external.rs
+++ b/chatbot/src/externals/summarize_external.rs
@@ -2,9 +2,20 @@ use std::sync::Arc;
 
 use crate::chat_format::ChatMessage;
 use crate::roles::{RenderInputs, Role};
-use crate::types::conversation::{HistoryEntry, InterruptionReason, LLMInput};
+use crate::types::conversation::{ConversationMessage, HistoryEntry, InterruptionReason, LLMInput};
 use crate::types::memory::MemoryManagerAction;
 use crate::Env;
+
+fn render_message(msg: &ConversationMessage) -> String {
+    let mut line = format!("{}: {}", msg.name, msg.to_content());
+    if !msg.images.is_empty() {
+        line.push_str(&format!(
+            " [attached {} image(s) — not visible to you]",
+            msg.images.len()
+        ));
+    }
+    line
+}
 
 fn history_to_transcript(history: &[HistoryEntry]) -> String {
     let mut lines: Vec<String> = Vec::new();
@@ -14,18 +25,25 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
                 lines.push(format!("Summary of earlier conversation:\n{summary}"))
             }
             HistoryEntry::Input(LLMInput::ConversationMessage(msg)) => {
-                lines.push(format!("{}: {}", msg.name, msg.to_content()))
+                lines.push(render_message(msg))
             }
             HistoryEntry::Input(LLMInput::ToolResults(results, followup)) => {
                 for result in results {
-                    lines.push(format!(
+                    let mut line = format!(
                         "Tool result [{}]: {}",
                         result.call.tool_type.wire_name(),
                         result.data.simplified
-                    ));
+                    );
+                    if result.data.image_for_assistant.is_some() {
+                        line.push_str(" [returned an image the assistant viewed — not visible to you]");
+                    }
+                    if result.data.image_for_user.is_some() {
+                        line.push_str(" [produced an image shown to the user — not visible to you]");
+                    }
+                    lines.push(line);
                 }
                 if let Some(msg) = followup {
-                    lines.push(format!("{}: {}", msg.name, msg.to_content()));
+                    lines.push(render_message(msg));
                 }
             }
             HistoryEntry::Output(response) => {

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -16,13 +16,15 @@ use services::discord::*;
 use std::sync::Arc;
 use tokio::task::JoinSet;
 
-use crate::roles::PrimaryRole;
+use crate::roles::{PrimaryRole, UtilityRole};
 use crate::state_machines::conversation_state_machine::ConversationMachine;
+use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
 
 #[derive(Clone)]
 pub struct Env {
     discord_http: Arc<Http>,
     primary: Arc<PrimaryRole>,
+    utility: Option<Arc<UtilityRole>>,
     announce_tool_use: bool,
 }
 
@@ -31,14 +33,31 @@ async fn init_env() -> anyhow::Result<Env> {
 
     send_logs_to_tracing(LogOptions::default().with_logs_enabled(false));
     let backend = Arc::new(LlamaBackend::init()?);
-    let primary =
-        Arc::new(tokio::task::spawn_blocking(move || PrimaryRole::load(backend)).await??);
+    let primary = Arc::new(
+        tokio::task::spawn_blocking({
+            let backend = Arc::clone(&backend);
+            move || PrimaryRole::load(backend)
+        })
+        .await??,
+    );
+
+    let utility = match tokio::task::spawn_blocking(move || UtilityRole::load(backend)).await? {
+        Ok(role) => {
+            println!("[startup] utility model ready");
+            Some(Arc::new(role))
+        }
+        Err(e) => {
+            eprintln!("[startup] utility model not loaded: {e:#} — compaction disabled");
+            None
+        }
+    };
 
     let discord_http = Arc::new(HttpBuilder::new(discord_token).build());
 
     Ok(Env {
         discord_http,
         primary,
+        utility,
         announce_tool_use: configuration::features::ANNOUNCE_TOOL_USE,
     })
 }
@@ -47,7 +66,8 @@ async fn init_env() -> anyhow::Result<Env> {
 async fn main() -> anyhow::Result<!> {
     re_framework::init_turso_store("framework_db/chatbot.db").await?;
     let env = init_env().await?;
-    re_framework::register::<ConversationMachine>(env);
+    re_framework::register::<ConversationMachine>(env.clone());
+    re_framework::register::<MemoryManagerMachine>(env);
     re_framework::start();
 
     tokio::spawn(async {

--- a/chatbot/src/model_pack.rs
+++ b/chatbot/src/model_pack.rs
@@ -11,7 +11,7 @@ pub struct Pack {
 #[derive(Debug, Deserialize)]
 pub struct Manifest {
     pub model: String,
-    pub mmproj: String,
+    pub mmproj: Option<String>,
     pub template: String,
     pub sampling: Sampling,
     pub context: Context,
@@ -73,7 +73,7 @@ impl Pack {
         self.dir.join(&self.manifest.model)
     }
 
-    pub fn mmproj_path(&self) -> PathBuf {
-        self.dir.join(&self.manifest.mmproj)
+    pub fn mmproj_path(&self) -> Option<PathBuf> {
+        self.manifest.mmproj.as_ref().map(|m| self.dir.join(m))
     }
 }

--- a/chatbot/src/roles.rs
+++ b/chatbot/src/roles.rs
@@ -2,6 +2,7 @@ mod local_model;
 mod parsers;
 mod primary_role;
 mod render;
+mod utility_role;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -9,6 +10,7 @@ use std::sync::Arc;
 use crate::chat_format::{ChatMessage, ToolDefinition};
 
 pub use primary_role::PrimaryRole;
+pub use utility_role::UtilityRole;
 
 pub trait Role: Send + Sync {
     fn system_prompt(&self) -> &str;

--- a/chatbot/src/roles/local_model.rs
+++ b/chatbot/src/roles/local_model.rs
@@ -21,7 +21,7 @@ const ADD_BOS_REEVAL_WHEN_CACHING_HITS: bool = false;
 const DRY_BREAKS_LONG_STRINGS: bool = true;
 
 pub(super) struct LocalModel {
-    mtmd: MtmdContext,
+    mtmd: Option<MtmdContext>,
     model: LlamaModel,
     backend: Arc<LlamaBackend>,
     cfg: GenConfig,
@@ -77,21 +77,30 @@ pub(super) fn load_model(backend: Arc<LlamaBackend>, pack: &Pack) -> anyhow::Res
     let model = LlamaModel::load_from_file(&backend, &model_path, &LlamaModelParams::default())?;
     println!("Loaded model from: {}", model_path.display());
 
-    let mmproj_path = pack.mmproj_path();
-    println!(
-        "Loading multimodal projector from: {}",
-        mmproj_path.display()
-    );
-    let mmproj_str = mmproj_path.to_str().ok_or_else(|| {
-        anyhow::anyhow!("mmproj path is not valid UTF-8: {}", mmproj_path.display())
-    })?;
-    let mtmd = MtmdContext::init_from_file(mmproj_str, &model, &MtmdContextParams::default())?;
-    println!(
-        "Loaded multimodal projector from: {} (vision={}, audio={})",
-        mmproj_path.display(),
-        mtmd.support_vision(),
-        mtmd.support_audio()
-    );
+    let mtmd = match pack.mmproj_path() {
+        None => {
+            println!("No multimodal projector in pack — loading text-only");
+            None
+        }
+        Some(mmproj_path) => {
+            println!(
+                "Loading multimodal projector from: {}",
+                mmproj_path.display()
+            );
+            let mmproj_str = mmproj_path.to_str().ok_or_else(|| {
+                anyhow::anyhow!("mmproj path is not valid UTF-8: {}", mmproj_path.display())
+            })?;
+            let mtmd =
+                MtmdContext::init_from_file(mmproj_str, &model, &MtmdContextParams::default())?;
+            println!(
+                "Loaded multimodal projector from: {} (vision={}, audio={})",
+                mmproj_path.display(),
+                mtmd.support_vision(),
+                mtmd.support_audio()
+            );
+            Some(mtmd)
+        }
+    };
 
     Ok(LocalModel {
         mtmd,
@@ -116,10 +125,15 @@ pub(super) fn run(
     thinking: &ThinkingPolicy,
 ) -> anyhow::Result<String> {
     let cfg = &model.cfg;
-    if images.is_empty() {
-        run_generation_text(model, cfg, prompt, temperature, thinking)
-    } else {
-        run_generation_mtmd(model, cfg, prompt, images, temperature, thinking)
+    match (&model.mtmd, images.is_empty()) {
+        (_, true) => run_generation_text(model, cfg, prompt, temperature, thinking),
+        (Some(mtmd), false) => {
+            run_generation_mtmd(model, mtmd, cfg, prompt, images, temperature, thinking)
+        }
+        (None, false) => Err(anyhow::anyhow!(
+            "text-only model received {} image(s) but has no multimodal projector",
+            images.len()
+        )),
     }
 }
 
@@ -199,6 +213,7 @@ fn run_generation_text(
 
 fn run_generation_mtmd(
     model: &LocalModel,
+    mtmd: &MtmdContext,
     cfg: &GenConfig,
     prompt: &str,
     images: &[Arc<Vec<u8>>],
@@ -206,7 +221,6 @@ fn run_generation_mtmd(
     thinking: &ThinkingPolicy,
 ) -> anyhow::Result<String> {
     let llama = &model.model;
-    let mtmd = &model.mtmd;
 
     let bitmaps = images
         .iter()

--- a/chatbot/src/roles/utility_role.rs
+++ b/chatbot/src/roles/utility_role.rs
@@ -13,8 +13,14 @@ const SYSTEM_PROMPT: &str = "You are a summarization engine. You are given the o
     everything later turns would need: who the participants are, stable facts and preferences the \
     user stated, decisions and conclusions reached, tools used and what they returned, and any \
     open threads or unfinished requests. Drop small talk and redundant back-and-forth. Write it as \
-    dense prose or terse bullet points, in the third person. Output only the summary itself, with \
-    no preamble, no headers, and no commentary.";
+    dense prose or terse bullet points, in the third person.\n\n\
+    The transcript may mark that an image was attached, viewed, or produced (e.g. '[attached 1 \
+    image(s) — not visible to you]'). You cannot see these images. When one appears, record in the \
+    summary that an image was present at that point, and — based only on what the surrounding \
+    conversation says about it — add a brief description of what it most likely showed, clearly \
+    marked as an assumption (e.g. 'presumably a screenshot of ...'). If nothing in the conversation \
+    hints at its content, just note that an image was shared without guessing.\n\n\
+    Output only the summary itself, with no preamble, no headers, and no commentary.";
 
 const TEMPERATURE: f32 = 0.3;
 

--- a/chatbot/src/roles/utility_role.rs
+++ b/chatbot/src/roles/utility_role.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use llama_cpp_2::llama_backend::LlamaBackend;
+use tokio::task::spawn_blocking;
+
+use super::local_model::{self, LocalModel};
+use super::{ParsedResponse, RenderInputs, Role, ThinkingPolicy};
+use crate::model_pack::Pack;
+
+const SYSTEM_PROMPT: &str = "You are a summarization engine. You are given the older portion of a \
+    conversation between a user and an assistant. Produce a compact summary that preserves \
+    everything later turns would need: who the participants are, stable facts and preferences the \
+    user stated, decisions and conclusions reached, tools used and what they returned, and any \
+    open threads or unfinished requests. Drop small talk and redundant back-and-forth. Write it as \
+    dense prose or terse bullet points, in the third person. Output only the summary itself, with \
+    no preamble, no headers, and no commentary.";
+
+const TEMPERATURE: f32 = 0.3;
+
+const PACK_DIR_ENV: &str = "UTILITY_MODEL_PACK_DIR";
+const DEFAULT_PACK_DIR: &str = "./models/qwen3-4b";
+
+fn pack_dir() -> PathBuf {
+    std::env::var_os(PACK_DIR_ENV).map_or_else(|| DEFAULT_PACK_DIR.into(), PathBuf::from)
+}
+
+pub struct UtilityRole {
+    model: LocalModel,
+}
+
+impl UtilityRole {
+    pub fn load(backend: Arc<LlamaBackend>) -> anyhow::Result<Self> {
+        let pack = Pack::load_from(&pack_dir())?;
+        Ok(UtilityRole { model: local_model::load_model(backend, &pack)? })
+    }
+}
+
+impl Role for UtilityRole {
+    fn system_prompt(&self) -> &str {
+        SYSTEM_PROMPT
+    }
+
+    fn temperature(&self) -> f32 {
+        TEMPERATURE
+    }
+
+    fn model_path(&self) -> PathBuf {
+        pack_dir()
+    }
+
+    fn render_prompt(&self, inputs: &RenderInputs) -> anyhow::Result<String> {
+        self.model.render(self.system_prompt(), inputs)
+    }
+
+    async fn generate(
+        self: Arc<Self>,
+        prompt: String,
+        images: Vec<Arc<Vec<u8>>>,
+    ) -> anyhow::Result<String> {
+        let thinking = self.thinking();
+        let temperature = self.temperature();
+        spawn_blocking(move || {
+            local_model::run(&self.model, &prompt, &images, temperature, &thinking)
+        })
+        .await?
+    }
+
+    fn parse_response(&self, raw: &str) -> ParsedResponse {
+        self.model.parse(raw)
+    }
+
+    fn thinking(&self) -> ThinkingPolicy {
+        let close_marker = self.model.close_marker();
+        ThinkingPolicy {
+            force_close: String::new(),
+            close_marker: close_marker.to_string(),
+            max_tokens: usize::MAX,
+        }
+    }
+}

--- a/chatbot/src/state_machines.rs
+++ b/chatbot/src/state_machines.rs
@@ -1,1 +1,2 @@
 pub mod conversation_state_machine;
+pub mod memory_manager_state_machine;

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -407,40 +407,22 @@ fn conversation_transition(
             let in_flight = conversation.compaction_in_flight;
             match (current_state, in_flight) {
                 (ConversationState::Idle { recent_conversation }, Some(prefix_len)) => {
-                    match result {
+                    let recent_conversation = match result {
                         Ok(summary) => {
-                            let mut history = recent_conversation.history();
-                            let drop = prefix_len.min(history.len());
-                            let tail = history.split_off(drop);
-                            let kept = tail.len();
-                            let mut compacted = Vec::with_capacity(kept + 1);
-                            compacted.push(HistoryEntry::Summary(summary.clone()));
-                            compacted.extend(tail);
-                            println!(
-                                "[compact] {conversation_id} applied summary — dropped {drop} entries, kept {kept} recent"
-                            );
-                            Ok(Conversation {
-                                state: ConversationState::Idle {
-                                    recent_conversation: RecentConversation::new(
-                                        recent_conversation.thoughts.clone(),
-                                        compacted,
-                                    ),
-                                },
-                                compaction_in_flight: None,
-                                ..conversation
-                            })
+                            apply_compaction(conversation_id, recent_conversation, prefix_len, summary)
                         }
                         Err(reason) => {
                             println!("[compact] {conversation_id} compaction did not complete: {reason:?}");
-                            Ok(Conversation {
-                                state: ConversationState::Idle {
-                                    recent_conversation,
-                                },
-                                compaction_in_flight: None,
-                                ..conversation
-                            })
+                            recent_conversation
                         }
-                    }
+                    };
+                    Ok(Conversation {
+                        state: ConversationState::Idle {
+                            recent_conversation,
+                        },
+                        compaction_in_flight: None,
+                        ..conversation
+                    })
                 }
                 (current_state, _) => {
                     println!("[compact] {conversation_id} compaction result arrived while busy or untracked; dropping");
@@ -572,6 +554,25 @@ fn maybe_fire_compaction(
     );
     conversation.compaction_in_flight = Some(prefix_len);
     println!("[compact] {conversation_id} firing compaction of {prefix_len} entries");
+}
+
+fn apply_compaction(
+    conversation_id: &ConversationId,
+    recent_conversation: RecentConversation,
+    prefix_len: usize,
+    summary: &str,
+) -> RecentConversation {
+    let mut history = recent_conversation.history();
+    let drop = prefix_len.min(history.len());
+    let tail = history.split_off(drop);
+    let kept = tail.len();
+    let mut compacted = Vec::with_capacity(kept + 1);
+    compacted.push(HistoryEntry::Summary(summary.to_string()));
+    compacted.extend(tail);
+    println!(
+        "[compact] {conversation_id} applied summary — dropped {drop} entries, kept {kept} recent"
+    );
+    RecentConversation::new(recent_conversation.thoughts.clone(), compacted)
 }
 
 fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<ConversationAction>> {

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -6,6 +6,8 @@ use crate::externals::{
 use crate::types::conversation::{
     latest_file_hash, ToolResult, ToolResultData, ToolType, MAX_TOOL_ROUNDS,
 };
+use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
+use crate::types::memory::{MemoryManagerAction, MemoryManagerConstructor};
 use crate::{
     types::conversation::{
         Conversation, ConversationAction, ConversationConstructor, ConversationId,
@@ -26,6 +28,9 @@ const REDACT_HISTORY_IMAGES: bool = false;
 
 const LLM_TIMEOUT_MS: i64 = 300_000;
 const SEND_TIMEOUT_MS: i64 = 60_000;
+
+const COMPACT_WATERMARK: usize = 24;
+const KEEP_RECENT: usize = 12;
 
 pub struct ConversationMachine;
 
@@ -80,6 +85,7 @@ fn send_then(
     pending: Vec<ConversationMessage>,
     is_group: bool,
     bot_identity: String,
+    compaction_in_flight: Option<usize>,
     effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
     if outbound.is_empty() {
@@ -91,6 +97,7 @@ fn send_then(
             pending,
             is_group,
             bot_identity,
+            compaction_in_flight,
             effects,
         );
     }
@@ -110,6 +117,7 @@ fn send_then(
         pending,
         is_group,
         bot_identity,
+        compaction_in_flight,
     })
 }
 
@@ -121,6 +129,7 @@ fn apply_post_send(
     pending: Vec<ConversationMessage>,
     is_group: bool,
     bot_identity: String,
+    compaction_in_flight: Option<usize>,
     effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
     match post_send {
@@ -132,6 +141,7 @@ fn apply_post_send(
             pending,
             is_group,
             bot_identity,
+            compaction_in_flight,
         }),
         PostSend::CallTools {
             tool_rounds,
@@ -165,6 +175,7 @@ fn apply_post_send(
                 pending,
                 is_group,
                 bot_identity,
+                compaction_in_flight,
             })
         }
         PostSend::SendToolResponse {
@@ -195,6 +206,7 @@ fn apply_post_send(
                 pending,
                 is_group,
                 bot_identity,
+                compaction_in_flight,
             })
         }
     }
@@ -287,6 +299,7 @@ fn conversation_transition(
                     conversation.pending,
                     conversation.is_group,
                     conversation.bot_identity.clone(),
+                    conversation.compaction_in_flight,
                     effects,
                 )
             }
@@ -316,6 +329,7 @@ fn conversation_transition(
             conversation.pending,
             conversation.is_group,
             conversation.bot_identity.clone(),
+            conversation.compaction_in_flight,
             effects,
         ),
         (
@@ -374,6 +388,7 @@ fn conversation_transition(
                     pending,
                     conversation.is_group,
                     conversation.bot_identity.clone(),
+                    conversation.compaction_in_flight,
                     effects,
                 )
             } else {
@@ -386,6 +401,55 @@ fn conversation_transition(
                     },
                     ..conversation
                 })
+            }
+        }
+        (current_state, ConversationAction::CompactionResult(result)) => {
+            let in_flight = conversation.compaction_in_flight;
+            match (current_state, in_flight) {
+                (ConversationState::Idle { recent_conversation }, Some(prefix_len)) => {
+                    match result {
+                        Ok(summary) => {
+                            let mut history = recent_conversation.history();
+                            let drop = prefix_len.min(history.len());
+                            let tail = history.split_off(drop);
+                            let kept = tail.len();
+                            let mut compacted = Vec::with_capacity(kept + 1);
+                            compacted.push(HistoryEntry::Summary(summary.clone()));
+                            compacted.extend(tail);
+                            println!(
+                                "[compact] {conversation_id} applied summary — dropped {drop} entries, kept {kept} recent"
+                            );
+                            Ok(Conversation {
+                                state: ConversationState::Idle {
+                                    recent_conversation: RecentConversation::new(
+                                        recent_conversation.thoughts.clone(),
+                                        compacted,
+                                    ),
+                                },
+                                compaction_in_flight: None,
+                                ..conversation
+                            })
+                        }
+                        Err(reason) => {
+                            println!("[compact] {conversation_id} compaction did not complete: {reason:?}");
+                            Ok(Conversation {
+                                state: ConversationState::Idle {
+                                    recent_conversation,
+                                },
+                                compaction_in_flight: None,
+                                ..conversation
+                            })
+                        }
+                    }
+                }
+                (current_state, _) => {
+                    println!("[compact] {conversation_id} compaction result arrived while busy or untracked; dropping");
+                    Ok(Conversation {
+                        state: current_state,
+                        compaction_in_flight: None,
+                        ..conversation
+                    })
+                }
             }
         }
         _ => Err(anyhow::anyhow!(
@@ -437,11 +501,13 @@ fn post_transition(
     };
 
     let Some(msg) = take_pending(&mut conversation.pending) else {
+        maybe_fire_compaction(env, conversation_id, &mut conversation, &recent_conversation, effects);
         return Ok(conversation);
     };
 
     let is_group = conversation.is_group;
     let bot_identity = conversation.bot_identity.clone();
+    let compaction_in_flight = conversation.compaction_in_flight;
 
     let history = recent_conversation.history();
 
@@ -468,7 +534,44 @@ fn post_transition(
         pending: Vec::new(),
         is_group,
         bot_identity,
+        compaction_in_flight,
     })
+}
+
+fn maybe_fire_compaction(
+    env: &Arc<Env>,
+    conversation_id: &ConversationId,
+    conversation: &mut Conversation,
+    recent_conversation: &RecentConversation,
+    effects: &mut ConversationEffects,
+) {
+    if env.utility.is_none() || conversation.compaction_in_flight.is_some() {
+        return;
+    }
+
+    let history = recent_conversation.history();
+    let compactable = history
+        .iter()
+        .filter(|entry| !matches!(entry, HistoryEntry::Summary(_)))
+        .count();
+    if compactable < COMPACT_WATERMARK {
+        return;
+    }
+
+    let prefix_len = history.len().saturating_sub(KEEP_RECENT);
+    if prefix_len == 0 {
+        return;
+    }
+
+    let prefix = history[..prefix_len].to_vec();
+    effects.enqueue_act_maybe_construct::<MemoryManagerMachine>(
+        MemoryManagerConstructor {
+            id: conversation_id.clone(),
+        },
+        MemoryManagerAction::Compact { history: prefix },
+    );
+    conversation.compaction_in_flight = Some(prefix_len);
+    println!("[compact] {conversation_id} firing compaction of {prefix_len} entries");
 }
 
 fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<ConversationAction>> {
@@ -505,5 +608,6 @@ fn construct_conversation(constructor: ConversationConstructor) -> Conversation 
         last_transition: Utc::now(),
         is_group: constructor.is_group,
         bot_identity: constructor.bot_identity,
+        compaction_in_flight: None,
     }
 }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -34,37 +34,78 @@ const KEEP_RECENT: usize = 12;
 
 pub struct ConversationMachine;
 
-impl StateMachine for ConversationMachine {
-    type State = Conversation;
-    type Id = ConversationId;
-    type Action = ConversationAction;
-    type Construction = ConversationConstructor;
-    type Env = crate::Env;
-
-    fn construct(
-        constructor: ConversationConstructor,
-        _effects: &mut ConversationEffects,
-    ) -> Conversation {
-        construct_conversation(constructor)
+fn compact_state(
+    conversation_id: &ConversationId,
+    state: ConversationState,
+    output: &CompactionOutput,
+) -> ConversationState {
+    match state {
+        ConversationState::Idle {
+            recent_conversation,
+        } => ConversationState::Idle {
+            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
+        },
+        ConversationState::SendingMessage {
+            recent_conversation,
+            post_send,
+        } => ConversationState::SendingMessage {
+            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
+            post_send,
+        },
+        ConversationState::RunningTools {
+            recent_conversation,
+            tool_rounds,
+            pending_tools,
+            completed_tools,
+        } => ConversationState::RunningTools {
+            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
+            tool_rounds,
+            pending_tools,
+            completed_tools,
+        },
+        ConversationState::AwaitingLLMDecision {
+            history,
+            current_input,
+            tool_rounds,
+        } => ConversationState::AwaitingLLMDecision {
+            history: compact_history(conversation_id, history, output),
+            current_input,
+            tool_rounds,
+        },
     }
+}
 
-    fn transition(
-        state: &Conversation,
-        id: &ConversationId,
-        env: &Arc<Env>,
-        action: &ConversationAction,
-        effects: &mut ConversationEffects,
-    ) -> ConversationTransitionResult {
-        conversation_transition(env, id, state.clone(), action, effects)
-    }
+fn compact_recent(
+    conversation_id: &ConversationId,
+    recent_conversation: RecentConversation,
+    output: &CompactionOutput,
+) -> RecentConversation {
+    let RecentConversation { thoughts, history } = recent_conversation;
+    let compacted = compact_history(conversation_id, history.into(), output);
+    RecentConversation::new(thoughts, compacted)
+}
 
-    fn schedule(state: &Conversation) -> Option<Scheduled<ConversationAction>> {
-        conversation_schedule(state)
-    }
+fn compact_history(
+    conversation_id: &ConversationId,
+    history: Vec<HistoryEntry>,
+    output: &CompactionOutput,
+) -> Vec<HistoryEntry> {
+    let Some(boundary) = history.iter().position(|entry| entry.id == output.through) else {
+        println!("[compact] {conversation_id} boundary already compacted away — no-op");
+        return history;
+    };
 
-    fn name() -> &'static str {
-        "ConversationMachine"
-    }
+    let mut history = history;
+    let tail = history.split_off(boundary + 1);
+    let kept = tail.len();
+    let dropped = boundary + 1;
+    let mut compacted = Vec::with_capacity(kept + 1);
+    compacted.push(HistoryEntry::summary(output.summary.clone()));
+    compacted.extend(tail);
+    println!(
+        "[compact] {conversation_id} applied summary — replaced {dropped} entries, kept {kept}"
+    );
+    compacted
 }
 
 fn state_label(state: &ConversationState) -> &'static str {
@@ -539,80 +580,6 @@ fn maybe_fire_compaction(
     println!("[compact] {conversation_id} firing compaction of {prefix_len} entries");
 }
 
-fn compact_state(
-    conversation_id: &ConversationId,
-    state: ConversationState,
-    output: &CompactionOutput,
-) -> ConversationState {
-    match state {
-        ConversationState::Idle {
-            recent_conversation,
-        } => ConversationState::Idle {
-            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
-        },
-        ConversationState::SendingMessage {
-            recent_conversation,
-            post_send,
-        } => ConversationState::SendingMessage {
-            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
-            post_send,
-        },
-        ConversationState::RunningTools {
-            recent_conversation,
-            tool_rounds,
-            pending_tools,
-            completed_tools,
-        } => ConversationState::RunningTools {
-            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
-            tool_rounds,
-            pending_tools,
-            completed_tools,
-        },
-        ConversationState::AwaitingLLMDecision {
-            history,
-            current_input,
-            tool_rounds,
-        } => ConversationState::AwaitingLLMDecision {
-            history: compact_history(conversation_id, history, output),
-            current_input,
-            tool_rounds,
-        },
-    }
-}
-
-fn compact_recent(
-    conversation_id: &ConversationId,
-    recent_conversation: RecentConversation,
-    output: &CompactionOutput,
-) -> RecentConversation {
-    let RecentConversation { thoughts, history } = recent_conversation;
-    let compacted = compact_history(conversation_id, history.into(), output);
-    RecentConversation::new(thoughts, compacted)
-}
-
-fn compact_history(
-    conversation_id: &ConversationId,
-    history: Vec<HistoryEntry>,
-    output: &CompactionOutput,
-) -> Vec<HistoryEntry> {
-    let Some(boundary) = history.iter().position(|entry| entry.id == output.through) else {
-        println!("[compact] {conversation_id} boundary already compacted away — no-op");
-        return history;
-    };
-
-    let mut history = history;
-    let tail = history.split_off(boundary + 1);
-    let kept = tail.len();
-    let dropped = boundary + 1;
-    let mut compacted = Vec::with_capacity(kept + 1);
-    compacted.push(HistoryEntry::summary(output.summary.clone()));
-    compacted.extend(tail);
-    println!(
-        "[compact] {conversation_id} applied summary — replaced {dropped} entries, kept {kept}"
-    );
-    compacted
-}
-
 fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<ConversationAction>> {
     match &conversation.state {
         ConversationState::Idle { .. } => None,
@@ -648,5 +615,38 @@ fn construct_conversation(constructor: ConversationConstructor) -> Conversation 
         is_group: constructor.is_group,
         bot_identity: constructor.bot_identity,
         compaction_in_flight: false,
+    }
+}
+
+impl StateMachine for ConversationMachine {
+    type State = Conversation;
+    type Id = ConversationId;
+    type Action = ConversationAction;
+    type Construction = ConversationConstructor;
+    type Env = crate::Env;
+
+    fn construct(
+        constructor: ConversationConstructor,
+        _effects: &mut ConversationEffects,
+    ) -> Conversation {
+        construct_conversation(constructor)
+    }
+
+    fn transition(
+        state: &Conversation,
+        id: &ConversationId,
+        env: &Arc<Env>,
+        action: &ConversationAction,
+        effects: &mut ConversationEffects,
+    ) -> ConversationTransitionResult {
+        conversation_transition(env, id, state.clone(), action, effects)
+    }
+
+    fn schedule(state: &Conversation) -> Option<Scheduled<ConversationAction>> {
+        conversation_schedule(state)
+    }
+
+    fn name() -> &'static str {
+        "ConversationMachine"
     }
 }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -10,9 +10,9 @@ use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
 use crate::types::memory::{MemoryManagerAction, MemoryManagerConstructor};
 use crate::{
     types::conversation::{
-        Conversation, ConversationAction, ConversationConstructor, ConversationId,
-        ConversationMessage, ConversationState, HistoryEntry, InterruptionReason, LLMInput,
-        PostSend, RecentConversation,
+        CompactionOutput, Conversation, ConversationAction, ConversationConstructor,
+        ConversationId, ConversationMessage, ConversationState, HistoryEntry, HistoryEntryKind,
+        InterruptionReason, LLMInput, PostSend, RecentConversation,
     },
     Env,
 };
@@ -85,7 +85,7 @@ fn send_then(
     pending: Vec<ConversationMessage>,
     is_group: bool,
     bot_identity: String,
-    compaction_in_flight: Option<usize>,
+    compaction_in_flight: bool,
     effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
     if outbound.is_empty() {
@@ -129,7 +129,7 @@ fn apply_post_send(
     pending: Vec<ConversationMessage>,
     is_group: bool,
     bot_identity: String,
-    compaction_in_flight: Option<usize>,
+    compaction_in_flight: bool,
     effects: &mut ConversationEffects,
 ) -> ConversationTransitionResult {
     match post_send {
@@ -261,8 +261,8 @@ fn conversation_transition(
                     current_input
                 };
                 let mut updated_history = history;
-                updated_history.push(HistoryEntry::Input(recorded_input));
-                updated_history.push(HistoryEntry::Output(response.clone()));
+                updated_history.push(HistoryEntry::input(recorded_input));
+                updated_history.push(HistoryEntry::output(response.clone()));
 
                 let updated_conversation =
                     RecentConversation::new(response.thoughts.clone(), updated_history);
@@ -305,7 +305,7 @@ fn conversation_transition(
             }
             Err(reason) => {
                 let mut history = history;
-                history.push(HistoryEntry::OutputInterrupted(reason.clone()));
+                history.push(HistoryEntry::interrupted(reason.clone()));
                 Ok(Conversation {
                     state: ConversationState::Idle {
                         recent_conversation: RecentConversation::new(String::new(), history),
@@ -404,35 +404,18 @@ fn conversation_transition(
             }
         }
         (current_state, ConversationAction::CompactionResult(result)) => {
-            let in_flight = conversation.compaction_in_flight;
-            match (current_state, in_flight) {
-                (ConversationState::Idle { recent_conversation }, Some(prefix_len)) => {
-                    let recent_conversation = match result {
-                        Ok(summary) => {
-                            apply_compaction(conversation_id, recent_conversation, prefix_len, summary)
-                        }
-                        Err(reason) => {
-                            println!("[compact] {conversation_id} compaction did not complete: {reason:?}");
-                            recent_conversation
-                        }
-                    };
-                    Ok(Conversation {
-                        state: ConversationState::Idle {
-                            recent_conversation,
-                        },
-                        compaction_in_flight: None,
-                        ..conversation
-                    })
+            let state = match result {
+                Ok(output) => compact_state(conversation_id, current_state, output),
+                Err(reason) => {
+                    println!("[compact] {conversation_id} compaction did not complete: {reason:?}");
+                    current_state
                 }
-                (current_state, _) => {
-                    println!("[compact] {conversation_id} compaction result arrived while busy or untracked; dropping");
-                    Ok(Conversation {
-                        state: current_state,
-                        compaction_in_flight: None,
-                        ..conversation
-                    })
-                }
-            }
+            };
+            Ok(Conversation {
+                state,
+                compaction_in_flight: false,
+                ..conversation
+            })
         }
         _ => Err(anyhow::anyhow!(
             "no transition for {action:?} in state {from}"
@@ -527,14 +510,14 @@ fn maybe_fire_compaction(
     recent_conversation: &RecentConversation,
     effects: &mut ConversationEffects,
 ) {
-    if env.utility.is_none() || conversation.compaction_in_flight.is_some() {
+    if env.utility.is_none() || conversation.compaction_in_flight {
         return;
     }
 
     let history = recent_conversation.history();
     let compactable = history
         .iter()
-        .filter(|entry| !matches!(entry, HistoryEntry::Summary(_)))
+        .filter(|entry| !matches!(entry.kind, HistoryEntryKind::Summary(_)))
         .count();
     if compactable < COMPACT_WATERMARK {
         return;
@@ -552,27 +535,82 @@ fn maybe_fire_compaction(
         },
         MemoryManagerAction::Compact { history: prefix },
     );
-    conversation.compaction_in_flight = Some(prefix_len);
+    conversation.compaction_in_flight = true;
     println!("[compact] {conversation_id} firing compaction of {prefix_len} entries");
 }
 
-fn apply_compaction(
+fn compact_state(
+    conversation_id: &ConversationId,
+    state: ConversationState,
+    output: &CompactionOutput,
+) -> ConversationState {
+    match state {
+        ConversationState::Idle {
+            recent_conversation,
+        } => ConversationState::Idle {
+            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
+        },
+        ConversationState::SendingMessage {
+            recent_conversation,
+            post_send,
+        } => ConversationState::SendingMessage {
+            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
+            post_send,
+        },
+        ConversationState::RunningTools {
+            recent_conversation,
+            tool_rounds,
+            pending_tools,
+            completed_tools,
+        } => ConversationState::RunningTools {
+            recent_conversation: compact_recent(conversation_id, recent_conversation, output),
+            tool_rounds,
+            pending_tools,
+            completed_tools,
+        },
+        ConversationState::AwaitingLLMDecision {
+            history,
+            current_input,
+            tool_rounds,
+        } => ConversationState::AwaitingLLMDecision {
+            history: compact_history(conversation_id, history, output),
+            current_input,
+            tool_rounds,
+        },
+    }
+}
+
+fn compact_recent(
     conversation_id: &ConversationId,
     recent_conversation: RecentConversation,
-    prefix_len: usize,
-    summary: &str,
+    output: &CompactionOutput,
 ) -> RecentConversation {
-    let mut history = recent_conversation.history();
-    let drop = prefix_len.min(history.len());
-    let tail = history.split_off(drop);
+    let RecentConversation { thoughts, history } = recent_conversation;
+    let compacted = compact_history(conversation_id, history.into(), output);
+    RecentConversation::new(thoughts, compacted)
+}
+
+fn compact_history(
+    conversation_id: &ConversationId,
+    history: Vec<HistoryEntry>,
+    output: &CompactionOutput,
+) -> Vec<HistoryEntry> {
+    let Some(boundary) = history.iter().position(|entry| entry.id == output.through) else {
+        println!("[compact] {conversation_id} boundary already compacted away — no-op");
+        return history;
+    };
+
+    let mut history = history;
+    let tail = history.split_off(boundary + 1);
     let kept = tail.len();
+    let dropped = boundary + 1;
     let mut compacted = Vec::with_capacity(kept + 1);
-    compacted.push(HistoryEntry::Summary(summary.to_string()));
+    compacted.push(HistoryEntry::summary(output.summary.clone()));
     compacted.extend(tail);
     println!(
-        "[compact] {conversation_id} applied summary — dropped {drop} entries, kept {kept} recent"
+        "[compact] {conversation_id} applied summary — replaced {dropped} entries, kept {kept}"
     );
-    RecentConversation::new(recent_conversation.thoughts.clone(), compacted)
+    compacted
 }
 
 fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<ConversationAction>> {
@@ -609,6 +647,6 @@ fn construct_conversation(constructor: ConversationConstructor) -> Conversation 
         last_transition: Utc::now(),
         is_group: constructor.is_group,
         bot_identity: constructor.bot_identity,
-        compaction_in_flight: None,
+        compaction_in_flight: false,
     }
 }

--- a/chatbot/src/state_machines/memory_manager_state_machine.rs
+++ b/chatbot/src/state_machines/memory_manager_state_machine.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use re_framework::{Effects, Scheduled, StateMachine};
+
+use crate::externals::summarize_external::summarize;
+use crate::state_machines::conversation_state_machine::ConversationMachine;
+use crate::types::conversation::{ConversationAction, ConversationId, InterruptionReason};
+use crate::types::memory::{
+    MemoryManager, MemoryManagerAction, MemoryManagerConstructor, MemoryManagerState,
+};
+use crate::Env;
+
+const COMPACT_TIMEOUT_MS: i64 = 300_000;
+
+pub struct MemoryManagerMachine;
+
+impl StateMachine for MemoryManagerMachine {
+    type State = MemoryManager;
+    type Id = ConversationId;
+    type Action = MemoryManagerAction;
+    type Construction = MemoryManagerConstructor;
+    type Env = crate::Env;
+
+    fn construct(
+        _constructor: MemoryManagerConstructor,
+        _effects: &mut Effects<Self>,
+    ) -> MemoryManager {
+        MemoryManager {
+            state: MemoryManagerState::Idle,
+            last_transition: Utc::now(),
+        }
+    }
+
+    fn transition(
+        state: &MemoryManager,
+        id: &ConversationId,
+        env: &Arc<Env>,
+        action: &MemoryManagerAction,
+        effects: &mut Effects<Self>,
+    ) -> anyhow::Result<MemoryManager> {
+        let next_state = match (&state.state, action) {
+            (MemoryManagerState::Idle, MemoryManagerAction::Compact { history }) => {
+                effects.enqueue_external(summarize(Arc::clone(env), history.clone()));
+                MemoryManagerState::Compacting
+            }
+            (MemoryManagerState::Compacting, MemoryManagerAction::CompactionDone(result)) => {
+                effects.enqueue_action::<ConversationMachine>(
+                    id.clone(),
+                    ConversationAction::CompactionResult(result.clone()),
+                );
+                MemoryManagerState::Idle
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "no transition for {action:?} in memory manager"
+                ))
+            }
+        };
+
+        Ok(MemoryManager {
+            state: next_state,
+            last_transition: Utc::now(),
+        })
+    }
+
+    fn schedule(state: &MemoryManager) -> Option<Scheduled<MemoryManagerAction>> {
+        match &state.state {
+            MemoryManagerState::Idle => None,
+            MemoryManagerState::Compacting => Some(Scheduled {
+                at: state.last_transition + ChronoDuration::milliseconds(COMPACT_TIMEOUT_MS),
+                action: MemoryManagerAction::CompactionDone(Err(InterruptionReason::TimedOut)),
+            }),
+        }
+    }
+
+    fn name() -> &'static str {
+        "MemoryManagerMachine"
+    }
+}

--- a/chatbot/src/types.rs
+++ b/chatbot/src/types.rs
@@ -1,2 +1,3 @@
 pub mod conversation;
 pub mod media;
+pub mod memory;

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -210,6 +210,8 @@ pub struct Conversation {
     pub last_transition: DateTime<Utc>,
     pub is_group: bool,
     pub bot_identity: String,
+    #[serde(default)]
+    pub compaction_in_flight: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -421,6 +423,7 @@ pub enum HistoryEntry {
     Input(LLMInput),
     Output(LLMResponse),
     OutputInterrupted(InterruptionReason),
+    Summary(String),
 }
 
 pub fn latest_file_hash<'a>(history: &'a [HistoryEntry], path: &str) -> Option<&'a str> {
@@ -453,6 +456,7 @@ pub enum ConversationAction {
         id: String,
         result: Result<ToolResultData, String>,
     },
+    CompactionResult(Result<String, InterruptionReason>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -483,6 +487,7 @@ impl std::fmt::Debug for ConversationAction {
             ConversationAction::LLMDecisionResult(_) => write!(f, "LLMDecisionResult"),
             ConversationAction::MessageSent(_) => write!(f, "MessageSent"),
             ConversationAction::ToolResult { .. } => write!(f, "ToolResult"),
+            ConversationAction::CompactionResult(_) => write!(f, "CompactionResult"),
         }
     }
 }

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -211,7 +211,7 @@ pub struct Conversation {
     pub is_group: bool,
     pub bot_identity: String,
     #[serde(default)]
-    pub compaction_in_flight: Option<usize>,
+    pub compaction_in_flight: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -418,17 +418,59 @@ impl InterruptionReason {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct HistoryId(uuid::Uuid);
+
+impl HistoryId {
+    pub fn new() -> Self {
+        HistoryId(uuid::Uuid::new_v4())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum HistoryEntry {
+pub struct HistoryEntry {
+    pub id: HistoryId,
+    pub kind: HistoryEntryKind,
+}
+
+impl HistoryEntry {
+    fn with_kind(kind: HistoryEntryKind) -> Self {
+        HistoryEntry {
+            id: HistoryId::new(),
+            kind,
+        }
+    }
+    pub fn input(input: LLMInput) -> Self {
+        Self::with_kind(HistoryEntryKind::Input(input))
+    }
+    pub fn output(response: LLMResponse) -> Self {
+        Self::with_kind(HistoryEntryKind::Output(response))
+    }
+    pub fn interrupted(reason: InterruptionReason) -> Self {
+        Self::with_kind(HistoryEntryKind::OutputInterrupted(reason))
+    }
+    pub fn summary(summary: String) -> Self {
+        Self::with_kind(HistoryEntryKind::Summary(summary))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HistoryEntryKind {
     Input(LLMInput),
     Output(LLMResponse),
     OutputInterrupted(InterruptionReason),
     Summary(String),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompactionOutput {
+    pub summary: String,
+    pub through: HistoryId,
+}
+
 pub fn latest_file_hash<'a>(history: &'a [HistoryEntry], path: &str) -> Option<&'a str> {
-    history.iter().rev().find_map(|entry| match entry {
-        HistoryEntry::Input(LLMInput::ToolResults(results, _)) => {
+    history.iter().rev().find_map(|entry| match &entry.kind {
+        HistoryEntryKind::Input(LLMInput::ToolResults(results, _)) => {
             results.iter().rev().find_map(|r| match &r.call.tool_type {
                 ToolType::ReadFile { path: p, .. } | ToolType::EditFile { path: p, .. }
                     if p == path =>
@@ -456,7 +498,7 @@ pub enum ConversationAction {
         id: String,
         result: Result<ToolResultData, String>,
     },
-    CompactionResult(Result<String, InterruptionReason>),
+    CompactionResult(Result<CompactionOutput, InterruptionReason>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/chatbot/src/types/memory.rs
+++ b/chatbot/src/types/memory.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::types::conversation::{ConversationId, HistoryEntry, InterruptionReason};
+use crate::types::conversation::{CompactionOutput, ConversationId, HistoryEntry, InterruptionReason};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct MemoryManager {
@@ -18,7 +18,7 @@ pub enum MemoryManagerState {
 #[derive(Clone, Serialize, Deserialize)]
 pub enum MemoryManagerAction {
     Compact { history: Vec<HistoryEntry> },
-    CompactionDone(Result<String, InterruptionReason>),
+    CompactionDone(Result<CompactionOutput, InterruptionReason>),
 }
 
 impl std::fmt::Debug for MemoryManagerAction {

--- a/chatbot/src/types/memory.rs
+++ b/chatbot/src/types/memory.rs
@@ -1,0 +1,44 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::types::conversation::{ConversationId, HistoryEntry, InterruptionReason};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct MemoryManager {
+    pub state: MemoryManagerState,
+    pub last_transition: DateTime<Utc>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum MemoryManagerState {
+    Idle,
+    Compacting,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum MemoryManagerAction {
+    Compact { history: Vec<HistoryEntry> },
+    CompactionDone(Result<String, InterruptionReason>),
+}
+
+impl std::fmt::Debug for MemoryManagerAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MemoryManagerAction::Compact { .. } => write!(f, "Compact"),
+            MemoryManagerAction::CompactionDone(Ok(_)) => write!(f, "CompactionDone(ok)"),
+            MemoryManagerAction::CompactionDone(Err(_)) => write!(f, "CompactionDone(err)"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryManagerConstructor {
+    pub id: ConversationId,
+}
+
+impl re_framework::Identified for MemoryManagerConstructor {
+    type Id = ConversationId;
+    fn get_id(&self) -> &ConversationId {
+        &self.id
+    }
+}


### PR DESCRIPTION
Closes the compaction-skeleton scope of #199.

## What this does

A new **`MemoryManagerMachine`** entity compacts older conversation history on the side, off the main conversation thread:

1. When a Conversation returns to Idle with no pending work and its non-summary history reaches a watermark (24 entries), it fires the manager via `enqueue_act_maybe_construct`, handing over the oldest slice (everything but the last 12 entries) and setting a `compaction_in_flight` guard.
2. The manager (per-conversation, persistent) runs a **text-only utility model** (Qwen3-4B) as an external to summarize that slice, then replies with `CompactionResult(CompactionOutput { summary, through })`, where `through` is the guid of the inclusive last entry summarized.
3. On `CompactionResult` **in any conversation state**, `compact_state` finds `through` in that state's history and replaces `[0..=through]` with a single `HistoryEntry::Summary`, keeping everything after. The summary renders into the prompt as a marked assistant note.

**Race-free by construction:** every `HistoryEntry` is `{ id: HistoryId (uuid), kind }`; the id survives clones and state moves, so the boundary is identified by guid, not index. If `through` isn't found (already compacted away, or window-evicted), the apply is a safe no-op — no wrong entries dropped, no dependence on landing in Idle, nothing carried around.

Memory *organization* (extract → reconcile) is deferred; this is the shared trigger + entity + model harness, exercised via compaction only.

## Key decisions (from #199)

- **Text-only harness, boot-optional.** `mmproj` is now optional in `Pack`/`LocalModel`; `UtilityRole` loads from `UTILITY_MODEL_PACK_DIR` (default `./models/qwen3-4b`). If the pack is absent, boot logs a warning and compaction is disabled — deploys don't break. The trigger is also gated on `env.utility.is_some()`, so no manager is spawned when the model isn't loaded.
- **History-size threshold trigger** (`COMPACT_WATERMARK=24`, `KEEP_RECENT=12`), shared with future memory-org.
- **Apply-trim**: real compaction that shrinks the window, not produce-only.
- **Per-conversation, persistent** manager (framework has no self-delete-from-transition primitive yet; throwaway lifecycle is a follow-up).

## Model

Qwen3-4B **Q6_K**, text-only. `*.gguf` is gitignored (mirrors the primary pack); `manifest.toml` + `chat_template.jinja` are committed. `enable_thinking = false`, `n_ctx = 32768`, `max_generation_tokens = 2048`. The summarize external extracts the summary itself (`split_once("</think>")` → take-after, else whole) because a non-thinking model emits no close marker and the `qwen` parser would otherwise route the whole output to `reasoning`.

## Not verified live

Compiles clean (`cargo check`). **Not** run end-to-end here — the utility model shares the one (AMD) GPU with the deployed bot, and loading a second model locally risks contending with / hanging production. Live checks belong in a deploy:
- utility model loads via the text-only path;
- a long conversation crosses the watermark and fires the manager;
- the summary comes back and the window shrinks (`[compact]` logs);
- the timeout path (`Compacting` rescue) clears `compaction_in_flight` if summarization stalls.

## Deploy note

The Dockerfile doesn't COPY `chatbot/models` (weights come from the base image / host). For compaction to activate in the deployed bot, `chatbot/models/qwen3-4b/` (incl. the GGUF) must be present at runtime, or `UTILITY_MODEL_PACK_DIR` pointed at it. Until then it's a safe no-op.

## Image handling

The utility model is text-only and can't see images. The transcript marks where an image was attached/viewed/produced, and the summarizer is told to note it was present and add a best-guess description inferred from surrounding text, marked as an assumption. Dropping the pixels is intentional for now.
