### PR TITLE
chatbot: set_reminder tool backed by a ReminderForConversation entity

### DIFF
--- a/chatbot/src/externals/summarize_external.rs
+++ b/chatbot/src/externals/summarize_external.rs
@@ -41,6 +41,9 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
             HistoryEntryKind::Input(LLMInput::ConversationMessage(msg)) => {
                 lines.push(render_message(msg))
             }
+            HistoryEntryKind::Input(LLMInput::SystemMessage(sys)) => {
+                lines.push(format!("Reminder fired for {}: {}", sys.name, sys.note))
+            }
             HistoryEntryKind::Input(LLMInput::ToolResults(results, followup)) => {
                 for result in results {
                     let mut line = format!(

--- a/chatbot/src/externals/summarize_external.rs
+++ b/chatbot/src/externals/summarize_external.rs
@@ -43,12 +43,7 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
             }
             HistoryEntryKind::Input(LLMInput::SystemMessage(batch)) => {
                 for sys in batch {
-                    let who = if sys.name.is_empty() {
-                        "the user"
-                    } else {
-                        &sys.name
-                    };
-                    lines.push(format!("Reminder fired for {who}: {}", sys.note));
+                    lines.push(format!("Reminder fired for {}: {}", sys.addressee, sys.note));
                 }
             }
             HistoryEntryKind::Input(LLMInput::ToolResults(results, followup)) => {

--- a/chatbot/src/externals/summarize_external.rs
+++ b/chatbot/src/externals/summarize_external.rs
@@ -41,8 +41,15 @@ fn history_to_transcript(history: &[HistoryEntry]) -> String {
             HistoryEntryKind::Input(LLMInput::ConversationMessage(msg)) => {
                 lines.push(render_message(msg))
             }
-            HistoryEntryKind::Input(LLMInput::SystemMessage(sys)) => {
-                lines.push(format!("Reminder fired for {}: {}", sys.name, sys.note))
+            HistoryEntryKind::Input(LLMInput::SystemMessage(batch)) => {
+                for sys in batch {
+                    let who = if sys.name.is_empty() {
+                        "the user"
+                    } else {
+                        &sys.name
+                    };
+                    lines.push(format!("Reminder fired for {who}: {}", sys.note));
+                }
             }
             HistoryEntryKind::Input(LLMInput::ToolResults(results, followup)) => {
                 for result in results {

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -431,8 +431,10 @@ async fn run_tool(
                 metadata: HashMap::from([("file_hash".to_string(), content_hash(&updated))]),
             })
         }
-        // Dispatched from the ConversationMachine transition (it needs Effects to
-        // spawn the reminder entity), never routed through execute_tool.
+        // Runtime-dispatched tools (ToolType::dispatch() == Runtime) are handled
+        // inside the ConversationMachine transition and never reach the executor.
+        // This arm exists only for match exhaustiveness; reaching it means a
+        // dispatch()/execute_tool disagreement.
         ToolType::SetReminder { .. } => Err(
             "set_reminder is handled by the conversation runtime, not the tool executor".to_string(),
         ),

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -431,10 +431,6 @@ async fn run_tool(
                 metadata: HashMap::from([("file_hash".to_string(), content_hash(&updated))]),
             })
         }
-        // Runtime-dispatched tools (ToolType::dispatch() == Runtime) are handled
-        // inside the ConversationMachine transition and never reach the executor.
-        // This arm exists only for match exhaustiveness; reaching it means a
-        // dispatch()/execute_tool disagreement.
         ToolType::SetReminder { .. } => Err(
             "set_reminder is handled by the conversation runtime, not the tool executor".to_string(),
         ),

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -431,6 +431,11 @@ async fn run_tool(
                 metadata: HashMap::from([("file_hash".to_string(), content_hash(&updated))]),
             })
         }
+        // Dispatched from the ConversationMachine transition (it needs Effects to
+        // spawn the reminder entity), never routed through execute_tool.
+        ToolType::SetReminder { .. } => Err(
+            "set_reminder is handled by the conversation runtime, not the tool executor".to_string(),
+        ),
     }
 }
 

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -19,6 +19,7 @@ use tokio::task::JoinSet;
 use crate::roles::{PrimaryRole, UtilityRole};
 use crate::state_machines::conversation_state_machine::ConversationMachine;
 use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
