### PR TITLE
chatbot: split attach marker into attach_file/attach_image, drop send_image_to_user tool

### DIFF
--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -145,7 +145,8 @@ pub struct PulledFile {
 pub(crate) const MAX_ATTACHMENT_BYTES: usize = 8 * 1024 * 1024;
 
 /// Read a file from the sandbox as raw bytes for delivery to the user (any type, not just images).
-/// Backs the `[[attach:PATH]]` message pattern handled in `message_external`. The filename is the
+/// Backs the `[[attach_file:PATH]]` / `[[attach_image:PATH]]` message patterns handled in
+/// `message_external`. The filename is the
 /// path's basename, falling back to `attachment` for odd paths.
 pub async fn pull_file(conversation_id: &str, path: &str) -> Result<PulledFile, String> {
     let name = worker_name(conversation_id);

--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -134,20 +134,13 @@ pub async fn pull_image(conversation_id: &str, path: &str) -> Result<MessageImag
     Ok(MessageImage::Hydrated(image).downscaled())
 }
 
-/// A file pulled verbatim from the sandbox, ready to upload as a chat attachment.
 pub struct PulledFile {
     pub filename: String,
     pub bytes: Vec<u8>,
 }
 
-/// Upper bound on a message-pattern attachment. Discord accepts 25 MiB for the bot tier we target,
-/// but we stay well under to keep uploads fast and predictable across platforms.
 pub(crate) const MAX_ATTACHMENT_BYTES: usize = 8 * 1024 * 1024;
 
-/// Read a file from the sandbox as raw bytes for delivery to the user (any type, not just images).
-/// Backs the `[[attach_file:PATH]]` / `[[attach_image:PATH]]` message patterns handled in
-/// `message_external`. The filename is the
-/// path's basename, falling back to `attachment` for odd paths.
 pub async fn pull_file(conversation_id: &str, path: &str) -> Result<PulledFile, String> {
     let name = worker_name(conversation_id);
     ensure_worker(&name).await?;

--- a/chatbot/src/externals/message_external.rs
+++ b/chatbot/src/externals/message_external.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, LazyLock};
 use crate::{
     externals::bash_container_external::pull_file,
     types::conversation::{ConversationAction, Platform, ConversationId},
-    types::media::MessageImage,
     Env,
 };
 use regex::Regex;
@@ -11,14 +10,17 @@ use serenity::all::{CreateAttachment, CreateMessage};
 
 const DISCORD_MESSAGE_LIMIT: usize = 2000;
 
-/// The special in-message attachment marker: `[[attach:/path/in/sandbox]]`. Not a tool — it's a
-/// pattern the model writes inside its normal reply. At send time each match is removed from the
-/// text and the file at that sandbox path is uploaded as an attachment in its place. The path is
-/// captured non-greedily up to the closing `]]`.
-static ATTACH_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[\[attach:\s*(.*?)\s*\]\]").expect("ATTACH_RE is a valid regex"));
+/// The special in-message attachment markers: `[[attach_file:/path]]` and `[[attach_image:/path]]`.
+/// Not tools — patterns the model writes inside its normal reply. At send time each match is removed
+/// from the text and the file at that sandbox path is uploaded as an attachment in its place
+/// (Discord renders images inline by extension either way; the two names just signal intent). The
+/// path is captured non-greedily up to the closing `]]`.
+static ATTACH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[\[attach_(?:file|image):\s*(.*?)\s*\]\]").expect("ATTACH_RE is a valid regex")
+});
 
