### PR TITLE
chatbot: accept stringified numbers for read_file offset/limit

### DIFF
--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -28,10 +28,30 @@ struct PathArgs {
 #[derive(Debug, Deserialize)]
 struct ReadFileArgs {
     path: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_usize")]
     offset: Option<usize>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_lenient_opt_usize")]
     limit: Option<usize>,
+}
+
+fn de_lenient_opt_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumOrStr {
+        Num(usize),
+        Str(String),
+    }
+    match Option::<NumOrStr>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(NumOrStr::Num(n)) => Ok(Some(n)),
+        Some(NumOrStr::Str(s)) => match s.trim() {
+            "" => Ok(None),
+            t => t.parse::<usize>().map(Some).map_err(serde::de::Error::custom),
+        },
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -243,5 +263,38 @@ impl ToolType {
             }
             ToolKind::MetaNoOpExtraTurn => Ok(ToolType::MetaNoOpExtraTurn),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_file_accepts_stringified_numbers() {
+        let bound = ToolType::bind(
+            "read_file",
+            r#"{"path":"/tmp/x.json","offset":"60","limit":"20"}"#,
+        )
+        .expect("stringified numbers should bind");
+        assert!(matches!(
+            bound,
+            ToolType::ReadFile { offset: Some(60), limit: Some(20), .. }
+        ));
+    }
+
+    #[test]
+    fn read_file_accepts_numeric_and_absent() {
+        let numeric = ToolType::bind("read_file", r#"{"path":"/x","offset":5}"#).unwrap();
+        assert!(matches!(
+            numeric,
+            ToolType::ReadFile { offset: Some(5), limit: None, .. }
+        ));
+
+        let absent = ToolType::bind("read_file", r#"{"path":"/x"}"#).unwrap();
+        assert!(matches!(
+            absent,
+            ToolType::ReadFile { offset: None, limit: None, .. }
+        ));
     }
 }


### PR DESCRIPTION
## What

Make `read_file`'s optional numeric args (`offset`, `limit`) tolerant of stringified numbers.

## Why

The utility/primary model routinely emits integer tool args as quoted strings — `{"path":"…","offset":"60","limit":"20"}`. Strict `usize` deserialization rejected those, the tool-call bind failed, and because binds are collected atomically in `llama_cpp_external` (`collect::<Result<Vec<_>>>()?`), the **entire turn was discarded** — the model's message *and* every sibling call — leaving the conversation at Idle with no auto-retry.

Seen live on the TM.47 form task: after a bash step surfaced a JSON error, the model tried to `read_file(offset:"60", limit:"20")` to fix it, the call was dropped twice in a row, and the bot went silent mid-task until the user asked "what happened".

## Change

A lenient deserializer (`de_lenient_opt_usize`) on `offset`/`limit`: a JSON number or a numeric string both bind; empty string / null → `None`. Covered by two unit tests.

## Scope

This kills the common trigger (stringified numbers). It does **not** change the atomic-collect behavior — a genuinely un-bindable call still drops the turn. Turning malformed binds into per-call error tool-results (so the model self-corrects instead of stalling), plus recovery from timeout/failed interruptions, are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)