### PR TITLE
chatbot: deliver sandbox files via an [[attach:PATH]] message pattern

### DIFF
--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -134,6 +134,50 @@ pub async fn pull_image(conversation_id: &str, path: &str) -> Result<MessageImag
     Ok(MessageImage::Hydrated(image).downscaled())
 }
 
+/// A file pulled verbatim from the sandbox, ready to upload as a chat attachment.
+pub struct PulledFile {
+    pub filename: String,
+    pub bytes: Vec<u8>,
+}
+
+/// Upper bound on a message-pattern attachment. Discord accepts 25 MiB for the bot tier we target,
+/// but we stay well under to keep uploads fast and predictable across platforms.
+pub(crate) const MAX_ATTACHMENT_BYTES: usize = 8 * 1024 * 1024;
+
+/// Read a file from the sandbox as raw bytes for delivery to the user (any type, not just images).
+/// Backs the `[[attach:PATH]]` message pattern handled in `message_external`. The filename is the
+/// path's basename, falling back to `attachment` for odd paths.
+pub async fn pull_file(conversation_id: &str, path: &str) -> Result<PulledFile, String> {
+    let name = worker_name(conversation_id);
+    ensure_worker(&name).await?;
+
+    let out = docker(&["exec", &name, "cat", "--", path]).await?;
+    if !out.status.success() {
+        return Err(format!(
+            "could not read '{path}': {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    let bytes = out.stdout;
+    if bytes.is_empty() {
+        return Err(format!("'{path}' is empty — nothing to attach"));
+    }
+    if bytes.len() > MAX_ATTACHMENT_BYTES {
+        return Err(format!(
+            "'{path}' is {} bytes, over the {MAX_ATTACHMENT_BYTES}-byte attachment limit",
+            bytes.len()
+        ));
+    }
+
+    let filename = path
+        .rsplit('/')
+        .find(|s| !s.is_empty())
+        .unwrap_or("attachment")
+        .to_string();
+    Ok(PulledFile { filename, bytes })
+}
+
 pub async fn read_file(conversation_id: &str, path: &str) -> Result<String, String> {
     let name = worker_name(conversation_id);
     ensure_worker(&name).await?;

--- a/chatbot/src/externals/message_external.rs
+++ b/chatbot/src/externals/message_external.rs
@@ -1,13 +1,41 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use crate::{
+    externals::bash_container_external::pull_file,
     types::conversation::{ConversationAction, Platform, ConversationId},
     types::media::MessageImage,
     Env,
 };
+use regex::Regex;
 use serenity::all::{CreateAttachment, CreateMessage};
 
 const DISCORD_MESSAGE_LIMIT: usize = 2000;
+
+/// The special in-message attachment marker: `[[attach:/path/in/sandbox]]`. Not a tool — it's a
+/// pattern the model writes inside its normal reply. At send time each match is removed from the
+/// text and the file at that sandbox path is uploaded as an attachment in its place. The path is
+/// captured non-greedily up to the closing `]]`.
+static ATTACH_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[\[attach:\s*(.*?)\s*\]\]").expect("ATTACH_RE is a valid regex"));
+
+/// Pull the sandbox paths named by `[[attach:…]]` markers out of `text`, returning the text with
+/// those markers stripped and the list of referenced paths (in order, deduplicated). Whitespace
+/// left where a marker was removed is collapsed so the visible message stays clean.
+fn extract_attach_paths(text: &str) -> (String, Vec<String>) {
+    let mut paths: Vec<String> = Vec::new();
+    for cap in ATTACH_RE.captures_iter(text) {
+        let path = cap[1].trim().to_string();
+        if !path.is_empty() && !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+    let cleaned = ATTACH_RE.replace_all(text, "");
+    let collapsed = Regex::new(r"[ \t]{2,}")
+        .expect("static whitespace regex is valid")
+        .replace_all(cleaned.trim(), " ")
+        .to_string();
+    (collapsed, paths)
+}
 
 fn split_for_discord(content: &str) -> Vec<String> {
     let mut chunks = Vec::new();
@@ -87,6 +115,7 @@ pub async fn send_message(
     conversation_id: ConversationId,
     outbound: OutboundMessage,
 ) -> ConversationAction {
+    let container_key = conversation_id.to_string();
     let text = compose(&conversation_id.0, outbound.message, &outbound.tool_names);
     match conversation_id.0 {
         Platform::Discord => {
@@ -98,12 +127,29 @@ pub async fn send_message(
                 }
             };
 
-            let files: Vec<CreateAttachment> = outbound
+            // Resolve any `[[attach:PATH]]` markers into real files pulled from the sandbox, and
+            // strip the markers from the visible text. Failures leave a small inline note so the
+            // user isn't silently missing an attachment the reply referred to.
+            let (mut text, attach_paths) = extract_attach_paths(&text);
+            let mut pattern_files: Vec<CreateAttachment> = Vec::new();
+            for path in &attach_paths {
+                match pull_file(&container_key, path).await {
+                    Ok(file) => pattern_files.push(CreateAttachment::bytes(file.bytes, file.filename)),
+                    Err(err) => {
+                        eprintln!("[send] attach '{path}' failed: {err}");
+                        let note = Platform::Discord.subtext(&format!("couldn't attach {path}: {err}"));
+                        text = if text.is_empty() { note } else { format!("{text}\n{note}") };
+                    }
+                }
+            }
+
+            let mut files: Vec<CreateAttachment> = outbound
                 .attachments
                 .iter()
                 .enumerate()
                 .filter_map(|(i, a)| discord_attachment(a, i))
                 .collect();
+            files.extend(pattern_files);
 
             let chunks = split_for_discord(&text);
 
@@ -137,5 +183,43 @@ pub async fn send_message(
             ConversationAction::MessageSent(Ok(()))
         }
         _ => panic!("Telegram not yet implemented"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_attach_paths;
+
+    #[test]
+    fn strips_marker_and_captures_path() {
+        let (text, paths) = extract_attach_paths("Here's the report [[attach:/tmp/report.pdf]] enjoy");
+        assert_eq!(text, "Here's the report enjoy");
+        assert_eq!(paths, vec!["/tmp/report.pdf"]);
+    }
+
+    #[test]
+    fn marker_only_message_becomes_empty_text() {
+        let (text, paths) = extract_attach_paths("[[attach:chart.png]]");
+        assert_eq!(text, "");
+        assert_eq!(paths, vec!["chart.png"]);
+    }
+
+    #[test]
+    fn multiple_markers_dedup_and_preserve_order() {
+        let (text, paths) =
+            extract_attach_paths("a [[attach:/x]] b [[attach:/y]] c [[attach:/x]]");
+        assert_eq!(text, "a b c");
+        assert_eq!(paths, vec!["/x", "/y"]);
+    }
+
+    #[test]
+    fn tolerates_internal_whitespace_and_no_markers() {
+        let (text, paths) = extract_attach_paths("[[attach:  /a b/c.txt  ]]");
+        assert_eq!(paths, vec!["/a b/c.txt"]);
+        assert!(text.is_empty());
+
+        let (plain, none) = extract_attach_paths("just a normal message");
+        assert_eq!(plain, "just a normal message");
+        assert!(none.is_empty());
     }
 }

--- a/chatbot/src/roles/primary_role.rs
+++ b/chatbot/src/roles/primary_role.rs
@@ -27,6 +27,15 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     re-scan an image: give one best reading, flag what's unclear rather than re-guess, and \
     reconsider only if the user or a tool contradicts you.\n\n\
     Call tools (one or several) when they help; answer once you have enough.\n\n\
+    SENDING A FILE: to hand the user a file from your bash sandbox, put the marker \
+    `[[attach:PATH]]` anywhere in your reply text — e.g. `Here's the report [[attach:/tmp/report.pdf]]`. \
+    This is NOT a tool and costs no tool turn; it's a special pattern in your message. When your \
+    reply is sent, each marker is removed from the text and the file at that sandbox path (the same \
+    filesystem as run_bash_command) is uploaded as a real attachment in its place. It works for any \
+    file type — PDFs, archives, code, data, images. Only reference paths that actually exist in your \
+    sandbox; if a path can't be read the marker is dropped and a short note shown instead. (For \
+    images specifically you may also use the send_image_to_user tool, but this marker is the general \
+    way to deliver any file.)\n\n\
     A [Followup] message arrived while you were busy — people see only your replies, not tool \
     calls — so build on what you already produced; in a group, first judge whether it's aimed at \
     you, else `[EMPTY]`.";


### PR DESCRIPTION
Adds a second, tool-free way for the model to send a file to the user: it writes the marker `[[attach:PATH]]` inside its normal reply, and the send-message external resolves it — stripping the marker from the visible text and uploading the file at that sandbox path as a real attachment in its place.

- bash_container_external: `pull_file` reads any sandbox file as raw bytes (basename as filename, 8 MiB cap) — the generic counterpart to the image-only `pull_image`.
- message_external: `extract_attach_paths` scans the outgoing text for markers (order-preserving, deduped) and strips them; `send_message` pulls each file from the conversation's sandbox and attaches it. A path that can't be read drops the marker and leaves a short inline note instead of silently vanishing.
- primary_role: system prompt explains the marker and stresses it's a message pattern, not a tool (costs no tool turn); send_image_to_user stays for images.

Unit tests cover marker stripping, marker-only messages, dedup/order, and whitespace handling.