-/// Pull the sandbox paths named by `[[attach:…]]` markers out of `text`, returning the text with
+/// Pull the sandbox paths named by `[[attach_file:…]]` / `[[attach_image:…]]` markers out of
+/// `text`, returning the text with
 /// those markers stripped and the list of referenced paths (in order, deduplicated). Whitespace
 /// left where a marker was removed is collapsed so the visible message stays clean.
 fn extract_attach_paths(text: &str) -> (String, Vec<String>) {
@@ -80,34 +82,12 @@ fn compose(platform: &Platform, message: Option<String>, tool_names: &[String]) 
 pub struct OutboundMessage {
     pub message: Option<String>,
     pub tool_names: Vec<String>,
-    pub attachments: Vec<Attachment>,
-}
-
-pub enum Attachment {
-    Image(MessageImage),
 }
 
 impl OutboundMessage {
     pub fn is_empty(&self) -> bool {
-        self.message.is_none() && self.tool_names.is_empty() && self.attachments.is_empty()
+        self.message.is_none() && self.tool_names.is_empty()
     }
-}
-
-fn discord_attachment(attachment: &Attachment, index: usize) -> Option<CreateAttachment> {
-    let image = match attachment {
-        Attachment::Image(image) => image,
-    };
-    let MessageImage::Hydrated(image) = image else {
-        return None;
-    };
-    let ext = match image.mime.as_str() {
-        "image/png" => "png",
-        "image/jpeg" | "image/jpg" => "jpg",
-        "image/gif" => "gif",
-        "image/webp" => "webp",
-        _ => "bin",
-    };
-    Some(CreateAttachment::bytes((*image.bytes).clone(), format!("attachment_{index}.{ext}")))
 }
 
 pub async fn send_message(
@@ -127,14 +107,14 @@ pub async fn send_message(
                 }
             };
 
-            // Resolve any `[[attach:PATH]]` markers into real files pulled from the sandbox, and
-            // strip the markers from the visible text. Failures leave a small inline note so the
-            // user isn't silently missing an attachment the reply referred to.
+            // Resolve any `[[attach_file:PATH]]` / `[[attach_image:PATH]]` markers into real files
+            // pulled from the sandbox, and strip the markers from the visible text. Failures leave a
+            // small inline note so the user isn't silently missing an attachment the reply referred to.
             let (mut text, attach_paths) = extract_attach_paths(&text);
-            let mut pattern_files: Vec<CreateAttachment> = Vec::new();
+            let mut files: Vec<CreateAttachment> = Vec::new();
             for path in &attach_paths {
                 match pull_file(&container_key, path).await {
-                    Ok(file) => pattern_files.push(CreateAttachment::bytes(file.bytes, file.filename)),
+                    Ok(file) => files.push(CreateAttachment::bytes(file.bytes, file.filename)),
                     Err(err) => {
                         eprintln!("[send] attach '{path}' failed: {err}");
                         let note = Platform::Discord.subtext(&format!("couldn't attach {path}: {err}"));
@@ -142,14 +122,6 @@ pub async fn send_message(
                     }
                 }
             }
-
-            let mut files: Vec<CreateAttachment> = outbound
-                .attachments
-                .iter()
-                .enumerate()
-                .filter_map(|(i, a)| discord_attachment(a, i))
-                .collect();
-            files.extend(pattern_files);
 
             let chunks = split_for_discord(&text);
 
@@ -192,29 +164,30 @@ mod tests {
 
     #[test]
     fn strips_marker_and_captures_path() {
-        let (text, paths) = extract_attach_paths("Here's the report [[attach:/tmp/report.pdf]] enjoy");
+        let (text, paths) =
+            extract_attach_paths("Here's the report [[attach_file:/tmp/report.pdf]] enjoy");
         assert_eq!(text, "Here's the report enjoy");
         assert_eq!(paths, vec!["/tmp/report.pdf"]);
     }
 
     #[test]
     fn marker_only_message_becomes_empty_text() {
-        let (text, paths) = extract_attach_paths("[[attach:chart.png]]");
+        let (text, paths) = extract_attach_paths("[[attach_image:chart.png]]");
         assert_eq!(text, "");
         assert_eq!(paths, vec!["chart.png"]);
     }
 
     #[test]
-    fn multiple_markers_dedup_and_preserve_order() {
+    fn file_and_image_markers_both_match_dedup_and_preserve_order() {
         let (text, paths) =
-            extract_attach_paths("a [[attach:/x]] b [[attach:/y]] c [[attach:/x]]");
+            extract_attach_paths("a [[attach_file:/x]] b [[attach_image:/y]] c [[attach_file:/x]]");
         assert_eq!(text, "a b c");
         assert_eq!(paths, vec!["/x", "/y"]);
     }
 
     #[test]
     fn tolerates_internal_whitespace_and_no_markers() {
-        let (text, paths) = extract_attach_paths("[[attach:  /a b/c.txt  ]]");
+        let (text, paths) = extract_attach_paths("[[attach_file:  /a b/c.txt  ]]");
         assert_eq!(paths, vec!["/a b/c.txt"]);
         assert!(text.is_empty());
 

--- a/chatbot/src/externals/message_external.rs
+++ b/chatbot/src/externals/message_external.rs
@@ -10,19 +10,10 @@ use serenity::all::{CreateAttachment, CreateMessage};
 
 const DISCORD_MESSAGE_LIMIT: usize = 2000;
 
-/// The special in-message attachment markers: `[[attach_file:/path]]` and `[[attach_image:/path]]`.
-/// Not tools — patterns the model writes inside its normal reply. At send time each match is removed
-/// from the text and the file at that sandbox path is uploaded as an attachment in its place
-/// (Discord renders images inline by extension either way; the two names just signal intent). The
-/// path is captured non-greedily up to the closing `]]`.
 static ATTACH_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\[\[attach_(?:file|image):\s*(.*?)\s*\]\]").expect("ATTACH_RE is a valid regex")
 });
 
-/// Pull the sandbox paths named by `[[attach_file:…]]` / `[[attach_image:…]]` markers out of
-/// `text`, returning the text with
-/// those markers stripped and the list of referenced paths (in order, deduplicated). Whitespace
-/// left where a marker was removed is collapsed so the visible message stays clean.
 fn extract_attach_paths(text: &str) -> (String, Vec<String>) {
     let mut paths: Vec<String> = Vec::new();
     for cap in ATTACH_RE.captures_iter(text) {
@@ -107,9 +98,6 @@ pub async fn send_message(
                 }
             };
 
-            // Resolve any `[[attach_file:PATH]]` / `[[attach_image:PATH]]` markers into real files
-            // pulled from the sandbox, and strip the markers from the visible text. Failures leave a
-            // small inline note so the user isn't silently missing an attachment the reply referred to.
             let (mut text, attach_paths) = extract_attach_paths(&text);
             let mut files: Vec<CreateAttachment> = Vec::new();
             for path in &attach_paths {

--- a/chatbot/src/externals/summarize_external.rs
+++ b/chatbot/src/externals/summarize_external.rs
@@ -40,9 +40,6 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
                     if result.data.image_for_assistant.is_some() {
                         line.push_str(" [returned an image the assistant viewed — not visible to you]");
                     }
-                    if result.data.image_for_user.is_some() {
-                        line.push_str(" [produced an image shown to the user — not visible to you]");
-                    }
                     lines.push(line);
                 }
                 if let Some(msg) = followup {

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -375,18 +375,6 @@ async fn run_tool(
                 actual: note.clone(),
                 simplified: note,
                 image_for_assistant: Some(image),
-                image_for_user: None,
-                metadata: HashMap::new(),
-            })
-        }
-        ToolType::SendImageToUser { path } => {
-            let image = pull_image(conversation_id, &path).await?;
-            let note = format!("Image '{path}' sent to the user — Both you and the user can see it.");
-            Ok(ToolResultData {
-                actual: note.clone(),
-                simplified: note,
-                image_for_assistant: None,
-                image_for_user: Some(image),
                 metadata: HashMap::new(),
             })
         }
@@ -405,7 +393,6 @@ async fn run_tool(
                 simplified: clip_to(&body, SIMPLIFIED_MAX),
                 actual: body,
                 image_for_assistant: None,
-                image_for_user: None,
                 metadata: HashMap::from([("file_hash".to_string(), hash)]),
             })
         }
@@ -437,7 +424,6 @@ async fn run_tool(
                 simplified: clip_to(&body, SIMPLIFIED_MAX),
                 actual: body,
                 image_for_assistant: None,
-                image_for_user: None,
                 metadata: HashMap::from([("file_hash".to_string(), content_hash(&updated))]),
             })
         }