+use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
 
 #[derive(Clone)]
 pub struct Env {
@@ -67,7 +68,8 @@ async fn main() -> anyhow::Result<!> {
     re_framework::init_turso_store("framework_db/chatbot.db").await?;
     let env = init_env().await?;
     re_framework::register::<ConversationMachine>(env.clone());
-    re_framework::register::<MemoryManagerMachine>(env);
+    re_framework::register::<MemoryManagerMachine>(env.clone());
+    re_framework::register::<ReminderForConversationMachine>(env);
     re_framework::start();
 
     tokio::spawn(async {

--- a/chatbot/src/state_machines.rs
+++ b/chatbot/src/state_machines.rs
@@ -1,2 +1,3 @@
 pub mod conversation_state_machine;
 pub mod memory_manager_state_machine;
+pub mod reminder_state_machine;

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -3,12 +3,12 @@ use crate::externals::{
     message_external::{send_message, OutboundMessage},
     tool_call_external::execute_tool,
 };
+use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
+use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
 use crate::types::conversation::{
     latest_file_hash, Pending, SystemMessage, ToolDispatch, ToolResult, ToolResultData, ToolType,
     MAX_TOOL_ROUNDS,
 };
-use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
-use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
 use crate::types::media::Attachment;
 use crate::types::memory::{MemoryManagerAction, MemoryManagerConstructor};
 use crate::types::reminder::{
@@ -197,54 +197,55 @@ fn apply_post_send(
             let history = recent_conversation.history();
             let mut pending_tools = HashMap::new();
             for tool_call in tool_calls {
-                if matches!(tool_call.tool_type.dispatch(), ToolDispatch::Runtime) {
-                    let ToolType::SetReminder {
-                        delay_seconds,
-                        note,
-                        addressee,
-                    } = &tool_call.tool_type
-                    else {
-                        continue;
-                    };
-                    let text = match validate_delay(*delay_seconds) {
-                        Ok(fire_at) => {
-                            effects.enqueue_construct::<ReminderForConversationMachine>(
-                                ReminderConstructor {
-                                    id: ReminderForConversationId {
-                                        conversation_id: conversation_id.clone(),
-                                        reminder_id: ReminderId::new(),
+                match tool_call.tool_type.dispatch() {
+                    ToolDispatch::Runtime => {
+                        let ToolType::SetReminder {
+                            delay_seconds,
+                            note,
+                            addressee,
+                        } = &tool_call.tool_type
+                        else {
+                            continue;
+                        };
+                        let text = match validate_delay(*delay_seconds) {
+                            Ok(fire_at) => {
+                                effects.enqueue_construct::<ReminderForConversationMachine>(
+                                    ReminderConstructor {
+                                        id: ReminderForConversationId {
+                                            conversation_id: conversation_id.clone(),
+                                            reminder_id: ReminderId::new(),
+                                        },
+                                        addressee: addressee.clone(),
+                                        note: note.clone(),
+                                        delay_seconds: *delay_seconds,
                                     },
-                                    addressee: addressee.clone(),
-                                    note: note.clone(),
-                                    delay_seconds: *delay_seconds,
-                                },
-                            );
-                            reminder_confirmation(fire_at, note)
-                        }
-                        Err(msg) => msg,
-                    };
-                    effects.enqueue_action::<ConversationMachine>(
-                        conversation_id.clone(),
-                        ConversationAction::ToolResult {
-                            id: tool_call.id.clone(),
-                            result: Ok(ToolResultData::text(text.clone(), text)),
-                        },
-                    );
-                    pending_tools.insert(tool_call.id.clone(), tool_call);
-                    continue;
-                }
-
-                let expected_file_hash = match &tool_call.tool_type {
-                    ToolType::EditFile { path, .. } => {
-                        latest_file_hash(&history, path).map(str::to_string)
+                                );
+                                reminder_confirmation(fire_at, note)
+                            }
+                            Err(msg) => msg,
+                        };
+                        effects.enqueue_action::<ConversationMachine>(
+                            conversation_id.clone(),
+                            ConversationAction::ToolResult {
+                                id: tool_call.id.clone(),
+                                result: Ok(ToolResultData::text(text.clone(), text)),
+                            },
+                        );
                     }
-                    _ => None,
-                };
-                effects.enqueue_external(execute_tool(
-                    conversation_id.to_string(),
-                    tool_call.clone(),
-                    expected_file_hash,
-                ));
+                    ToolDispatch::Executor => {
+                        let expected_file_hash = match &tool_call.tool_type {
+                            ToolType::EditFile { path, .. } => {
+                                latest_file_hash(&history, path).map(str::to_string)
+                            }
+                            _ => None,
+                        };
+                        effects.enqueue_external(execute_tool(
+                            conversation_id.to_string(),
+                            tool_call.clone(),
+                            expected_file_hash,
+                        ));
+                    }
+                }
                 pending_tools.insert(tool_call.id.clone(), tool_call);
             }
 
@@ -330,10 +331,7 @@ fn conversation_transition(
                 ..conversation
             })
         }
-        (
-            user_state,
-            ConversationAction::ReminderFired { note, addressee },
-        ) => {
+        (user_state, ConversationAction::ReminderFired { note, addressee }) => {
             let mut pending = conversation.pending;
             pending.push(Pending::System(SystemMessage {
                 note: note.clone(),
@@ -628,7 +626,13 @@ fn post_transition(
     };
 
     let Some(current_input) = take_pending(&mut conversation.pending) else {
-        maybe_fire_compaction(env, conversation_id, &mut conversation, &recent_conversation, effects);
+        maybe_fire_compaction(
+            env,
+            conversation_id,
+            &mut conversation,
+            &recent_conversation,
+            effects,
+        );
         return Ok(conversation);
     };
 
@@ -713,7 +717,10 @@ fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<Conver
         ConversationState::RunningTools { pending_tools, .. } => pending_tools
             .iter()
             .map(|(id, call)| {
-                (id.clone(), conversation.last_transition + call.tool_type.rescue_timeout())
+                (
+                    id.clone(),
+                    conversation.last_transition + call.tool_type.rescue_timeout(),
+                )
             })
             .min_by_key(|(_, at)| *at)
             .map(|(id, at)| Scheduled {
@@ -828,6 +835,8 @@ mod tests {
             panic!("mixed batch should merge into a ConversationMessage");
         };
         assert!(msg.text.contains("hey"));
-        assert!(msg.text.contains("[Reminder — IMPORTANT] For Alice: take meds"));
+        assert!(msg
+            .text
+            .contains("[Reminder — IMPORTANT] For Alice: take meds"));
     }
 }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -516,22 +516,24 @@ fn conversation_transition(
 }
 
 fn take_pending(pending: &mut Vec<Pending>) -> Option<LLMInput> {
-    if pending.is_empty() {
-        return None;
-    }
     let drained = std::mem::take(pending);
-
-    if drained.iter().all(|p| matches!(p, Pending::System(_))) {
-        let batch = drained
-            .into_iter()
-            .filter_map(|p| match p {
-                Pending::System(s) => Some(s),
-                Pending::Message(_) => None,
-            })
-            .collect();
-        return Some(LLMInput::SystemMessage(batch));
+    match drained.as_slice() {
+        [] => None,
+        _ if drained.iter().all(|p| matches!(p, Pending::System(_))) => {
+            let batch = drained
+                .into_iter()
+                .filter_map(|p| match p {
+                    Pending::System(s) => Some(s),
+                    Pending::Message(_) => None,
+                })
+                .collect();
+            Some(LLMInput::SystemMessage(batch))
+        }
+        _ => Some(LLMInput::ConversationMessage(merge_pending(drained))),
     }
+}
 
+fn merge_pending(drained: Vec<Pending>) -> ConversationMessage {
     let queued = drained
         .iter()
         .any(|p| matches!(p, Pending::Message(m) if m.queued));
@@ -559,13 +561,13 @@ fn take_pending(pending: &mut Vec<Pending>) -> Option<LLMInput> {
         })
         .collect::<Vec<_>>()
         .join("\n");
-    Some(LLMInput::ConversationMessage(ConversationMessage {
+    ConversationMessage {
         text,
         queued,
         user_id,
         name,
         attachments,
-    }))
+    }
 }
 
 fn followup_message(input: LLMInput) -> Option<ConversationMessage> {
@@ -587,19 +589,17 @@ fn followup_message(input: LLMInput) -> Option<ConversationMessage> {
 }
 
 fn validate_delay(delay_seconds: i64) -> Result<DateTime<Utc>, String> {
-    if delay_seconds <= 0 {
-        return Err(format!(
-            "Reminder not set: delay_seconds must be a positive number of seconds in the future (got {delay_seconds})."
-        ));
+    match delay_seconds {
+        d if d <= 0 => Err(format!(
+            "Reminder not set: delay_seconds must be a positive number of seconds in the future (got {d})."
+        )),
+        d if d > MAX_REMINDER_SECS => Err(format!(
+            "Reminder not set: delay_seconds {d} is too far out (max {MAX_REMINDER_SECS}, ~1 year)."
+        )),
+        d => Utc::now()
+            .checked_add_signed(ChronoDuration::seconds(d))
+            .ok_or_else(|| "Reminder not set: the requested time overflows.".to_string()),
     }
-    if delay_seconds > MAX_REMINDER_SECS {
-        return Err(format!(
-            "Reminder not set: delay_seconds {delay_seconds} is too far out (max {MAX_REMINDER_SECS}, ~1 year)."
-        ));
-    }
-    Utc::now()
-        .checked_add_signed(ChronoDuration::seconds(delay_seconds))
-        .ok_or_else(|| "Reminder not set: the requested time overflows.".to_string())
 }
 
 fn reminder_confirmation(fire_at: DateTime<Utc>, note: &str) -> String {

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -202,8 +202,8 @@ fn apply_post_send(
                         note,
                         addressee,
                     } => {
-                        let text = match validate_delay(*delay_seconds) {
-                            Ok(fire_at) => {
+                        let text = validate_delay(*delay_seconds)
+                            .map(|fire_at| {
                                 effects.enqueue_construct::<ReminderForConversationMachine>(
                                     ReminderConstructor {
                                         id: ReminderForConversationId {
@@ -216,9 +216,8 @@ fn apply_post_send(
                                     },
                                 );
                                 reminder_confirmation(fire_at, note)
-                            }
-                            Err(msg) => msg,
-                        };
+                            })
+                            .unwrap_or_else(|msg| msg);
                         effects.enqueue_action::<ConversationMachine>(
                             conversation_id.clone(),
                             ConversationAction::ToolResult {

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -211,7 +211,7 @@ fn apply_post_send(
                                     },
                                     addressee: addressee.clone(),
                                     note: note.clone(),
-                                    delay_seconds: *delay_seconds,
+                                    fire_at,
                                 }),
                                 reminder_confirmation(fire_at, note),
                             ),

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -4,14 +4,16 @@ use crate::externals::{
     tool_call_external::execute_tool,
 };
 use crate::types::conversation::{
-    latest_file_hash, Pending, SystemMessage, ToolCall, ToolResult, ToolResultData, ToolType,
-    MAX_TOOL_ROUNDS,
+    latest_file_hash, Pending, SystemMessage, ToolCall, ToolDispatch, ToolResult, ToolResultData,
+    ToolType, MAX_TOOL_ROUNDS,
 };
 use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
 use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
 use crate::types::media::Attachment;
 use crate::types::memory::{MemoryManagerAction, MemoryManagerConstructor};
-use crate::types::reminder::{ReminderConstructor, ReminderForConversationId, ReminderId};
+use crate::types::reminder::{
+    ReminderConstructor, ReminderForConversationId, ReminderId, MAX_REMINDER_SECS,
+};
 use crate::{
     types::conversation::{
         CompactionOutput, Conversation, ConversationAction, ConversationConstructor,
@@ -20,7 +22,7 @@ use crate::{
     },
     Env,
 };
-use chrono::{Duration as ChronoDuration, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use re_framework::{Effects, Scheduled, StateMachine};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -200,24 +202,36 @@ fn apply_post_send(
             let mut pending_tools = HashMap::new();
             let mut completed_tools: Vec<(ToolCall, ToolResultData)> = Vec::new();
             for tool_call in tool_calls {
-                if let ToolType::SetReminder {
-                    delay_seconds,
-                    note,
-                } = &tool_call.tool_type
-                {
-                    effects.enqueue_construct::<ReminderForConversationMachine>(ReminderConstructor {
-                        id: ReminderForConversationId {
-                            conversation_id: conversation_id.clone(),
-                            reminder_id: ReminderId::new(),
-                        },
-                        user_id: requester_id.clone(),
-                        name: requester_name.clone(),
-                        note: note.clone(),
-                        delay_seconds: *delay_seconds,
-                    });
-                    let confirmation = reminder_confirmation(*delay_seconds, note);
-                    completed_tools
-                        .push((tool_call, ToolResultData::text(confirmation.clone(), confirmation)));
+                // Runtime-dispatched tools (currently only set_reminder) are
+                // handled here — they need Effects and never go to execute_tool.
+                if matches!(tool_call.tool_type.dispatch(), ToolDispatch::Runtime) {
+                    let ToolType::SetReminder {
+                        delay_seconds,
+                        note,
+                    } = &tool_call.tool_type
+                    else {
+                        // dispatch() only routes SetReminder here today.
+                        continue;
+                    };
+                    let result = match validate_delay(*delay_seconds) {
+                        Ok(fire_at) => {
+                            effects.enqueue_construct::<ReminderForConversationMachine>(
+                                ReminderConstructor {
+                                    id: ReminderForConversationId {
+                                        conversation_id: conversation_id.clone(),
+                                        reminder_id: ReminderId::new(),
+                                    },
+                                    user_id: requester_id.clone(),
+                                    name: requester_name.clone(),
+                                    note: note.clone(),
+                                    delay_seconds: *delay_seconds,
+                                },
+                            );
+                            reminder_confirmation(fire_at, note)
+                        }
+                        Err(msg) => msg,
+                    };
+                    completed_tools.push((tool_call, ToolResultData::text(result.clone(), result)));
                     continue;
                 }
 
@@ -515,30 +529,28 @@ fn conversation_transition(
 /// `System` turn (the common case — a reminder firing while Idle drains alone);
 /// any other batch merges into one `Message`, folding reminder notes in as their
 /// already-tagged, high-importance text.
-fn take_pending(pending: &mut Vec<Pending>) -> Option<Pending> {
+fn take_pending(pending: &mut Vec<Pending>) -> Option<LLMInput> {
     if pending.is_empty() {
         return None;
     }
     let drained = std::mem::take(pending);
 
+    // A pure-reminder batch stays a system turn, each reminder rendered
+    // individually (preserving per-reminder identity in a group chat).
     if drained.iter().all(|p| matches!(p, Pending::System(_))) {
-        let mut merged: Option<SystemMessage> = None;
-        for p in drained {
-            let Pending::System(s) = p else { continue };
-            merged = Some(match merged {
-                None => s,
-                Some(mut acc) => {
-                    acc.note.push('\n');
-                    acc.note.push_str(&s.note);
-                    acc.user_id = s.user_id;
-                    acc.name = s.name;
-                    acc
-                }
-            });
-        }
-        return merged.map(Pending::System);
+        let batch = drained
+            .into_iter()
+            .filter_map(|p| match p {
+                Pending::System(s) => Some(s),
+                Pending::Message(_) => None,
+            })
+            .collect();
+        return Some(LLMInput::SystemMessage(batch));
     }
 
+    // Mixed / user batch: merge into one user turn as before. Any reminder in the
+    // batch contributes its already-tagged content (which includes "For {name}"),
+    // so identity survives the merge here too.
     let queued = drained
         .iter()
         .any(|p| matches!(p, Pending::Message(m) if m.queued));
@@ -566,7 +578,7 @@ fn take_pending(pending: &mut Vec<Pending>) -> Option<Pending> {
         })
         .collect::<Vec<_>>()
         .join("\n");
-    Some(Pending::Message(ConversationMessage {
+    Some(LLMInput::ConversationMessage(ConversationMessage {
         text,
         queued,
         user_id,
@@ -575,12 +587,40 @@ fn take_pending(pending: &mut Vec<Pending>) -> Option<Pending> {
     }))
 }
 
+/// Flatten a drained input into the tool-round followup slot, which bundles
+/// late-arriving input with tool results as `Option<ConversationMessage>`.
+///
+/// NOTE: this is the one place a fired reminder does *not* stay a system turn — a
+/// reminder that lands while tools are running is rendered as a user turn here.
+/// Per-reminder identity is still preserved (it's carried in the tagged text),
+/// but the representation diverges from the Idle-drain path. See #210 followup.
+fn followup_message(input: LLMInput) -> Option<ConversationMessage> {
+    match input {
+        LLMInput::ConversationMessage(m) => Some(m),
+        LLMInput::SystemMessage(batch) => Some(ConversationMessage {
+            text: batch
+                .iter()
+                .map(SystemMessage::to_content)
+                .collect::<Vec<_>>()
+                .join("\n"),
+            queued: false,
+            user_id: String::new(),
+            name: String::new(),
+            attachments: Vec::new(),
+        }),
+        // take_pending never yields ToolResults (they don't queue).
+        LLMInput::ToolResults(..) => None,
+    }
+}
+
 /// Identity of whoever's input drove this turn — used to name the target user on
 /// a reminder set during it. Falls back through history for a tool-result turn.
 fn input_identity(input: &LLMInput) -> Option<(String, String)> {
     match input {
         LLMInput::ConversationMessage(m) => Some((m.user_id.clone(), m.name.clone())),
-        LLMInput::SystemMessage(s) => Some((s.user_id.clone(), s.name.clone())),
+        LLMInput::SystemMessage(batch) => batch
+            .last()
+            .map(|s| (s.user_id.clone(), s.name.clone())),
         LLMInput::ToolResults(_, followup) => {
             followup.as_ref().map(|m| (m.user_id.clone(), m.name.clone()))
         }
@@ -599,13 +639,31 @@ fn requester_identity(recent: &RecentConversation) -> (String, String) {
         .unwrap_or_default()
 }
 
-/// Approximate confirmation handed back to the model as the reminder tool's
-/// (synthetic) result, so it can tell the user it's set.
-fn reminder_confirmation(delay_seconds: i64, note: &str) -> String {
-    let fire_at = Utc::now() + ChronoDuration::seconds(delay_seconds);
+/// Validate a model-supplied delay before scheduling. Returns the computed
+/// `fire_at`, or an error string handed back as the tool result. Bounding the
+/// range keeps the chrono arithmetic (here and in the entity) from overflow.
+fn validate_delay(delay_seconds: i64) -> Result<DateTime<Utc>, String> {
+    if delay_seconds <= 0 {
+        return Err(format!(
+            "Reminder not set: delay_seconds must be a positive number of seconds in the future (got {delay_seconds})."
+        ));
+    }
+    if delay_seconds > MAX_REMINDER_SECS {
+        return Err(format!(
+            "Reminder not set: delay_seconds {delay_seconds} is too far out (max {MAX_REMINDER_SECS}, ~1 year)."
+        ));
+    }
+    Utc::now()
+        .checked_add_signed(ChronoDuration::seconds(delay_seconds))
+        .ok_or_else(|| "Reminder not set: the requested time overflows.".to_string())
+}
+
+/// Confirmation handed back to the model as the reminder tool's (synthetic)
+/// result, so it can tell the user it's set.
+fn reminder_confirmation(fire_at: DateTime<Utc>, note: &str) -> String {
     format!(
-        "Reminder set — fires in {delay_seconds}s (~{}). Note: \"{note}\". Tell the user you've set it; \
-         you'll be prompted automatically when it fires. Reminders do not survive a bot restart.",
+        "Reminder set — fires around {}. Note: \"{note}\". Tell the user you've set it; you'll be \
+         prompted automatically when it fires. (Reminders are lost on a redeploy.)",
         fire_at.format("%Y-%m-%d %H:%M:%S UTC")
     )
 }
@@ -631,7 +689,7 @@ fn finish_tool_round(
         .into_iter()
         .map(|(call, data)| ToolResult { call, data })
         .collect();
-    let followup = take_pending(&mut pending).map(Pending::into_message);
+    let followup = take_pending(&mut pending).and_then(followup_message);
 
     send_then(
         env,
@@ -669,7 +727,7 @@ fn post_transition(
         _ => return Ok(conversation),
     };
 
-    let Some(drained) = take_pending(&mut conversation.pending) else {
+    let Some(current_input) = take_pending(&mut conversation.pending) else {
         maybe_fire_compaction(env, conversation_id, &mut conversation, &recent_conversation, effects);
         return Ok(conversation);
     };
@@ -679,8 +737,6 @@ fn post_transition(
     let compaction_in_flight = conversation.compaction_in_flight;
 
     let history = recent_conversation.history();
-
-    let current_input = drained.into_llm_input();
 
     effects.enqueue_external(get_llm_decision(
         Arc::clone(env),
@@ -811,5 +867,70 @@ impl StateMachine for ConversationMachine {
 
     fn name() -> &'static str {
         "ConversationMachine"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::conversation::SystemMessage;
+
+    fn system(name: &str, note: &str) -> Pending {
+        Pending::System(SystemMessage {
+            note: note.to_string(),
+            user_id: format!("id_{name}"),
+            name: name.to_string(),
+        })
+    }
+
+    fn user(name: &str, text: &str) -> Pending {
+        Pending::Message(ConversationMessage {
+            text: text.to_string(),
+            queued: false,
+            user_id: format!("id_{name}"),
+            name: name.to_string(),
+            attachments: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn validate_delay_rejects_non_positive_and_too_large() {
+        assert!(validate_delay(0).is_err());
+        assert!(validate_delay(-3600).is_err());
+        assert!(validate_delay(MAX_REMINDER_SECS + 1).is_err());
+        assert!(validate_delay(3600).is_ok());
+        // A value that would overflow chrono is rejected, not panicked.
+        assert!(validate_delay(i64::MAX).is_err());
+    }
+
+    #[test]
+    fn take_pending_preserves_per_reminder_identity() {
+        // Two reminders firing together must not be attributed to one user.
+        let mut pending = vec![system("Alice", "take meds"), system("Bob", "call mom")];
+        let input = take_pending(&mut pending).expect("drains a batch");
+        let LLMInput::SystemMessage(batch) = &input else {
+            panic!("pure-reminder batch should be a SystemMessage");
+        };
+        assert_eq!(batch.len(), 2);
+
+        let (messages, _) = input.messages_and_media("<marker>", true);
+        let rendered = messages
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("For Alice: take meds"), "got: {rendered}");
+        assert!(rendered.contains("For Bob: call mom"), "got: {rendered}");
+    }
+
+    #[test]
+    fn take_pending_merges_mixed_batch_into_user_turn_keeping_reminder_text() {
+        let mut pending = vec![user("Alice", "hey"), system("Alice", "take meds")];
+        let input = take_pending(&mut pending).expect("drains a batch");
+        let LLMInput::ConversationMessage(msg) = &input else {
+            panic!("mixed batch should merge into a ConversationMessage");
+        };
+        assert!(msg.text.contains("hey"));
+        assert!(msg.text.contains("[Reminder — IMPORTANT] For Alice: take meds"));
     }
 }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -202,22 +202,24 @@ fn apply_post_send(
                         note,
                         addressee,
                     } => {
-                        let text = validate_delay(*delay_seconds)
-                            .map(|fire_at| {
-                                effects.enqueue_construct::<ReminderForConversationMachine>(
-                                    ReminderConstructor {
-                                        id: ReminderForConversationId {
-                                            conversation_id: conversation_id.clone(),
-                                            reminder_id: ReminderId::new(),
-                                        },
-                                        addressee: addressee.clone(),
-                                        note: note.clone(),
-                                        delay_seconds: *delay_seconds,
+                        let (maybe_construct, text) = match validate_delay(*delay_seconds) {
+                            Ok(fire_at) => (
+                                Some(ReminderConstructor {
+                                    id: ReminderForConversationId {
+                                        conversation_id: conversation_id.clone(),
+                                        reminder_id: ReminderId::new(),
                                     },
-                                );
-                                reminder_confirmation(fire_at, note)
-                            })
-                            .unwrap_or_else(|msg| msg);
+                                    addressee: addressee.clone(),
+                                    note: note.clone(),
+                                    delay_seconds: *delay_seconds,
+                                }),
+                                reminder_confirmation(fire_at, note),
+                            ),
+                            Err(msg) => (None, msg),
+                        };
+                        if let Some(constructor) = maybe_construct {
+                            effects.enqueue_construct::<ReminderForConversationMachine>(constructor);
+                        }
                         effects.enqueue_action::<ConversationMachine>(
                             conversation_id.clone(),
                             ConversationAction::ToolResult {

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -6,8 +6,7 @@ use crate::externals::{
 use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
 use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
 use crate::types::conversation::{
-    latest_file_hash, Pending, SystemMessage, ToolDispatch, ToolResult, ToolResultData, ToolType,
-    MAX_TOOL_ROUNDS,
+    latest_file_hash, Pending, SystemMessage, ToolResult, ToolResultData, ToolType, MAX_TOOL_ROUNDS,
 };
 use crate::types::media::Attachment;
 use crate::types::memory::{MemoryManagerAction, MemoryManagerConstructor};
@@ -197,16 +196,12 @@ fn apply_post_send(
             let history = recent_conversation.history();
             let mut pending_tools = HashMap::new();
             for tool_call in tool_calls {
-                match tool_call.tool_type.dispatch() {
-                    ToolDispatch::Runtime => {
-                        let ToolType::SetReminder {
-                            delay_seconds,
-                            note,
-                            addressee,
-                        } = &tool_call.tool_type
-                        else {
-                            continue;
-                        };
+                match &tool_call.tool_type {
+                    ToolType::SetReminder {
+                        delay_seconds,
+                        note,
+                        addressee,
+                    } => {
                         let text = match validate_delay(*delay_seconds) {
                             Ok(fire_at) => {
                                 effects.enqueue_construct::<ReminderForConversationMachine>(
@@ -232,8 +227,8 @@ fn apply_post_send(
                             },
                         );
                     }
-                    ToolDispatch::Executor => {
-                        let expected_file_hash = match &tool_call.tool_type {
+                    tool_type => {
+                        let expected_file_hash = match tool_type {
                             ToolType::EditFile { path, .. } => {
                                 latest_file_hash(&history, path).map(str::to_string)
                             }

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -4,11 +4,14 @@ use crate::externals::{
     tool_call_external::execute_tool,
 };
 use crate::types::conversation::{
-    latest_file_hash, ToolResult, ToolResultData, ToolType, MAX_TOOL_ROUNDS,
+    latest_file_hash, Pending, SystemMessage, ToolCall, ToolResult, ToolResultData, ToolType,
+    MAX_TOOL_ROUNDS,
 };
 use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
+use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
 use crate::types::media::Attachment;
 use crate::types::memory::{MemoryManagerAction, MemoryManagerConstructor};
+use crate::types::reminder::{ReminderConstructor, ReminderForConversationId, ReminderId};
 use crate::{
     types::conversation::{
         CompactionOutput, Conversation, ConversationAction, ConversationConstructor,
@@ -124,7 +127,7 @@ fn send_then(
     outbound: OutboundMessage,
     post_send: PostSend,
     recent_conversation: RecentConversation,
-    pending: Vec<ConversationMessage>,
+    pending: Vec<Pending>,
     is_group: bool,
     bot_identity: String,
     compaction_in_flight: bool,
@@ -168,7 +171,7 @@ fn apply_post_send(
     conversation_id: &ConversationId,
     post_send: PostSend,
     recent_conversation: RecentConversation,
-    pending: Vec<ConversationMessage>,
+    pending: Vec<Pending>,
     is_group: bool,
     bot_identity: String,
     compaction_in_flight: bool,
@@ -190,8 +193,34 @@ fn apply_post_send(
             tool_calls,
         } => {
             let history = recent_conversation.history();
+            // A reminder is dispatched here, not via execute_tool: creating the
+            // entity needs Effects. It resolves immediately with a synthetic
+            // confirmation so the round can complete and the bot can tell the user.
+            let (requester_id, requester_name) = requester_identity(&recent_conversation);
             let mut pending_tools = HashMap::new();
+            let mut completed_tools: Vec<(ToolCall, ToolResultData)> = Vec::new();
             for tool_call in tool_calls {
+                if let ToolType::SetReminder {
+                    delay_seconds,
+                    note,
+                } = &tool_call.tool_type
+                {
+                    effects.enqueue_construct::<ReminderForConversationMachine>(ReminderConstructor {
+                        id: ReminderForConversationId {
+                            conversation_id: conversation_id.clone(),
+                            reminder_id: ReminderId::new(),
+                        },
+                        user_id: requester_id.clone(),
+                        name: requester_name.clone(),
+                        note: note.clone(),
+                        delay_seconds: *delay_seconds,
+                    });
+                    let confirmation = reminder_confirmation(*delay_seconds, note);
+                    completed_tools
+                        .push((tool_call, ToolResultData::text(confirmation.clone(), confirmation)));
+                    continue;
+                }
+
                 let expected_file_hash = match &tool_call.tool_type {
                     ToolType::EditFile { path, .. } => {
                         latest_file_hash(&history, path).map(str::to_string)
@@ -206,19 +235,35 @@ fn apply_post_send(
                 pending_tools.insert(tool_call.id.clone(), tool_call);
             }
 
-            Ok(Conversation {
-                state: ConversationState::RunningTools {
+            if pending_tools.is_empty() {
+                // Nothing real to await (reminders only) — the round is already done.
+                finish_tool_round(
+                    env,
+                    conversation_id,
                     recent_conversation,
-                    tool_rounds: tool_rounds + 1,
-                    pending_tools,
-                    completed_tools: Vec::new(),
-                },
-                last_transition: Utc::now(),
-                pending,
-                is_group,
-                bot_identity,
-                compaction_in_flight,
-            })
+                    tool_rounds + 1,
+                    completed_tools,
+                    pending,
+                    is_group,
+                    bot_identity,
+                    compaction_in_flight,
+                    effects,
+                )
+            } else {
+                Ok(Conversation {
+                    state: ConversationState::RunningTools {
+                        recent_conversation,
+                        tool_rounds: tool_rounds + 1,
+                        pending_tools,
+                        completed_tools,
+                    },
+                    last_transition: Utc::now(),
+                    pending,
+                    is_group,
+                    bot_identity,
+                    compaction_in_flight,
+                })
+            }
         }
         PostSend::SendToolResponse {
             tool_rounds,
@@ -274,13 +319,36 @@ fn conversation_transition(
         ) => {
             let mut pending = conversation.pending;
             let queued = !matches!(&user_state, ConversationState::Idle { .. });
-            pending.push(ConversationMessage {
+            pending.push(Pending::Message(ConversationMessage {
                 text: msg.clone(),
                 queued,
                 user_id: user_id.clone(),
                 name: name.clone(),
                 attachments: attachments.iter().map(Attachment::downscaled).collect(),
-            });
+            }));
+
+            Ok(Conversation {
+                pending,
+                state: user_state,
+                ..conversation
+            })
+        }
+        (
+            user_state,
+            ConversationAction::ReminderFired {
+                note,
+                user_id,
+                name,
+            },
+        ) => {
+            // Enters the pending queue exactly like a user message; drained into an
+            // LLMInput::SystemMessage when the machine next reaches Idle.
+            let mut pending = conversation.pending;
+            pending.push(Pending::System(SystemMessage {
+                note: note.clone(),
+                user_id: user_id.clone(),
+                name: name.clone(),
+            }));
 
             Ok(Conversation {
                 pending,
@@ -396,30 +464,13 @@ fn conversation_transition(
             }
 
             if pending_tools.is_empty() {
-                completed_tools.sort_by(|(a, _), (b, _)| a.id.cmp(&b.id));
-
-                let results = completed_tools
-                    .into_iter()
-                    .map(|(call, data)| ToolResult { call, data })
-                    .collect();
-
-                let mut pending = conversation.pending;
-                let followup = take_pending(&mut pending);
-
-                send_then(
+                finish_tool_round(
                     env,
                     conversation_id,
-                    OutboundMessage {
-                        message: None,
-                        tool_names: Vec::new(),
-                    },
-                    PostSend::SendToolResponse {
-                        tool_rounds,
-                        results,
-                        followup,
-                    },
                     recent_conversation,
-                    pending,
+                    tool_rounds,
+                    completed_tools,
+                    conversation.pending,
                     conversation.is_group,
                     conversation.bot_identity.clone(),
                     conversation.compaction_in_flight,
@@ -459,29 +510,148 @@ fn conversation_transition(
     post_transition(env, conversation_id, state, effects)
 }
 
-fn take_pending(pending: &mut Vec<ConversationMessage>) -> Option<ConversationMessage> {
-    (!pending.is_empty()).then(|| {
-        let drained = std::mem::take(pending);
-        let queued = drained.iter().any(|m| m.queued);
-        let user_id = drained
-            .last()
-            .map(|m| m.user_id.clone())
-            .unwrap_or_default();
-        let name = drained.last().map(|m| m.name.clone()).unwrap_or_default();
-        let attachments = drained.iter().flat_map(|m| m.attachments.clone()).collect();
-        let text = drained
-            .into_iter()
-            .map(|m| m.text)
-            .collect::<Vec<_>>()
-            .join("\n");
-        ConversationMessage {
-            text,
-            queued,
-            user_id,
-            name,
-            attachments,
+/// Drain the whole pending queue in arrival order into a single turn, the same
+/// way user messages have always been merged. A batch of only reminders stays a
+/// `System` turn (the common case — a reminder firing while Idle drains alone);
+/// any other batch merges into one `Message`, folding reminder notes in as their
+/// already-tagged, high-importance text.
+fn take_pending(pending: &mut Vec<Pending>) -> Option<Pending> {
+    if pending.is_empty() {
+        return None;
+    }
+    let drained = std::mem::take(pending);
+
+    if drained.iter().all(|p| matches!(p, Pending::System(_))) {
+        let mut merged: Option<SystemMessage> = None;
+        for p in drained {
+            let Pending::System(s) = p else { continue };
+            merged = Some(match merged {
+                None => s,
+                Some(mut acc) => {
+                    acc.note.push('\n');
+                    acc.note.push_str(&s.note);
+                    acc.user_id = s.user_id;
+                    acc.name = s.name;
+                    acc
+                }
+            });
         }
-    })
+        return merged.map(Pending::System);
+    }
+
+    let queued = drained
+        .iter()
+        .any(|p| matches!(p, Pending::Message(m) if m.queued));
+    let (user_id, name) = drained
+        .iter()
+        .rev()
+        .find_map(|p| match p {
+            Pending::Message(m) => Some((m.user_id.clone(), m.name.clone())),
+            Pending::System(_) => None,
+        })
+        .unwrap_or_default();
+    let attachments = drained
+        .iter()
+        .filter_map(|p| match p {
+            Pending::Message(m) => Some(m.attachments.clone()),
+            Pending::System(_) => None,
+        })
+        .flatten()
+        .collect();
+    let text = drained
+        .into_iter()
+        .map(|p| match p {
+            Pending::Message(m) => m.text,
+            Pending::System(s) => s.to_content(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(Pending::Message(ConversationMessage {
+        text,
+        queued,
+        user_id,
+        name,
+        attachments,
+    }))
+}
+
+/// Identity of whoever's input drove this turn — used to name the target user on
+/// a reminder set during it. Falls back through history for a tool-result turn.
+fn input_identity(input: &LLMInput) -> Option<(String, String)> {
+    match input {
+        LLMInput::ConversationMessage(m) => Some((m.user_id.clone(), m.name.clone())),
+        LLMInput::SystemMessage(s) => Some((s.user_id.clone(), s.name.clone())),
+        LLMInput::ToolResults(_, followup) => {
+            followup.as_ref().map(|m| (m.user_id.clone(), m.name.clone()))
+        }
+    }
+}
+
+fn requester_identity(recent: &RecentConversation) -> (String, String) {
+    recent
+        .history()
+        .iter()
+        .rev()
+        .find_map(|entry| match &entry.kind {
+            HistoryEntryKind::Input(input) => input_identity(input),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// Approximate confirmation handed back to the model as the reminder tool's
+/// (synthetic) result, so it can tell the user it's set.
+fn reminder_confirmation(delay_seconds: i64, note: &str) -> String {
+    let fire_at = Utc::now() + ChronoDuration::seconds(delay_seconds);
+    format!(
+        "Reminder set — fires in {delay_seconds}s (~{}). Note: \"{note}\". Tell the user you've set it; \
+         you'll be prompted automatically when it fires. Reminders do not survive a bot restart.",
+        fire_at.format("%Y-%m-%d %H:%M:%S UTC")
+    )
+}
+
+/// Complete a tool round: order the results, drain any late-arriving input as the
+/// followup, and hand the batch back to the model. Shared by the normal
+/// all-tools-returned path and the reminders-only immediate-completion path.
+#[allow(clippy::too_many_arguments)]
+fn finish_tool_round(
+    env: &Arc<Env>,
+    conversation_id: &ConversationId,
+    recent_conversation: RecentConversation,
+    tool_rounds: usize,
+    mut completed_tools: Vec<(ToolCall, ToolResultData)>,
+    mut pending: Vec<Pending>,
+    is_group: bool,
+    bot_identity: String,
+    compaction_in_flight: bool,
+    effects: &mut ConversationEffects,
+) -> ConversationTransitionResult {
+    completed_tools.sort_by(|(a, _), (b, _)| a.id.cmp(&b.id));
+    let results = completed_tools
+        .into_iter()
+        .map(|(call, data)| ToolResult { call, data })
+        .collect();
+    let followup = take_pending(&mut pending).map(Pending::into_message);
+
+    send_then(
+        env,
+        conversation_id,
+        OutboundMessage {
+            message: None,
+            tool_names: Vec::new(),
+        },
+        PostSend::SendToolResponse {
+            tool_rounds,
+            results,
+            followup,
+        },
+        recent_conversation,
+        pending,
+        is_group,
+        bot_identity,
+        compaction_in_flight,
+        effects,
+    )
 }
 
 fn post_transition(
@@ -499,7 +669,7 @@ fn post_transition(
         _ => return Ok(conversation),
     };
 
-    let Some(msg) = take_pending(&mut conversation.pending) else {
+    let Some(drained) = take_pending(&mut conversation.pending) else {
         maybe_fire_compaction(env, conversation_id, &mut conversation, &recent_conversation, effects);
         return Ok(conversation);
     };
@@ -510,7 +680,7 @@ fn post_transition(
 
     let history = recent_conversation.history();
 
-    let current_input = LLMInput::ConversationMessage(msg);
+    let current_input = drained.into_llm_input();
 
     effects.enqueue_external(get_llm_decision(
         Arc::clone(env),

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -195,22 +195,16 @@ fn apply_post_send(
             tool_calls,
         } => {
             let history = recent_conversation.history();
-            // A reminder is dispatched here, not via execute_tool: creating the
-            // entity needs Effects. It resolves immediately with a synthetic
-            // confirmation so the round can complete and the bot can tell the user.
             let (requester_id, requester_name) = requester_identity(&recent_conversation);
             let mut pending_tools = HashMap::new();
             let mut completed_tools: Vec<(ToolCall, ToolResultData)> = Vec::new();
             for tool_call in tool_calls {
-                // Runtime-dispatched tools (currently only set_reminder) are
-                // handled here — they need Effects and never go to execute_tool.
                 if matches!(tool_call.tool_type.dispatch(), ToolDispatch::Runtime) {
                     let ToolType::SetReminder {
                         delay_seconds,
                         note,
                     } = &tool_call.tool_type
                     else {
-                        // dispatch() only routes SetReminder here today.
                         continue;
                     };
                     let result = match validate_delay(*delay_seconds) {
@@ -250,7 +244,6 @@ fn apply_post_send(
             }
 
             if pending_tools.is_empty() {
-                // Nothing real to await (reminders only) — the round is already done.
                 finish_tool_round(
                     env,
                     conversation_id,
@@ -355,8 +348,6 @@ fn conversation_transition(
                 name,
             },
         ) => {
-            // Enters the pending queue exactly like a user message; drained into an
-            // LLMInput::SystemMessage when the machine next reaches Idle.
             let mut pending = conversation.pending;
             pending.push(Pending::System(SystemMessage {
                 note: note.clone(),
@@ -524,19 +515,12 @@ fn conversation_transition(
     post_transition(env, conversation_id, state, effects)
 }
 
-/// Drain the whole pending queue in arrival order into a single turn, the same
-/// way user messages have always been merged. A batch of only reminders stays a
-/// `System` turn (the common case — a reminder firing while Idle drains alone);
-/// any other batch merges into one `Message`, folding reminder notes in as their
-/// already-tagged, high-importance text.
 fn take_pending(pending: &mut Vec<Pending>) -> Option<LLMInput> {
     if pending.is_empty() {
         return None;
     }
     let drained = std::mem::take(pending);
 
-    // A pure-reminder batch stays a system turn, each reminder rendered
-    // individually (preserving per-reminder identity in a group chat).
     if drained.iter().all(|p| matches!(p, Pending::System(_))) {
         let batch = drained
             .into_iter()
@@ -548,9 +532,6 @@ fn take_pending(pending: &mut Vec<Pending>) -> Option<LLMInput> {
         return Some(LLMInput::SystemMessage(batch));
     }
 
-    // Mixed / user batch: merge into one user turn as before. Any reminder in the
-    // batch contributes its already-tagged content (which includes "For {name}"),
-    // so identity survives the merge here too.
     let queued = drained
         .iter()
         .any(|p| matches!(p, Pending::Message(m) if m.queued));
@@ -587,13 +568,6 @@ fn take_pending(pending: &mut Vec<Pending>) -> Option<LLMInput> {
     }))
 }
 
-/// Flatten a drained input into the tool-round followup slot, which bundles
-/// late-arriving input with tool results as `Option<ConversationMessage>`.
-///
-/// NOTE: this is the one place a fired reminder does *not* stay a system turn — a
-/// reminder that lands while tools are running is rendered as a user turn here.
-/// Per-reminder identity is still preserved (it's carried in the tagged text),
-/// but the representation diverges from the Idle-drain path. See #210 followup.
 fn followup_message(input: LLMInput) -> Option<ConversationMessage> {
     match input {
         LLMInput::ConversationMessage(m) => Some(m),
@@ -608,13 +582,10 @@ fn followup_message(input: LLMInput) -> Option<ConversationMessage> {
             name: String::new(),
             attachments: Vec::new(),
         }),
-        // take_pending never yields ToolResults (they don't queue).
         LLMInput::ToolResults(..) => None,
     }
 }
 
-/// Identity of whoever's input drove this turn — used to name the target user on
-/// a reminder set during it. Falls back through history for a tool-result turn.
 fn input_identity(input: &LLMInput) -> Option<(String, String)> {
     match input {
         LLMInput::ConversationMessage(m) => Some((m.user_id.clone(), m.name.clone())),
@@ -639,9 +610,6 @@ fn requester_identity(recent: &RecentConversation) -> (String, String) {
         .unwrap_or_default()
 }
 
-/// Validate a model-supplied delay before scheduling. Returns the computed
-/// `fire_at`, or an error string handed back as the tool result. Bounding the
-/// range keeps the chrono arithmetic (here and in the entity) from overflow.
 fn validate_delay(delay_seconds: i64) -> Result<DateTime<Utc>, String> {
     if delay_seconds <= 0 {
         return Err(format!(
@@ -658,8 +626,6 @@ fn validate_delay(delay_seconds: i64) -> Result<DateTime<Utc>, String> {
         .ok_or_else(|| "Reminder not set: the requested time overflows.".to_string())
 }
 
-/// Confirmation handed back to the model as the reminder tool's (synthetic)
-/// result, so it can tell the user it's set.
 fn reminder_confirmation(fire_at: DateTime<Utc>, note: &str) -> String {
     format!(
         "Reminder set — fires around {}. Note: \"{note}\". Tell the user you've set it; you'll be \
@@ -668,9 +634,6 @@ fn reminder_confirmation(fire_at: DateTime<Utc>, note: &str) -> String {
     )
 }
 
-/// Complete a tool round: order the results, drain any late-arriving input as the
-/// followup, and hand the batch back to the model. Shared by the normal
-/// all-tools-returned path and the reminders-only immediate-completion path.
 #[allow(clippy::too_many_arguments)]
 fn finish_tool_round(
     env: &Arc<Env>,
@@ -899,13 +862,11 @@ mod tests {
         assert!(validate_delay(-3600).is_err());
         assert!(validate_delay(MAX_REMINDER_SECS + 1).is_err());
         assert!(validate_delay(3600).is_ok());
-        // A value that would overflow chrono is rejected, not panicked.
         assert!(validate_delay(i64::MAX).is_err());
     }
 
     #[test]
     fn take_pending_preserves_per_reminder_identity() {
-        // Two reminders firing together must not be attributed to one user.
         let mut pending = vec![system("Alice", "take meds"), system("Bob", "call mom")];
         let input = take_pending(&mut pending).expect("drains a batch");
         let LLMInput::SystemMessage(batch) = &input else {

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -4,8 +4,8 @@ use crate::externals::{
     tool_call_external::execute_tool,
 };
 use crate::types::conversation::{
-    latest_file_hash, Pending, SystemMessage, ToolCall, ToolDispatch, ToolResult, ToolResultData,
-    ToolType, MAX_TOOL_ROUNDS,
+    latest_file_hash, Pending, SystemMessage, ToolDispatch, ToolResult, ToolResultData, ToolType,
+    MAX_TOOL_ROUNDS,
 };
 use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
 use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
@@ -195,19 +195,18 @@ fn apply_post_send(
             tool_calls,
         } => {
             let history = recent_conversation.history();
-            let (requester_id, requester_name) = requester_identity(&recent_conversation);
             let mut pending_tools = HashMap::new();
-            let mut completed_tools: Vec<(ToolCall, ToolResultData)> = Vec::new();
             for tool_call in tool_calls {
                 if matches!(tool_call.tool_type.dispatch(), ToolDispatch::Runtime) {
                     let ToolType::SetReminder {
                         delay_seconds,
                         note,
+                        addressee,
                     } = &tool_call.tool_type
                     else {
                         continue;
                     };
-                    let result = match validate_delay(*delay_seconds) {
+                    let text = match validate_delay(*delay_seconds) {
                         Ok(fire_at) => {
                             effects.enqueue_construct::<ReminderForConversationMachine>(
                                 ReminderConstructor {
@@ -215,8 +214,7 @@ fn apply_post_send(
                                         conversation_id: conversation_id.clone(),
                                         reminder_id: ReminderId::new(),
                                     },
-                                    user_id: requester_id.clone(),
-                                    name: requester_name.clone(),
+                                    addressee: addressee.clone(),
                                     note: note.clone(),
                                     delay_seconds: *delay_seconds,
                                 },
@@ -225,7 +223,14 @@ fn apply_post_send(
                         }
                         Err(msg) => msg,
                     };
-                    completed_tools.push((tool_call, ToolResultData::text(result.clone(), result)));
+                    effects.enqueue_action::<ConversationMachine>(
+                        conversation_id.clone(),
+                        ConversationAction::ToolResult {
+                            id: tool_call.id.clone(),
+                            result: Ok(ToolResultData::text(text.clone(), text)),
+                        },
+                    );
+                    pending_tools.insert(tool_call.id.clone(), tool_call);
                     continue;
                 }
 
@@ -243,34 +248,19 @@ fn apply_post_send(
                 pending_tools.insert(tool_call.id.clone(), tool_call);
             }
 
-            if pending_tools.is_empty() {
-                finish_tool_round(
-                    env,
-                    conversation_id,
+            Ok(Conversation {
+                state: ConversationState::RunningTools {
                     recent_conversation,
-                    tool_rounds + 1,
-                    completed_tools,
-                    pending,
-                    is_group,
-                    bot_identity,
-                    compaction_in_flight,
-                    effects,
-                )
-            } else {
-                Ok(Conversation {
-                    state: ConversationState::RunningTools {
-                        recent_conversation,
-                        tool_rounds: tool_rounds + 1,
-                        pending_tools,
-                        completed_tools,
-                    },
-                    last_transition: Utc::now(),
-                    pending,
-                    is_group,
-                    bot_identity,
-                    compaction_in_flight,
-                })
-            }
+                    tool_rounds: tool_rounds + 1,
+                    pending_tools,
+                    completed_tools: Vec::new(),
+                },
+                last_transition: Utc::now(),
+                pending,
+                is_group,
+                bot_identity,
+                compaction_in_flight,
+            })
         }
         PostSend::SendToolResponse {
             tool_rounds,
@@ -342,17 +332,12 @@ fn conversation_transition(
         }
         (
             user_state,
-            ConversationAction::ReminderFired {
-                note,
-                user_id,
-                name,
-            },
+            ConversationAction::ReminderFired { note, addressee },
         ) => {
             let mut pending = conversation.pending;
             pending.push(Pending::System(SystemMessage {
                 note: note.clone(),
-                user_id: user_id.clone(),
-                name: name.clone(),
+                addressee: addressee.clone(),
             }));
 
             Ok(Conversation {
@@ -469,13 +454,30 @@ fn conversation_transition(
             }
 
             if pending_tools.is_empty() {
-                finish_tool_round(
+                completed_tools.sort_by(|(a, _), (b, _)| a.id.cmp(&b.id));
+
+                let results = completed_tools
+                    .into_iter()
+                    .map(|(call, data)| ToolResult { call, data })
+                    .collect();
+
+                let mut pending = conversation.pending;
+                let followup = take_pending(&mut pending).and_then(followup_message);
+
+                send_then(
                     env,
                     conversation_id,
+                    OutboundMessage {
+                        message: None,
+                        tool_names: Vec::new(),
+                    },
+                    PostSend::SendToolResponse {
+                        tool_rounds,
+                        results,
+                        followup,
+                    },
                     recent_conversation,
-                    tool_rounds,
-                    completed_tools,
-                    conversation.pending,
+                    pending,
                     conversation.is_group,
                     conversation.bot_identity.clone(),
                     conversation.compaction_in_flight,
@@ -586,30 +588,6 @@ fn followup_message(input: LLMInput) -> Option<ConversationMessage> {
     }
 }
 
-fn input_identity(input: &LLMInput) -> Option<(String, String)> {
-    match input {
-        LLMInput::ConversationMessage(m) => Some((m.user_id.clone(), m.name.clone())),
-        LLMInput::SystemMessage(batch) => batch
-            .last()
-            .map(|s| (s.user_id.clone(), s.name.clone())),
-        LLMInput::ToolResults(_, followup) => {
-            followup.as_ref().map(|m| (m.user_id.clone(), m.name.clone()))
-        }
-    }
-}
-
-fn requester_identity(recent: &RecentConversation) -> (String, String) {
-    recent
-        .history()
-        .iter()
-        .rev()
-        .find_map(|entry| match &entry.kind {
-            HistoryEntryKind::Input(input) => input_identity(input),
-            _ => None,
-        })
-        .unwrap_or_default()
-}
-
 fn validate_delay(delay_seconds: i64) -> Result<DateTime<Utc>, String> {
     if delay_seconds <= 0 {
         return Err(format!(
@@ -631,47 +609,6 @@ fn reminder_confirmation(fire_at: DateTime<Utc>, note: &str) -> String {
         "Reminder set — fires around {}. Note: \"{note}\". Tell the user you've set it; you'll be \
          prompted automatically when it fires. (Reminders are lost on a redeploy.)",
         fire_at.format("%Y-%m-%d %H:%M:%S UTC")
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn finish_tool_round(
-    env: &Arc<Env>,
-    conversation_id: &ConversationId,
-    recent_conversation: RecentConversation,
-    tool_rounds: usize,
-    mut completed_tools: Vec<(ToolCall, ToolResultData)>,
-    mut pending: Vec<Pending>,
-    is_group: bool,
-    bot_identity: String,
-    compaction_in_flight: bool,
-    effects: &mut ConversationEffects,
-) -> ConversationTransitionResult {
-    completed_tools.sort_by(|(a, _), (b, _)| a.id.cmp(&b.id));
-    let results = completed_tools
-        .into_iter()
-        .map(|(call, data)| ToolResult { call, data })
-        .collect();
-    let followup = take_pending(&mut pending).and_then(followup_message);
-
-    send_then(
-        env,
-        conversation_id,
-        OutboundMessage {
-            message: None,
-            tool_names: Vec::new(),
-        },
-        PostSend::SendToolResponse {
-            tool_rounds,
-            results,
-            followup,
-        },
-        recent_conversation,
-        pending,
-        is_group,
-        bot_identity,
-        compaction_in_flight,
-        effects,
     )
 }
 
@@ -838,11 +775,10 @@ mod tests {
     use super::*;
     use crate::types::conversation::SystemMessage;
 
-    fn system(name: &str, note: &str) -> Pending {
+    fn system(addressee: &str, note: &str) -> Pending {
         Pending::System(SystemMessage {
             note: note.to_string(),
-            user_id: format!("id_{name}"),
-            name: name.to_string(),
+            addressee: addressee.to_string(),
         })
     }
 

--- a/chatbot/src/state_machines/reminder_state_machine.rs
+++ b/chatbot/src/state_machines/reminder_state_machine.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use re_framework::{Effects, Scheduled, StateMachine};
+
+use crate::state_machines::conversation_state_machine::ConversationMachine;
+use crate::types::conversation::ConversationAction;
+use crate::types::reminder::{
+    ReminderAction, ReminderConstructor, ReminderForConversation, ReminderState,
+};
+use crate::Env;
+
+/// A one-shot durable timer scoped to a conversation. Set by the `set_reminder`
+/// tool, it schedules a single `Fire` at `fire_at`; when that fires it delivers a
+/// system message back into the conversation and moves to a terminal `Fired`
+/// state. Modeled on `MemoryManagerMachine`.
+pub struct ReminderForConversationMachine;
+
+impl StateMachine for ReminderForConversationMachine {
+    type State = ReminderForConversation;
+    type Id = crate::types::reminder::ReminderForConversationId;
+    type Action = ReminderAction;
+    type Construction = ReminderConstructor;
+    type Env = crate::Env;
+
+    fn construct(
+        constructor: ReminderConstructor,
+        _effects: &mut Effects<Self>,
+    ) -> ReminderForConversation {
+        let created_on = Utc::now();
+        let fire_at = created_on + ChronoDuration::seconds(constructor.delay_seconds);
+        ReminderForConversation {
+            state: ReminderState::Pending,
+            conversation_id: constructor.id.conversation_id,
+            user_id: constructor.user_id,
+            name: constructor.name,
+            note: constructor.note,
+            created_on,
+            fire_at,
+        }
+    }
+
+    fn transition(
+        state: &ReminderForConversation,
+        _id: &Self::Id,
+        _env: &Arc<Env>,
+        action: &ReminderAction,
+        effects: &mut Effects<Self>,
+    ) -> anyhow::Result<ReminderForConversation> {
+        let next_state = match (&state.state, action) {
+            (ReminderState::Pending, ReminderAction::Fire) => {
+                effects.enqueue_action::<ConversationMachine>(
+                    state.conversation_id.clone(),
+                    ConversationAction::ReminderFired {
+                        note: state.note.clone(),
+                        user_id: state.user_id.clone(),
+                        name: state.name.clone(),
+                    },
+                );
+                ReminderState::Fired
+            }
+            _ => return Err(anyhow::anyhow!("no transition for {action:?} in reminder")),
+        };
+
+        Ok(ReminderForConversation {
+            state: next_state,
+            ..state.clone()
+        })
+    }
+
+    fn schedule(state: &ReminderForConversation) -> Option<Scheduled<ReminderAction>> {
+        match &state.state {
+            ReminderState::Pending => Some(Scheduled {
+                at: state.fire_at,
+                action: ReminderAction::Fire,
+            }),
+            ReminderState::Fired => None,
+        }
+    }
+
+    fn name() -> &'static str {
+        "ReminderForConversationMachine"
+    }
+}

--- a/chatbot/src/state_machines/reminder_state_machine.rs
+++ b/chatbot/src/state_machines/reminder_state_machine.rs
@@ -6,7 +6,7 @@ use re_framework::{Effects, Scheduled, StateMachine};
 use crate::state_machines::conversation_state_machine::ConversationMachine;
 use crate::types::conversation::ConversationAction;
 use crate::types::reminder::{
-    ReminderAction, ReminderConstructor, ReminderForConversation, ReminderState,
+    ReminderAction, ReminderConstructor, ReminderForConversation, ReminderState, MAX_REMINDER_SECS,
 };
 use crate::Env;
 
@@ -28,7 +28,12 @@ impl StateMachine for ReminderForConversationMachine {
         _effects: &mut Effects<Self>,
     ) -> ReminderForConversation {
         let created_on = Utc::now();
-        let fire_at = created_on + ChronoDuration::seconds(constructor.delay_seconds);
+        // Defensive: dispatch already validates the range, but clamp here too so
+        // constructing the Duration / adding it can never overflow-panic.
+        let delay = constructor.delay_seconds.clamp(0, MAX_REMINDER_SECS);
+        let fire_at = created_on
+            .checked_add_signed(ChronoDuration::seconds(delay))
+            .unwrap_or(created_on);
         ReminderForConversation {
             state: ReminderState::Pending,
             conversation_id: constructor.id.conversation_id,

--- a/chatbot/src/state_machines/reminder_state_machine.rs
+++ b/chatbot/src/state_machines/reminder_state_machine.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
-use chrono::{Duration as ChronoDuration, Utc};
+use chrono::Utc;
 use re_framework::{Effects, Scheduled, StateMachine};
 
 use crate::state_machines::conversation_state_machine::ConversationMachine;
 use crate::types::conversation::ConversationAction;
 use crate::types::reminder::{
-    ReminderAction, ReminderConstructor, ReminderForConversation, ReminderState, MAX_REMINDER_SECS,
+    ReminderAction, ReminderConstructor, ReminderForConversation, ReminderForConversationId,
+    ReminderState,
 };
 use crate::Env;
 
@@ -14,7 +15,7 @@ pub struct ReminderForConversationMachine;
 
 impl StateMachine for ReminderForConversationMachine {
     type State = ReminderForConversation;
-    type Id = crate::types::reminder::ReminderForConversationId;
+    type Id = ReminderForConversationId;
     type Action = ReminderAction;
     type Construction = ReminderConstructor;
     type Env = crate::Env;
@@ -23,18 +24,13 @@ impl StateMachine for ReminderForConversationMachine {
         constructor: ReminderConstructor,
         _effects: &mut Effects<Self>,
     ) -> ReminderForConversation {
-        let created_on = Utc::now();
-        let delay = constructor.delay_seconds.clamp(0, MAX_REMINDER_SECS);
-        let fire_at = created_on
-            .checked_add_signed(ChronoDuration::seconds(delay))
-            .unwrap_or(created_on);
         ReminderForConversation {
             state: ReminderState::Pending,
             conversation_id: constructor.id.conversation_id,
             addressee: constructor.addressee,
             note: constructor.note,
-            created_on,
-            fire_at,
+            created_on: Utc::now(),
+            fire_at: constructor.fire_at,
         }
     }
 

--- a/chatbot/src/state_machines/reminder_state_machine.rs
+++ b/chatbot/src/state_machines/reminder_state_machine.rs
@@ -31,8 +31,7 @@ impl StateMachine for ReminderForConversationMachine {
         ReminderForConversation {
             state: ReminderState::Pending,
             conversation_id: constructor.id.conversation_id,
-            user_id: constructor.user_id,
-            name: constructor.name,
+            addressee: constructor.addressee,
             note: constructor.note,
             created_on,
             fire_at,
@@ -52,8 +51,7 @@ impl StateMachine for ReminderForConversationMachine {
                     state.conversation_id.clone(),
                     ConversationAction::ReminderFired {
                         note: state.note.clone(),
-                        user_id: state.user_id.clone(),
-                        name: state.name.clone(),
+                        addressee: state.addressee.clone(),
                     },
                 );
                 ReminderState::Fired

--- a/chatbot/src/state_machines/reminder_state_machine.rs
+++ b/chatbot/src/state_machines/reminder_state_machine.rs
@@ -10,10 +10,6 @@ use crate::types::reminder::{
 };
 use crate::Env;
 
-/// A one-shot durable timer scoped to a conversation. Set by the `set_reminder`
-/// tool, it schedules a single `Fire` at `fire_at`; when that fires it delivers a
-/// system message back into the conversation and moves to a terminal `Fired`
-/// state. Modeled on `MemoryManagerMachine`.
 pub struct ReminderForConversationMachine;
 
 impl StateMachine for ReminderForConversationMachine {
@@ -28,8 +24,6 @@ impl StateMachine for ReminderForConversationMachine {
         _effects: &mut Effects<Self>,
     ) -> ReminderForConversation {
         let created_on = Utc::now();
-        // Defensive: dispatch already validates the range, but clamp here too so
-        // constructing the Duration / adding it can never overflow-panic.
         let delay = constructor.delay_seconds.clamp(0, MAX_REMINDER_SECS);
         let fire_at = created_on
             .checked_add_signed(ChronoDuration::seconds(delay))

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -61,6 +61,32 @@ struct EditFileArgs {
     new_string: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct SetReminderArgs {
+    #[serde(deserialize_with = "de_lenient_i64")]
+    delay_seconds: i64,
+    note: String,
+}
+
+fn de_lenient_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumOrStr {
+        Num(i64),
+        Str(String),
+    }
+    match NumOrStr::deserialize(deserializer)? {
+        NumOrStr::Num(n) => Ok(n),
+        NumOrStr::Str(s) => s
+            .trim()
+            .parse::<i64>()
+            .map_err(serde::de::Error::custom),
+    }
+}
+
 fn parse_args<T: serde::de::DeserializeOwned>(name: &str, arguments: &str) -> anyhow::Result<T> {
     serde_json::from_str(arguments)
         .map_err(|e| anyhow::anyhow!("{name} arguments failed to bind: {e} — raw: {arguments}"))
@@ -76,6 +102,7 @@ impl ToolKind {
             ToolKind::ViewImage => "view_image",
             ToolKind::ReadFile => "read_file",
             ToolKind::EditFile => "edit_file",
+            ToolKind::SetReminder => "set_reminder",
             ToolKind::MetaNoOpExtraTurn => "meta_no_op_extra_turn",
         }
     }
@@ -157,6 +184,17 @@ impl ToolKind {
                     "required": ["path", "old_string", "new_string"]
                 }),
             ),
+            ToolKind::SetReminder => (
+                "Set a reminder to message the user in the future. When the delay elapses, the conversation wakes on its own and you are prompted to send the reminder — so you do NOT keep this turn open waiting; call it, tell the user you've set it, and finish. Compute delay_seconds yourself from the current time in the metadata footer. Note: reminders do not currently survive a bot restart.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "delay_seconds": { "type": "integer", "description": "How far in the future to fire, in seconds from now, e.g. 7200 for two hours. Compute it from the current time shown in the footer." },
+                        "note": { "type": "string", "description": "What to remind the user about, in your own words — this is handed back to you when the reminder fires, e.g. \"take your meds\" or \"the meeting with Alex starts in 10 minutes\"." }
+                    },
+                    "required": ["delay_seconds", "note"]
+                }),
+            ),
             ToolKind::MetaNoOpExtraTurn => (
                 "Give yourself another turn after this reply — use it to say something to the user across multiple steps. Put the first part in this reply's message, call this tool, and you'll be prompted again to continue with the next part. Pointless to call with no message (nothing is sent to the user), and pointless to call alongside other tools (a tool call already earns you another turn).",
                 json!({ "type": "object", "properties": {}, "required": [] }),
@@ -222,6 +260,15 @@ impl ToolType {
             ]
             .into_iter()
             .collect(),
+            ToolType::SetReminder {
+                delay_seconds,
+                note,
+            } => [
+                ("delay_seconds".to_string(), json!(delay_seconds)),
+                ("note".to_string(), json!(note)),
+            ]
+            .into_iter()
+            .collect(),
             ToolType::MetaNoOpExtraTurn => Map::new(),
         }
     }
@@ -261,6 +308,13 @@ impl ToolType {
                     new_string: args.new_string,
                 })
             }
+            ToolKind::SetReminder => {
+                let args = parse_args::<SetReminderArgs>(name, arguments)?;
+                Ok(ToolType::SetReminder {
+                    delay_seconds: args.delay_seconds,
+                    note: args.note,
+                })
+            }
             ToolKind::MetaNoOpExtraTurn => Ok(ToolType::MetaNoOpExtraTurn),
         }
     }
@@ -295,6 +349,24 @@ mod tests {
         assert!(matches!(
             absent,
             ToolType::ReadFile { offset: None, limit: None, .. }
+        ));
+    }
+
+    #[test]
+    fn set_reminder_accepts_numeric_and_stringified_delay() {
+        let numeric =
+            ToolType::bind("set_reminder", r#"{"delay_seconds":7200,"note":"take meds"}"#).unwrap();
+        assert!(matches!(
+            numeric,
+            ToolType::SetReminder { delay_seconds: 7200, .. }
+        ));
+
+        let stringified =
+            ToolType::bind("set_reminder", r#"{"delay_seconds":"7200","note":"take meds"}"#)
+                .unwrap();
+        assert!(matches!(
+            stringified,
+            ToolType::SetReminder { delay_seconds: 7200, .. }
         ));
     }
 }

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -34,8 +34,6 @@ struct ReadFileArgs {
     limit: Option<usize>,
 }
 
-/// Models routinely stringify numbers ("60" instead of 60). Accept either a
-/// native number or a numeric string for a required field.
 fn de_lenient_number<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -54,8 +52,6 @@ where
     }
 }
 
-/// Optional variant of [`de_lenient_number`]; an absent field or empty string
-/// becomes `None`.
 fn de_lenient_opt_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -34,6 +34,28 @@ struct ReadFileArgs {
     limit: Option<usize>,
 }
 
+/// Models routinely stringify numbers ("60" instead of 60). Accept either a
+/// native number or a numeric string for a required field.
+fn de_lenient_number<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de> + std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumOrStr<T> {
+        Num(T),
+        Str(String),
+    }
+    match NumOrStr::<T>::deserialize(deserializer)? {
+        NumOrStr::Num(n) => Ok(n),
+        NumOrStr::Str(s) => s.trim().parse::<T>().map_err(serde::de::Error::custom),
+    }
+}
+
+/// Optional variant of [`de_lenient_number`]; an absent field or empty string
+/// becomes `None`.
 fn de_lenient_opt_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -63,28 +85,9 @@ struct EditFileArgs {
 
 #[derive(Debug, Deserialize)]
 struct SetReminderArgs {
-    #[serde(deserialize_with = "de_lenient_i64")]
+    #[serde(deserialize_with = "de_lenient_number")]
     delay_seconds: i64,
     note: String,
-}
-
-fn de_lenient_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum NumOrStr {
-        Num(i64),
-        Str(String),
-    }
-    match NumOrStr::deserialize(deserializer)? {
-        NumOrStr::Num(n) => Ok(n),
-        NumOrStr::Str(s) => s
-            .trim()
-            .parse::<i64>()
-            .map_err(serde::de::Error::custom),
-    }
 }
 
 fn parse_args<T: serde::de::DeserializeOwned>(name: &str, arguments: &str) -> anyhow::Result<T> {
@@ -185,7 +188,7 @@ impl ToolKind {
                 }),
             ),
             ToolKind::SetReminder => (
-                "Set a reminder to message the user in the future. When the delay elapses, the conversation wakes on its own and you are prompted to send the reminder — so you do NOT keep this turn open waiting; call it, tell the user you've set it, and finish. Compute delay_seconds yourself from the current time in the metadata footer. Note: reminders do not currently survive a bot restart.",
+                "Set a reminder to message the user in the future. When the delay elapses, the conversation wakes on its own and you are prompted to send the reminder — so you do NOT keep this turn open waiting; call it, tell the user you've set it, and finish. Compute delay_seconds yourself from the current time in the metadata footer. Note: reminders are lost on a redeploy (they do survive a normal restart).",
                 json!({
                     "type": "object",
                     "properties": {

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -84,6 +84,7 @@ struct SetReminderArgs {
     #[serde(deserialize_with = "de_lenient_number")]
     delay_seconds: i64,
     note: String,
+    addressee: String,
 }
 
 fn parse_args<T: serde::de::DeserializeOwned>(name: &str, arguments: &str) -> anyhow::Result<T> {
@@ -184,14 +185,15 @@ impl ToolKind {
                 }),
             ),
             ToolKind::SetReminder => (
-                "Set a reminder to message the user in the future. When the delay elapses, the conversation wakes on its own and you are prompted to send the reminder — so you do NOT keep this turn open waiting; call it, tell the user you've set it, and finish. Compute delay_seconds yourself from the current time in the metadata footer. Note: reminders are lost on a redeploy (they do survive a normal restart).",
+                "Set a reminder to message a user in the future. When the delay elapses, the conversation wakes on its own and you are prompted to send the reminder — so you do NOT keep this turn open waiting; call it, tell the user you've set it, and finish. Compute delay_seconds yourself from the current time in the metadata footer. Note: reminders are lost on a redeploy (they do survive a normal restart).",
                 json!({
                     "type": "object",
                     "properties": {
                         "delay_seconds": { "type": "integer", "description": "How far in the future to fire, in seconds from now, e.g. 7200 for two hours. Compute it from the current time shown in the footer." },
-                        "note": { "type": "string", "description": "What to remind the user about, in your own words — this is handed back to you when the reminder fires, e.g. \"take your meds\" or \"the meeting with Alex starts in 10 minutes\"." }
+                        "note": { "type": "string", "description": "What to remind the user about, in your own words — this is handed back to you when the reminder fires, e.g. \"take your meds\" or \"the meeting with Alex starts in 10 minutes\"." },
+                        "addressee": { "type": "string", "description": "Who the reminder is for — the display name of the user it should be delivered to, as shown in the \"(id) Name:\" tag. In a one-to-one chat this is that user; in a group, whoever asked for it." }
                     },
-                    "required": ["delay_seconds", "note"]
+                    "required": ["delay_seconds", "note", "addressee"]
                 }),
             ),
             ToolKind::MetaNoOpExtraTurn => (
@@ -262,9 +264,11 @@ impl ToolType {
             ToolType::SetReminder {
                 delay_seconds,
                 note,
+                addressee,
             } => [
                 ("delay_seconds".to_string(), json!(delay_seconds)),
                 ("note".to_string(), json!(note)),
+                ("addressee".to_string(), json!(addressee)),
             ]
             .into_iter()
             .collect(),
@@ -312,6 +316,7 @@ impl ToolType {
                 Ok(ToolType::SetReminder {
                     delay_seconds: args.delay_seconds,
                     note: args.note,
+                    addressee: args.addressee,
                 })
             }
             ToolKind::MetaNoOpExtraTurn => Ok(ToolType::MetaNoOpExtraTurn),
@@ -353,16 +358,21 @@ mod tests {
 
     #[test]
     fn set_reminder_accepts_numeric_and_stringified_delay() {
-        let numeric =
-            ToolType::bind("set_reminder", r#"{"delay_seconds":7200,"note":"take meds"}"#).unwrap();
+        let numeric = ToolType::bind(
+            "set_reminder",
+            r#"{"delay_seconds":7200,"note":"take meds","addressee":"Alice"}"#,
+        )
+        .unwrap();
         assert!(matches!(
             numeric,
             ToolType::SetReminder { delay_seconds: 7200, .. }
         ));
 
-        let stringified =
-            ToolType::bind("set_reminder", r#"{"delay_seconds":"7200","note":"take meds"}"#)
-                .unwrap();
+        let stringified = ToolType::bind(
+            "set_reminder",
+            r#"{"delay_seconds":"7200","note":"take meds","addressee":"Alice"}"#,
+        )
+        .unwrap();
         assert!(matches!(
             stringified,
             ToolType::SetReminder { delay_seconds: 7200, .. }

--- a/chatbot/src/types.rs
+++ b/chatbot/src/types.rs
@@ -1,3 +1,4 @@
 pub mod conversation;
 pub mod media;
 pub mod memory;
+pub mod reminder;

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -146,17 +146,12 @@ pub struct ConversationMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SystemMessage {
     pub note: String,
-    pub user_id: String,
-    pub name: String,
+    pub addressee: String,
 }
 
 impl SystemMessage {
-                pub fn to_content(&self) -> String {
-        if self.name.is_empty() {
-            format!("[Reminder — IMPORTANT] {}", self.note)
-        } else {
-            format!("[Reminder — IMPORTANT] For {}: {}", self.name, self.note)
-        }
+    pub fn to_content(&self) -> String {
+        format!("[Reminder — IMPORTANT] For {}: {}", self.addressee, self.note)
     }
 }
 
@@ -341,6 +336,7 @@ pub enum ToolType {
     SetReminder {
         delay_seconds: i64,
         note: String,
+        addressee: String,
     },
     MetaNoOpExtraTurn,
 }
@@ -542,8 +538,7 @@ pub enum ConversationAction {
     CompactionResult(Result<CompactionOutput, InterruptionReason>),
     ReminderFired {
         note: String,
-        user_id: String,
-        name: String,
+        addressee: String,
     },
 }
 

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -341,20 +341,7 @@ pub enum ToolType {
     MetaNoOpExtraTurn,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ToolDispatch {
-    Executor,
-    Runtime,
-}
-
 impl ToolType {
-    pub fn dispatch(&self) -> ToolDispatch {
-        match self {
-            ToolType::SetReminder { .. } => ToolDispatch::Runtime,
-            _ => ToolDispatch::Executor,
-        }
-    }
-
     pub fn rescue_timeout(&self) -> Duration {
         let ms = match self {
             ToolType::RunBashCommand { .. } => 300_000,

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -143,10 +143,6 @@ pub struct ConversationMessage {
     pub attachments: Vec<Attachment>,
 }
 
-/// A non-user input into the conversation — currently only a fired reminder.
-/// Kept separate from `ConversationMessage` so history/summarize can treat it
-/// distinctly and the model does not "reply to" a fake user. Carries the target
-/// user's identity so a reminder that fires in a group chat names who it is for.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SystemMessage {
     pub note: String,
@@ -155,10 +151,7 @@ pub struct SystemMessage {
 }
 
 impl SystemMessage {
-    /// Rendered as a tagged, high-importance turn addressed to the user. Falls
-    /// back to an unaddressed form when the requester's name is unknown (e.g. a
-    /// reminder set on a tool-result turn whose user message was compacted away).
-    pub fn to_content(&self) -> String {
+                pub fn to_content(&self) -> String {
         if self.name.is_empty() {
             format!("[Reminder — IMPORTANT] {}", self.note)
         } else {
@@ -234,9 +227,6 @@ impl ConversationMessage {
     }
 }
 
-/// A queued input awaiting drain into an `LLMInput`. Tool results never queue
-/// (they enter via `PostSend::SendToolResponse`, not `pending`), so the queue
-/// only ever holds message-like inputs — `LLMInput` minus `ToolResults`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Pending {
     Message(ConversationMessage),
@@ -258,10 +248,7 @@ pub struct Conversation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
     ConversationMessage(ConversationMessage),
-    /// One or more reminders that fired together (a batch drained from the
-    /// pending queue). Each is rendered individually so per-reminder identity is
-    /// preserved — merging into one would misattribute in a group chat.
-    SystemMessage(Vec<SystemMessage>),
+                SystemMessage(Vec<SystemMessage>),
     ToolResults(Vec<ToolResult>, Option<ConversationMessage>),
 }
 
@@ -358,10 +345,6 @@ pub enum ToolType {
     MetaNoOpExtraTurn,
 }
 
-/// Where a tool call is executed. Most tools run as an async external via
-/// `execute_tool`; a few need `Effects` (e.g. to spawn an entity) and are handled
-/// inside the `ConversationMachine` transition instead. Single source of truth
-/// for that split so the executor and the transition can't disagree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolDispatch {
     Executor,

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -155,9 +155,15 @@ pub struct SystemMessage {
 }
 
 impl SystemMessage {
-    /// Rendered as a tagged, high-importance turn addressed to the user.
+    /// Rendered as a tagged, high-importance turn addressed to the user. Falls
+    /// back to an unaddressed form when the requester's name is unknown (e.g. a
+    /// reminder set on a tool-result turn whose user message was compacted away).
     pub fn to_content(&self) -> String {
-        format!("[Reminder — IMPORTANT] For {}: {}", self.name, self.note)
+        if self.name.is_empty() {
+            format!("[Reminder — IMPORTANT] {}", self.note)
+        } else {
+            format!("[Reminder — IMPORTANT] For {}: {}", self.name, self.note)
+        }
     }
 }
 
@@ -237,30 +243,6 @@ pub enum Pending {
     System(SystemMessage),
 }
 
-impl Pending {
-    pub fn into_llm_input(self) -> LLMInput {
-        match self {
-            Pending::Message(m) => LLMInput::ConversationMessage(m),
-            Pending::System(s) => LLMInput::SystemMessage(s),
-        }
-    }
-
-    /// Flatten to a `ConversationMessage` for the tool-round followup slot, which
-    /// bundles late-arriving input with tool results. A reminder contributes its
-    /// already-tagged content as the message text.
-    pub fn into_message(self) -> ConversationMessage {
-        match self {
-            Pending::Message(m) => m,
-            Pending::System(s) => ConversationMessage {
-                text: s.to_content(),
-                queued: false,
-                user_id: s.user_id,
-                name: s.name,
-                attachments: Vec::new(),
-            },
-        }
-    }
-}
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Conversation {
@@ -276,7 +258,10 @@ pub struct Conversation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
     ConversationMessage(ConversationMessage),
-    SystemMessage(SystemMessage),
+    /// One or more reminders that fired together (a batch drained from the
+    /// pending queue). Each is rendered individually so per-reminder identity is
+    /// preserved — merging into one would misattribute in a group chat.
+    SystemMessage(Vec<SystemMessage>),
     ToolResults(Vec<ToolResult>, Option<ConversationMessage>),
 }
 
@@ -284,7 +269,7 @@ impl LLMInput {
     pub fn redacted(&self) -> LLMInput {
         match self {
             LLMInput::ConversationMessage(m) => LLMInput::ConversationMessage(m.redacted()),
-            LLMInput::SystemMessage(s) => LLMInput::SystemMessage(s.clone()),
+            LLMInput::SystemMessage(batch) => LLMInput::SystemMessage(batch.clone()),
             LLMInput::ToolResults(results, user) => LLMInput::ToolResults(
                 results.clone(),
                 user.as_ref().map(ConversationMessage::redacted),
@@ -302,8 +287,13 @@ impl LLMInput {
                 let (content, bytes) = msg.content_and_media(marker);
                 (vec![ChatMessage::user(content)], bytes)
             }
-            LLMInput::SystemMessage(sys) => {
-                (vec![ChatMessage::user(sys.to_content())], Vec::new())
+            LLMInput::SystemMessage(batch) => {
+                let content = batch
+                    .iter()
+                    .map(SystemMessage::to_content)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                (vec![ChatMessage::user(content)], Vec::new())
             }
             LLMInput::ToolResults(results, user_msg) => {
                 let mut messages: Vec<ChatMessage> = Vec::new();
@@ -368,7 +358,24 @@ pub enum ToolType {
     MetaNoOpExtraTurn,
 }
 
+/// Where a tool call is executed. Most tools run as an async external via
+/// `execute_tool`; a few need `Effects` (e.g. to spawn an entity) and are handled
+/// inside the `ConversationMachine` transition instead. Single source of truth
+/// for that split so the executor and the transition can't disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolDispatch {
+    Executor,
+    Runtime,
+}
+
 impl ToolType {
+    pub fn dispatch(&self) -> ToolDispatch {
+        match self {
+            ToolType::SetReminder { .. } => ToolDispatch::Runtime,
+            _ => ToolDispatch::Executor,
+        }
+    }
+
     pub fn rescue_timeout(&self) -> Duration {
         let ms = match self {
             ToolType::RunBashCommand { .. } => 300_000,

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -143,6 +143,24 @@ pub struct ConversationMessage {
     pub attachments: Vec<Attachment>,
 }
 
+/// A non-user input into the conversation — currently only a fired reminder.
+/// Kept separate from `ConversationMessage` so history/summarize can treat it
+/// distinctly and the model does not "reply to" a fake user. Carries the target
+/// user's identity so a reminder that fires in a group chat names who it is for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemMessage {
+    pub note: String,
+    pub user_id: String,
+    pub name: String,
+}
+
+impl SystemMessage {
+    /// Rendered as a tagged, high-importance turn addressed to the user.
+    pub fn to_content(&self) -> String {
+        format!("[Reminder — IMPORTANT] For {}: {}", self.name, self.note)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationConstructor {
     pub id: ConversationId,
@@ -210,9 +228,43 @@ impl ConversationMessage {
     }
 }
 
+/// A queued input awaiting drain into an `LLMInput`. Tool results never queue
+/// (they enter via `PostSend::SendToolResponse`, not `pending`), so the queue
+/// only ever holds message-like inputs — `LLMInput` minus `ToolResults`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Pending {
+    Message(ConversationMessage),
+    System(SystemMessage),
+}
+
+impl Pending {
+    pub fn into_llm_input(self) -> LLMInput {
+        match self {
+            Pending::Message(m) => LLMInput::ConversationMessage(m),
+            Pending::System(s) => LLMInput::SystemMessage(s),
+        }
+    }
+
+    /// Flatten to a `ConversationMessage` for the tool-round followup slot, which
+    /// bundles late-arriving input with tool results. A reminder contributes its
+    /// already-tagged content as the message text.
+    pub fn into_message(self) -> ConversationMessage {
+        match self {
+            Pending::Message(m) => m,
+            Pending::System(s) => ConversationMessage {
+                text: s.to_content(),
+                queued: false,
+                user_id: s.user_id,
+                name: s.name,
+                attachments: Vec::new(),
+            },
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Conversation {
-    pub pending: Vec<ConversationMessage>,
+    pub pending: Vec<Pending>,
     pub state: ConversationState,
     pub last_transition: DateTime<Utc>,
     pub is_group: bool,
@@ -224,6 +276,7 @@ pub struct Conversation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LLMInput {
     ConversationMessage(ConversationMessage),
+    SystemMessage(SystemMessage),
     ToolResults(Vec<ToolResult>, Option<ConversationMessage>),
 }
 
@@ -231,6 +284,7 @@ impl LLMInput {
     pub fn redacted(&self) -> LLMInput {
         match self {
             LLMInput::ConversationMessage(m) => LLMInput::ConversationMessage(m.redacted()),
+            LLMInput::SystemMessage(s) => LLMInput::SystemMessage(s.clone()),
             LLMInput::ToolResults(results, user) => LLMInput::ToolResults(
                 results.clone(),
                 user.as_ref().map(ConversationMessage::redacted),
@@ -247,6 +301,9 @@ impl LLMInput {
             LLMInput::ConversationMessage(msg) => {
                 let (content, bytes) = msg.content_and_media(marker);
                 (vec![ChatMessage::user(content)], bytes)
+            }
+            LLMInput::SystemMessage(sys) => {
+                (vec![ChatMessage::user(sys.to_content())], Vec::new())
             }
             LLMInput::ToolResults(results, user_msg) => {
                 let mut messages: Vec<ChatMessage> = Vec::new();
@@ -304,6 +361,10 @@ pub enum ToolType {
         old_string: String,
         new_string: String,
     },
+    SetReminder {
+        delay_seconds: i64,
+        note: String,
+    },
     MetaNoOpExtraTurn,
 }
 
@@ -316,6 +377,7 @@ impl ToolType {
             ToolType::ViewImage { .. }
             | ToolType::ReadFile { .. }
             | ToolType::EditFile { .. }
+            | ToolType::SetReminder { .. }
             | ToolType::MetaNoOpExtraTurn => 30_000,
         };
         Duration::milliseconds(ms)
@@ -488,6 +550,11 @@ pub enum ConversationAction {
         result: Result<ToolResultData, String>,
     },
     CompactionResult(Result<CompactionOutput, InterruptionReason>),
+    ReminderFired {
+        note: String,
+        user_id: String,
+        name: String,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -517,6 +584,7 @@ impl std::fmt::Debug for ConversationAction {
             ConversationAction::MessageSent(_) => write!(f, "MessageSent"),
             ConversationAction::ToolResult { .. } => write!(f, "ToolResult"),
             ConversationAction::CompactionResult(_) => write!(f, "CompactionResult"),
+            ConversationAction::ReminderFired { .. } => write!(f, "ReminderFired"),
         }
     }
 }

--- a/chatbot/src/types/reminder.rs
+++ b/chatbot/src/types/reminder.rs
@@ -1,0 +1,84 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+use crate::types::conversation::ConversationId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReminderId(uuid::Uuid);
+
+impl ReminderId {
+    pub fn new() -> Self {
+        ReminderId(uuid::Uuid::new_v4())
+    }
+}
+
+impl Display for ReminderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Compound id so a conversation can hold multiple concurrent reminders (the
+/// memory manager, keyed by bare `ConversationId`, is one-per-conversation and
+/// does not work here).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReminderForConversationId {
+    pub conversation_id: ConversationId,
+    pub reminder_id: ReminderId,
+}
+
+impl re_framework::EntityId for ReminderForConversationId {
+    fn get_id_string(&self) -> String {
+        format!("{}__{}", self.conversation_id, self.reminder_id)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ReminderForConversation {
+    pub state: ReminderState,
+    /// Where the fired reminder is delivered back to.
+    pub conversation_id: ConversationId,
+    /// Who set the reminder / who it is for (named in the fired turn — matters
+    /// in a group chat).
+    pub user_id: String,
+    pub name: String,
+    pub note: String,
+    pub created_on: DateTime<Utc>,
+    pub fire_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum ReminderState {
+    Pending,
+    Fired,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum ReminderAction {
+    Fire,
+}
+
+impl std::fmt::Debug for ReminderAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReminderAction::Fire => write!(f, "Fire"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReminderConstructor {
+    pub id: ReminderForConversationId,
+    pub user_id: String,
+    pub name: String,
+    pub note: String,
+    pub delay_seconds: i64,
+}
+
+impl re_framework::Identified for ReminderConstructor {
+    type Id = ReminderForConversationId;
+    fn get_id(&self) -> &ReminderForConversationId {
+        &self.id
+    }
+}

--- a/chatbot/src/types/reminder.rs
+++ b/chatbot/src/types/reminder.rs
@@ -4,12 +4,23 @@ use std::fmt::Display;
 
 use crate::types::conversation::ConversationId;
 
+/// Upper bound on how far out a reminder may be scheduled (~1 year). Bounds the
+/// requested delay well below any chrono arithmetic overflow, so computing
+/// `fire_at` can never panic.
+pub const MAX_REMINDER_SECS: i64 = 366 * 24 * 60 * 60;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReminderId(uuid::Uuid);
 
 impl ReminderId {
     pub fn new() -> Self {
         ReminderId(uuid::Uuid::new_v4())
+    }
+}
+
+impl Default for ReminderId {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/chatbot/src/types/reminder.rs
+++ b/chatbot/src/types/reminder.rs
@@ -55,17 +55,9 @@ pub enum ReminderState {
     Fired,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReminderAction {
     Fire,
-}
-
-impl std::fmt::Debug for ReminderAction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReminderAction::Fire => write!(f, "Fire"),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -73,7 +65,7 @@ pub struct ReminderConstructor {
     pub id: ReminderForConversationId,
     pub addressee: String,
     pub note: String,
-    pub delay_seconds: i64,
+    pub fire_at: DateTime<Utc>,
 }
 
 impl re_framework::Identified for ReminderConstructor {

--- a/chatbot/src/types/reminder.rs
+++ b/chatbot/src/types/reminder.rs
@@ -4,9 +4,6 @@ use std::fmt::Display;
 
 use crate::types::conversation::ConversationId;
 
-/// Upper bound on how far out a reminder may be scheduled (~1 year). Bounds the
-/// requested delay well below any chrono arithmetic overflow, so computing
-/// `fire_at` can never panic.
 pub const MAX_REMINDER_SECS: i64 = 366 * 24 * 60 * 60;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -30,9 +27,6 @@ impl Display for ReminderId {
     }
 }
 
-/// Compound id so a conversation can hold multiple concurrent reminders (the
-/// memory manager, keyed by bare `ConversationId`, is one-per-conversation and
-/// does not work here).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReminderForConversationId {
     pub conversation_id: ConversationId,
@@ -48,11 +42,8 @@ impl re_framework::EntityId for ReminderForConversationId {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ReminderForConversation {
     pub state: ReminderState,
-    /// Where the fired reminder is delivered back to.
-    pub conversation_id: ConversationId,
-    /// Who set the reminder / who it is for (named in the fired turn — matters
-    /// in a group chat).
-    pub user_id: String,
+        pub conversation_id: ConversationId,
+            pub user_id: String,
     pub name: String,
     pub note: String,
     pub created_on: DateTime<Utc>,

--- a/chatbot/src/types/reminder.rs
+++ b/chatbot/src/types/reminder.rs
@@ -42,9 +42,8 @@ impl re_framework::EntityId for ReminderForConversationId {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ReminderForConversation {
     pub state: ReminderState,
-        pub conversation_id: ConversationId,
-            pub user_id: String,
-    pub name: String,
+    pub conversation_id: ConversationId,
+    pub addressee: String,
     pub note: String,
     pub created_on: DateTime<Utc>,
     pub fire_at: DateTime<Utc>,
@@ -72,8 +71,7 @@ impl std::fmt::Debug for ReminderAction {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReminderConstructor {
     pub id: ReminderForConversationId,
-    pub user_id: String,
-    pub name: String,
+    pub addressee: String,
     pub note: String,
     pub delay_seconds: i64,
 }


### PR DESCRIPTION
Implements #210.

Gives the bot a `set_reminder` tool. Unlike every other tool, it does **not** run through `execute_tool` — it spawns a durable per-conversation entity (`ReminderForConversation`) that schedules a future timer. When the timer fires, the entity delivers a **system message** back into the conversation, waking the bot to message the user.

## What's here

**New entity — `ReminderForConversation`** (`types/reminder.rs`, `state_machines/reminder_state_machine.rs`)
- Compound `(ConversationId, ReminderId)` id so a conversation can hold multiple concurrent reminders.
- Persists the deliver-back `conversation_id`, the requesting user (`user_id`/`name`), the `note`, `created_on`, and `fire_at`.
- `construct` stamps `created_on` and derives `fire_at = created_on + delay_seconds`; `schedule()` returns `Fire` at `fire_at`; on `Fire` it enqueues `ConversationAction::ReminderFired` and moves to a terminal `Fired`.
- Dispatched with a bare `enqueue_construct` — the framework persists `next_tick_on` from `schedule()` and re-arms the timer on process restart, so a bare construct is enough (no initial action needed).

**Input-type refactor** (`types/conversation.rs`)
- `LLMInput` gains a `SystemMessage` case (carries the target user's identity so a group-chat reminder names who it's for).
- The pending queue is wrapped in a two-case `Pending` enum (`Message` | `System`); `pending: Vec<Pending>`.
- `take_pending` drains the whole queue in arrival order as before — a pure-reminder batch stays a `System` turn; a mixed batch merges into one `Message` folding reminder notes in as tagged text.
- Reminders render as a tagged, user-addressed, high-importance turn: `[Reminder — IMPORTANT] For {name}: {note}`.

**Dispatch wiring** (`state_machines/conversation_state_machine.rs`)
- A `SetReminder` call is split off the `CallTools` loop: it constructs the entity via `Effects` and produces a **synthetic confirmation `ToolResult`** immediately, so the round completes and the bot can tell the user. Real tools still go through `execute_tool`.
- Shared `finish_tool_round` helper covers both the normal all-tools-returned path and the reminders-only immediate-completion path.
- `ReminderFired` pushes a `Pending::System` onto the queue exactly like a user message.

**Tool** (`tools.rs`) — `set_reminder` takes `delay_seconds` (lenient numeric parse, per #207) + `note`, and shows the normal tool-use announcement.

## Design decisions (from #210)
1. `delay_seconds` + record `created_on`. ✅
2. Tagged `[Reminder]` turn that names the user; `conversation_id` persisted on the entity. ✅
3. `take_pending` drains same as other messages; reminder text marked heavy-importance. ✅
4. `set_reminder` shows as a normal tool. ✅

## Testing
- `cargo check -p chatbot` passes cleanly (only pre-existing dead-code warnings in the gitignored `configuration.rs`).
- Added a unit test for `set_reminder` binding (numeric + stringified `delay_seconds`).
- ⚠️ The full test-binary build (links llama-cpp/vulkan) was still compiling at PR time — the unit-test *run* hasn't been observed green yet, only `cargo check`.

## Known caveats (carried from #210)
- Reminders do **not** survive a deploy until #194 lands (`framework_db` isn't mounted yet).
- Fired entities sit in a terminal `Fired` state forever (no self-delete primitive); GC is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)