### PR TITLE
chatbot: meta_no_op_extra_turn tool + per-tool announcement control

### DIFF
--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -364,6 +364,10 @@ async fn run_tool(
     expected_file_hash: Option<String>,
 ) -> Result<ToolResultData, String> {
     match tool_type {
+        ToolType::MetaNoOpExtraTurn => {
+            let note = "You have another turn — continue with the next part of your message now.";
+            Ok(ToolResultData::text(note.to_string(), note.to_string()))
+        }
         ToolType::WebSearch { query } => fetch_web_search(&query).await.map_err(|e| e.to_string()),
         ToolType::VisitUrl { url } => fetch_url_content(&url).await.map_err(|e| e.to_string()),
         ToolType::RunBashCommand { command } => run_bash(conversation_id, &command).await,

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -312,7 +312,7 @@ fn conversation_transition(
                     response
                         .tool_calls
                         .iter()
-                        .map(|tc| tc.tool_type.wire_name().to_string())
+                        .filter_map(|tc| tc.tool_type.announcement().map(str::to_string))
                         .collect()
                 } else {
                     Vec::new()

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -56,6 +56,14 @@ impl ToolKind {
             ToolKind::ViewImage => "view_image",
             ToolKind::ReadFile => "read_file",
             ToolKind::EditFile => "edit_file",
+            ToolKind::MetaNoOpExtraTurn => "meta_no_op_extra_turn",
+        }
+    }
+
+    fn announcement(&self) -> Option<&'static str> {
+        match self {
+            ToolKind::MetaNoOpExtraTurn => None,
+            _ => Some(self.wire_name()),
         }
     }
 
@@ -129,6 +137,10 @@ impl ToolKind {
                     "required": ["path", "old_string", "new_string"]
                 }),
             ),
+            ToolKind::MetaNoOpExtraTurn => (
+                "Give yourself another turn after this reply — use it to say something to the user across multiple steps. Put the first part in this reply's message, call this tool, and you'll be prompted again to continue with the next part. Pointless to call with no message (nothing is sent to the user), and pointless to call alongside other tools (a tool call already earns you another turn).",
+                json!({ "type": "object", "properties": {}, "required": [] }),
+            ),
         };
         ToolDefinition {
             kind: "function",
@@ -148,6 +160,10 @@ impl ToolType {
 
     pub fn wire_name(&self) -> &'static str {
         ToolKind::from(self).wire_name()
+    }
+
+    pub fn announcement(&self) -> Option<&'static str> {
+        ToolKind::from(self).announcement()
     }
 
     pub fn arguments_map(&self) -> Map<String, Value> {
@@ -186,6 +202,7 @@ impl ToolType {
             ]
             .into_iter()
             .collect(),
+            ToolType::MetaNoOpExtraTurn => Map::new(),
         }
     }
 
@@ -224,6 +241,7 @@ impl ToolType {
                     new_string: args.new_string,
                 })
             }
+            ToolKind::MetaNoOpExtraTurn => Ok(ToolType::MetaNoOpExtraTurn),
         }
     }
 }

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -297,6 +297,7 @@ pub enum ToolType {
         old_string: String,
         new_string: String,
     },
+    MetaNoOpExtraTurn,
 }
 
 impl ToolType {
@@ -307,7 +308,8 @@ impl ToolType {
             ToolType::WebSearch { .. } | ToolType::ResetBashContainer => 60_000,
             ToolType::ViewImage { .. }
             | ToolType::ReadFile { .. }
-            | ToolType::EditFile { .. } => 30_000,
+            | ToolType::EditFile { .. }
+            | ToolType::MetaNoOpExtraTurn => 30_000,
         };
         Duration::milliseconds(ms)
     }


### PR DESCRIPTION
## What

Two related additions to the chatbot tool layer.

### `meta_no_op_extra_turn` tool
A zero-arg no-op tool that lets the model take another turn alongside a message — useful for replying to the user across multiple steps. It leans entirely on the existing loop: any tool call rounds the conversation back through `SendToolResponse` → a fresh LLM decision, so a no-op is all it takes to buy the extra turn. Its result just nudges the model to continue. The description tells the model it's pointless to call with no message (nothing gets sent) or alongside other tools (those already grant a turn).

### Per-tool announcement control
The running-tools subtext ("using tool: …") was all-or-nothing across every tool call. Replaced the `Vec<String>` of wire names with a per-tool `announcement() -> Option<&'static str>`:
- `Some(label)` announces, defaulting to the wire name.
- `None` suppresses — no subtext for that tool.

This unifies "should it announce" and "with what text" into one knob and frees the label from being hardcoded to the raw wire name. `meta_no_op_extra_turn` returns `None`. `env.announce_tool_use` still gates announcements globally.

## Notes
- Behavior for existing tools is unchanged (each still announces its wire name).
- No state-machine shape change; `OutboundMessage.tool_names` still carries the final label list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)