### PR TITLE
discord: append non-image attachment URLs to message text

### DIFF
--- a/chatbot/src/services/discord.rs
+++ b/chatbot/src/services/discord.rs
@@ -49,11 +49,19 @@ impl EventHandler for Handler {
 
         let images = download_images(&message).await;
         let text = filter(&message, self.bot_user_id, &self.bot_name);
+        let attachments = attachment_note(&message);
 
-        if text.is_none() && images.is_empty() {
+        if text.is_none() && images.is_empty() && attachments.is_none() {
             return;
         }
-        let text = text.unwrap_or_default();
+
+        let mut body = text.unwrap_or_default();
+        if let Some(note) = attachments {
+            if !body.is_empty() {
+                body.push('\n');
+            }
+            body.push_str(&note);
+        }
 
         let is_group = message.guild_id.is_some();
         let author_id = message.author.id.get();
@@ -64,7 +72,7 @@ impl EventHandler for Handler {
             .clone()
             .unwrap_or_else(|| message.author.name.clone());
 
-        let msg = format!("{}: {text}", identity(&name, author_id));
+        let msg = format!("{}: {body}", identity(&name, author_id));
 
         let bot_identity = identity(&self.bot_name, self.bot_user_id);
 
@@ -110,6 +118,30 @@ async fn download_images(message: &DMessage) -> Vec<MessageImage> {
         }
     }
     images
+}
+
+fn attachment_note(message: &DMessage) -> Option<String> {
+    let lines: Vec<String> = message
+        .attachments
+        .iter()
+        .filter(|attachment| {
+            attachment
+                .content_type
+                .as_deref()
+                .is_none_or(|mime| !mime.starts_with("image/"))
+        })
+        .map(|attachment| {
+            let kind = attachment.content_type.as_deref().unwrap_or("unknown type");
+            format!("- {} ({kind}): {}", attachment.filename, attachment.url)
+        })
+        .collect();
+
+    (!lines.is_empty()).then(|| {
+        format!(
+            "[Attachments on this message — not shown inline; fetch with a tool if you need their contents:\n{}]",
+            lines.join("\n")
+        )
+    })
 }
 
 fn identity(name: &str, id: u64) -> String {


### PR DESCRIPTION
Closes #203.

Discord serves attachments from its CDN, so instead of downloading/ingesting them server-side, we surface the URLs and let the model fetch them on-demand in the bash sandbox.

**What:** non-image Discord attachments (documents, PDFs, CSVs, etc.) now have their filename + content-type + URL appended to the message text. Images are unchanged — still downloaded and fed inline.

**Why:** the model sees the attachments and downloads them with `curl` in `RunBashCommand` when it needs the contents (the worker has internet egress + curl/wget/python-requests). No server-side ingestion, no new types, no history/compaction bloat.

**Scope:** pure `services/discord.rs` change.
- New `attachment_note` helper builds a labeled block of non-image attachment URLs.
- Appended to the message body before `NewMessage` — no state machine, types, or model changes.
- Early-return guard now also passes attachment-only messages (consistent with image-only messages).

**Caveat:** Discord CDN URLs are signed and expire (~24h); fetching during the conversation is fine, a stale fetch can 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)