### PR TITLE
deploy: bake model packs into base image, drop runtime model mounts

### DIFF
--- a/chatbot/Dockerfile.base
+++ b/chatbot/Dockerfile.base
@@ -21,3 +21,6 @@ RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${
     && mv /tmp/docker/docker /usr/local/bin/docker \
     && rm -rf /tmp/docker /tmp/docker.tgz \
     && docker --version
+
+COPY models/qwen-qwen3-6-35b-a3b /app/models/qwen-qwen3-6-35b-a3b
+COPY models/qwen3-4b /app/models/qwen3-4b

--- a/chatbot/Justfile
+++ b/chatbot/Justfile
@@ -27,8 +27,8 @@ run_local tag="latest":
         --group-add video \
         --group-add render \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        -v "$(pwd)/models/qwen-qwen3-6-35b-a3b:/app/models/qwen-qwen3-6-35b-a3b:ro" \
         -e MODEL_PACK_DIR=/app/models/qwen-qwen3-6-35b-a3b \
+        -e UTILITY_MODEL_PACK_DIR=/app/models/qwen3-4b \
         --restart unless-stopped \
         zireael9797/bot:{{tag}}
 


### PR DESCRIPTION
The committed `Dockerfile.base` copied no models, but the live base image was built from a version that baked the big model in at `/app/models/*.gguf` — the committed file was **stale**. And at runtime `run_local` mounted the big-model pack dir (overriding the baked copy), so the base's baked ggufs were dead weight.

This makes the base self-contained and drops the runtime model mounts:

- **Dockerfile.base**: `COPY` both packs as pack dirs (manifest + template + gguf) at the paths the app reads — `/app/models/qwen-qwen3-6-35b-a3b` and `/app/models/qwen3-4b`.
- **Justfile `run_local`**: remove the big-model `-v` mount; set `MODEL_PACK_DIR` + `UTILITY_MODEL_PACK_DIR` to the baked paths. The `docker.sock` mount stays — the bash-sandbox tool needs it to spawn worker containers.

Enables compaction in the deployed bot: the Qwen3-4B utility pack is now present at `/app/models/qwen3-4b`, which `UtilityRole` loads.

Requires a `just build_base` (bakes ~40GB) before `just deploy_local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)