--- a/chatbot/src/roles/primary_role.rs
+++ b/chatbot/src/roles/primary_role.rs
@@ -27,15 +27,16 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     re-scan an image: give one best reading, flag what's unclear rather than re-guess, and \
     reconsider only if the user or a tool contradicts you.\n\n\
     Call tools (one or several) when they help; answer once you have enough.\n\n\
-    SENDING A FILE: to hand the user a file from your bash sandbox, put the marker \
-    `[[attach:PATH]]` anywhere in your reply text — e.g. `Here's the report [[attach:/tmp/report.pdf]]`. \
-    This is NOT a tool and costs no tool turn; it's a special pattern in your message. When your \
-    reply is sent, each marker is removed from the text and the file at that sandbox path (the same \
-    filesystem as run_bash_command) is uploaded as a real attachment in its place. It works for any \
-    file type — PDFs, archives, code, data, images. Only reference paths that actually exist in your \
-    sandbox; if a path can't be read the marker is dropped and a short note shown instead. (For \
-    images specifically you may also use the send_image_to_user tool, but this marker is the general \
-    way to deliver any file.)\n\n\
+    SENDING A FILE OR IMAGE: to hand the user something from your bash sandbox, put a marker \
+    anywhere in your reply text — `[[attach_file:PATH]]` for any file (e.g. `Here's the report \
+    [[attach_file:/tmp/report.pdf]]`) or `[[attach_image:PATH]]` to show an image (e.g. \
+    `[[attach_image:/tmp/plot.png]]`). These are NOT tools and cost no tool turn; they're special \
+    patterns in your message. When your reply is sent, each marker is removed from the text and the \
+    file at that sandbox path (the same filesystem as run_bash_command) is uploaded as a real \
+    attachment in its place — images show inline. Only reference paths that actually exist in your \
+    sandbox; if a path can't be read the marker is dropped and a short note shown instead. To show \
+    an image to the user, always use `[[attach_image:PATH]]` — the view_image tool only lets YOU \
+    see it, not the user.\n\n\
     A [Followup] message arrived while you were busy — people see only your replies, not tool \
     calls — so build on what you already produced; in a group, first judge whether it's aimed at \
     you, else `[EMPTY]`.";

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -1,6 +1,6 @@
 use crate::externals::{
     llama_cpp_external::get_llm_decision,
-    message_external::{send_message, Attachment, OutboundMessage},
+    message_external::{send_message, OutboundMessage},
     tool_call_external::execute_tool,
 };
 use crate::types::conversation::{
@@ -333,7 +333,6 @@ fn conversation_transition(
                     OutboundMessage {
                         message: response.message().map(str::to_string),
                         tool_names: announce_tools,
-                        attachments: Vec::new(),
                     },
                     post_send,
                     updated_conversation,
@@ -398,12 +397,6 @@ fn conversation_transition(
             if pending_tools.is_empty() {
                 completed_tools.sort_by(|(a, _), (b, _)| a.id.cmp(&b.id));
 
-                let attachments: Vec<Attachment> = completed_tools
-                    .iter()
-                    .filter_map(|(_, data)| data.image_for_user.clone())
-                    .map(Attachment::Image)
-                    .collect();
-
                 let results = completed_tools
                     .into_iter()
                     .map(|(call, data)| ToolResult { call, data })
@@ -418,7 +411,6 @@ fn conversation_transition(
                     OutboundMessage {
                         message: None,
                         tool_names: Vec::new(),
-                        attachments,
                     },
                     PostSend::SendToolResponse {
                         tool_rounds,

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -54,7 +54,6 @@ impl ToolKind {
             ToolKind::RunBashCommand => "run_bash_command",
             ToolKind::ResetBashContainer => "reset_bash_container",
             ToolKind::ViewImage => "view_image",
-            ToolKind::SendImageToUser => "send_image_to_user",
             ToolKind::ReadFile => "read_file",
             ToolKind::EditFile => "edit_file",
         }
@@ -97,17 +96,7 @@ impl ToolKind {
                 json!({ "type": "object", "properties": {}, "required": [] }),
             ),
             ToolKind::ViewImage => (
-                "Privately inspect an image yourself — the user does NOT see it. To show or send an image to the user, use send_image_to_user instead. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). Use it to inspect plots, screenshots, or downloaded images before deciding what to do next.",
-                json!({
-                    "type": "object",
-                    "properties": {
-                        "path": { "type": "string", "description": "Path to the image file inside your bash sandbox, e.g. \"/tmp/plot.png\" or \"chart.png\" (relative to the sandbox working directory)." }
-                    },
-                    "required": ["path"]
-                }),
-            ),
-            ToolKind::SendImageToUser => (
-                "Show an image to the user — send an image file from your bash sandbox into this chat so they can see it. This is how you display/share/show an image to the user; use it whenever they ask to see one. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). It goes to the user — they see it in the chat — and you see it too (it counts as a message you sent). Use it to deliver plots, generated images, or processed pictures.",
+                "Privately inspect an image yourself — the user does NOT see it. To show an image to the user, don't use this tool: write the marker `[[attach_image:PATH]]` in your reply instead. The path points to a file in the SAME private Linux environment as run_bash_command — create, download, or generate the image there first (e.g. with matplotlib, imagemagick, or curl). The file must be a valid image (PNG, JPEG, GIF, or WebP). Use it to inspect plots, screenshots, or downloaded images before deciding what to do next.",
                 json!({
                     "type": "object",
                     "properties": {
@@ -174,9 +163,6 @@ impl ToolType {
             ToolType::ViewImage { path } => {
                 [("path".to_string(), json!(path))].into_iter().collect()
             }
-            ToolType::SendImageToUser { path } => {
-                [("path".to_string(), json!(path))].into_iter().collect()
-            }
             ToolType::ReadFile {
                 path,
                 offset,
@@ -220,9 +206,6 @@ impl ToolType {
             }),
             ToolKind::ResetBashContainer => Ok(ToolType::ResetBashContainer),
             ToolKind::ViewImage => Ok(ToolType::ViewImage {
-                path: parse_args::<PathArgs>(name, arguments)?.path,
-            }),
-            ToolKind::SendImageToUser => Ok(ToolType::SendImageToUser {
                 path: parse_args::<PathArgs>(name, arguments)?.path,
             }),
             ToolKind::ReadFile => {

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -244,24 +244,12 @@ impl LLMInput {
             LLMInput::ToolResults(results, user_msg) => {
                 let mut messages: Vec<ChatMessage> = Vec::new();
                 let mut bytes: Vec<Arc<Vec<u8>>> = Vec::new();
-                let mut delivered: Vec<Arc<Vec<u8>>> = Vec::new();
 
                 for r in results {
                     let mut parts: Vec<String> = Vec::new();
                     let text = if full { &r.data.actual } else { &r.data.simplified };
                     if !text.is_empty() {
                         parts.push(text.clone());
-                    }
-                    if let Some(image) = &r.data.image_for_user {
-                        match image.hydrated_bytes() {
-                            Some(b) => {
-                                parts.push("[The image you produced was delivered to the user as your message — shown below.]".to_string());
-                                delivered.push(b);
-                            }
-                            None => parts.push(
-                                "[An image was delivered to the user as your message earlier in the conversation.]".to_string(),
-                            ),
-                        }
                     }
                     if let Some(image) = &r.data.image_for_assistant {
                         match image.hydrated_bytes() {
@@ -275,12 +263,6 @@ impl LLMInput {
                         }
                     }
                     messages.push(ChatMessage::tool(r.call.id.clone(), parts.join("\n")));
-                }
-
-                if !delivered.is_empty() {
-                    let content = vec![marker.to_string(); delivered.len()].join("\n");
-                    messages.push(ChatMessage::assistant(content));
-                    bytes.extend(delivered);
                 }
 
                 if let Some(msg) = user_msg {
@@ -305,7 +287,6 @@ pub enum ToolType {
     RunBashCommand { command: String },
     ResetBashContainer,
     ViewImage { path: String },
-    SendImageToUser { path: String },
     ReadFile {
         path: String,
         offset: Option<usize>,
@@ -325,7 +306,6 @@ impl ToolType {
             ToolType::VisitUrl { .. } => 90_000,
             ToolType::WebSearch { .. } | ToolType::ResetBashContainer => 60_000,
             ToolType::ViewImage { .. }
-            | ToolType::SendImageToUser { .. }
             | ToolType::ReadFile { .. }
             | ToolType::EditFile { .. } => 30_000,
         };
@@ -506,7 +486,6 @@ pub struct ToolResultData {
     pub actual: String,
     pub simplified: String,
     pub image_for_assistant: Option<MessageImage>,
-    pub image_for_user: Option<MessageImage>,
     pub metadata: HashMap<String, String>,
 }
 
@@ -516,7 +495,6 @@ impl ToolResultData {
             actual,
             simplified,
             image_for_assistant: None,
-            image_for_user: None,
             metadata: HashMap::new(),
         }
     }


### PR DESCRIPTION
Splits the `[[attach:PATH]]` marker into **`[[attach_file:PATH]]`** and **`[[attach_image:PATH]]`**, and moves image delivery off a dedicated tool onto the same marker mechanism as files.

## What
- **Two markers**: `message_external`'s `ATTACH_RE` matches both `attach_file` and `attach_image`; both resolve identically via `pull_file` (Discord renders images inline by extension). The names signal the model's intent; the mechanism is the same — 'make it work the same way file works'.
- **Removed the `send_image_to_user` tool**: the `ToolType` variant, its `tools.rs` entry (wire name / definition / args / bind), and its `tool_call_external` arm. `view_image` stays (private inspection); its description now points at `[[attach_image:PATH]]`.
- **Full clean revert of the dead plumbing** that only `send_image_to_user` fed: `image_for_user` field + readers, the `messages_and_media` 'delivered to user' rendering, the state-machine `attachments` collection, `OutboundMessage.attachments`, the `Attachment` enum, `discord_attachment`, and the summarizer note.
- Prompt (`primary_role`) reworded for the two markers.

## Kept (general tool infra from #173)
`send_then`, `OutboundMessage {message, tool_names}`, `view_image` + `image_for_assistant` rendering, `pull_image`, `pull_file`, the marker mechanism.

## Verified
`cargo check` clean, clippy clean (no denied lints), 4/4 marker tests pass. Net −89 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)