### PR TITLE
chatbot: malformed tool call becomes a meta-tool result, not a dropped turn

### DIFF
--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -12,6 +12,20 @@ use llama_cpp_2::mtmd::mtmd_default_marker;
 
 use std::sync::Arc;
 
+fn malformed_report(name: &str, error: &anyhow::Error) -> String {
+    let mut report = format!(
+        "That tool call was rejected and did NOT run: {error}. Re-check the tool name and its \
+         arguments against the tools available to you, then call it again."
+    );
+    if name.contains("attach") {
+        report.push_str(
+            " (Sending a file or image to the user is NOT a tool — instead put the marker \
+             [[attach_file:PATH]] or [[attach_image:PATH]] in your reply text.)",
+        );
+    }
+    report
+}
+
 fn budget_note(tool_rounds: usize, max_tool_rounds: usize) -> Option<String> {
     if max_tool_rounds == 0 {
         None
@@ -180,19 +194,26 @@ async fn get_response_from_llm(
 
     let thoughts = parsed.reasoning;
     let content = parsed.content;
-    let tool_calls = parsed
+    let tool_calls: Vec<ToolCall> = parsed
         .tool_calls
         .iter()
         .enumerate()
         .map(|(i, call)| {
-            ToolType::bind(&call.name, &call.arguments)
-                .map(|tool_type| ToolCall { id: format!("call_{i}"), tool_type })
-                .map_err(|e| {
+            let id = format!("call_{i}");
+            match ToolType::bind(&call.name, &call.arguments) {
+                Ok(tool_type) => ToolCall { id, tool_type },
+                Err(e) => {
                     eprintln!("[llm] tool call did not parse: {e:#}");
-                    InterruptionReason::MalformedToolCall
-                })
+                    ToolCall {
+                        id,
+                        tool_type: ToolType::MetaMalformed {
+                            report: malformed_report(&call.name, &e),
+                        },
+                    }
+                }
+            }
         })
-        .collect::<Result<Vec<_>, InterruptionReason>>()?;
+        .collect();
 
     let explicit_empty = content.eq_ignore_ascii_case("[EMPTY]");
     let reply = if !content.is_empty() && !explicit_empty {
@@ -252,5 +273,26 @@ pub async fn get_llm_decision(
     match llama_cpp_result {
         Ok(llama_cpp_response) => ConversationAction::LLMDecisionResult(Ok(llama_cpp_response)),
         Err(reason) => ConversationAction::LLMDecisionResult(Err(reason)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::malformed_report;
+
+    #[test]
+    fn malformed_report_names_the_error_and_adds_attach_hint() {
+        let unknown = anyhow::anyhow!("model called an unknown tool: attach_file");
+        let report = malformed_report("attach_file", &unknown);
+        assert!(report.contains("did NOT run"));
+        assert!(report.contains("attach_file"));
+        assert!(report.contains("[[attach_file:PATH]]"));
+
+        let bad_args =
+            anyhow::anyhow!("set_reminder arguments failed to bind: missing field delay_seconds");
+        let report = malformed_report("set_reminder", &bad_args);
+        assert!(report.contains("did NOT run"));
+        assert!(report.contains("missing field delay_seconds"));
+        assert!(!report.contains("[[attach_file"));
     }
 }

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -434,6 +434,10 @@ async fn run_tool(
         ToolType::SetReminder { .. } => Err(
             "set_reminder is handled by the conversation runtime, not the tool executor".to_string(),
         ),
+        ToolType::MetaMalformed { .. } => Err(
+            "meta_malformed_tool_call is handled by the conversation runtime, not the tool executor"
+                .to_string(),
+        ),
     }
 }
 

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -220,22 +220,10 @@ fn apply_post_send(
                         if let Some(constructor) = maybe_construct {
                             effects.enqueue_construct::<ReminderForConversationMachine>(constructor);
                         }
-                        effects.enqueue_action::<ConversationMachine>(
-                            conversation_id.clone(),
-                            ConversationAction::ToolResult {
-                                id: tool_call.id.clone(),
-                                result: Ok(ToolResultData::text(text.clone(), text)),
-                            },
-                        );
+                        enqueue_self_result(effects, conversation_id, &tool_call.id, text);
                     }
                     ToolType::MetaMalformed { report } => {
-                        effects.enqueue_action::<ConversationMachine>(
-                            conversation_id.clone(),
-                            ConversationAction::ToolResult {
-                                id: tool_call.id.clone(),
-                                result: Ok(ToolResultData::text(report.clone(), report.clone())),
-                            },
-                        );
+                        enqueue_self_result(effects, conversation_id, &tool_call.id, report.clone());
                     }
                     tool_type => {
                         let expected_file_hash = match tool_type {
@@ -358,13 +346,8 @@ fn conversation_transition(
             ConversationAction::LLMDecisionResult(res),
         ) => match res {
             Ok(response) => {
-                let recorded_input = if REDACT_HISTORY_IMAGES {
-                    current_input.redacted()
-                } else {
-                    current_input
-                };
                 let mut updated_history = history;
-                updated_history.push(HistoryEntry::input(recorded_input));
+                updated_history.push(record_input(current_input));
                 updated_history.push(HistoryEntry::output(response.clone()));
 
                 let updated_conversation =
@@ -406,13 +389,8 @@ fn conversation_transition(
                 )
             }
             Err(reason) => {
-                let recorded_input = if REDACT_HISTORY_IMAGES {
-                    current_input.redacted()
-                } else {
-                    current_input
-                };
                 let mut history = history;
-                history.push(HistoryEntry::input(recorded_input));
+                history.push(record_input(current_input));
                 history.push(HistoryEntry::interrupted(reason.clone()));
                 Ok(Conversation {
                     state: ConversationState::Idle {
@@ -619,6 +597,30 @@ fn reminder_confirmation(fire_at: DateTime<Utc>, note: &str) -> String {
          prompted automatically when it fires. (Reminders are lost on a redeploy.)",
         fire_at.format("%Y-%m-%d %H:%M:%S UTC")
     )
+}
+
+fn record_input(current_input: LLMInput) -> HistoryEntry {
+    let input = if REDACT_HISTORY_IMAGES {
+        current_input.redacted()
+    } else {
+        current_input
+    };
+    HistoryEntry::input(input)
+}
+
+fn enqueue_self_result(
+    effects: &mut ConversationEffects,
+    conversation_id: &ConversationId,
+    tool_call_id: &str,
+    text: String,
+) {
+    effects.enqueue_action::<ConversationMachine>(
+        conversation_id.clone(),
+        ConversationAction::ToolResult {
+            id: tool_call_id.to_string(),
+            result: Ok(ToolResultData::text(text.clone(), text)),
+        },
+    );
 }
 
 fn post_transition(

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -228,6 +228,15 @@ fn apply_post_send(
                             },
                         );
                     }
+                    ToolType::MetaMalformed { report } => {
+                        effects.enqueue_action::<ConversationMachine>(
+                            conversation_id.clone(),
+                            ConversationAction::ToolResult {
+                                id: tool_call.id.clone(),
+                                result: Ok(ToolResultData::text(report.clone(), report.clone())),
+                            },
+                        );
+                    }
                     tool_type => {
                         let expected_file_hash = match tool_type {
                             ToolType::EditFile { path, .. } => {

--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -406,7 +406,13 @@ fn conversation_transition(
                 )
             }
             Err(reason) => {
+                let recorded_input = if REDACT_HISTORY_IMAGES {
+                    current_input.redacted()
+                } else {
+                    current_input
+                };
                 let mut history = history;
+                history.push(HistoryEntry::input(recorded_input));
                 history.push(HistoryEntry::interrupted(reason.clone()));
                 Ok(Conversation {
                     state: ConversationState::Idle {

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -34,18 +34,19 @@ struct ReadFileArgs {
     limit: Option<usize>,
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum NumOrStr<T> {
+    Num(T),
+    Str(String),
+}
+
 fn de_lenient_number<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: serde::Deserializer<'de>,
     T: serde::Deserialize<'de> + std::str::FromStr,
     <T as std::str::FromStr>::Err: std::fmt::Display,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum NumOrStr<T> {
-        Num(T),
-        Str(String),
-    }
     match NumOrStr::<T>::deserialize(deserializer)? {
         NumOrStr::Num(n) => Ok(n),
         NumOrStr::Str(s) => s.trim().parse::<T>().map_err(serde::de::Error::custom),
@@ -56,13 +57,7 @@ fn de_lenient_opt_usize<'de, D>(deserializer: D) -> Result<Option<usize>, D::Err
 where
     D: serde::Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum NumOrStr {
-        Num(usize),
-        Str(String),
-    }
-    match Option::<NumOrStr>::deserialize(deserializer)? {
+    match Option::<NumOrStr<usize>>::deserialize(deserializer)? {
         None => Ok(None),
         Some(NumOrStr::Num(n)) => Ok(Some(n)),
         Some(NumOrStr::Str(s)) => match s.trim() {

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -104,14 +104,19 @@ impl ToolKind {
             ToolKind::EditFile => "edit_file",
             ToolKind::SetReminder => "set_reminder",
             ToolKind::MetaNoOpExtraTurn => "meta_no_op_extra_turn",
+            ToolKind::MetaMalformed => "meta_malformed_tool_call",
         }
     }
 
     fn announcement(&self) -> Option<&'static str> {
         match self {
-            ToolKind::MetaNoOpExtraTurn => None,
+            ToolKind::MetaNoOpExtraTurn | ToolKind::MetaMalformed => None,
             _ => Some(self.wire_name()),
         }
+    }
+
+    fn advertised(&self) -> bool {
+        !matches!(self, ToolKind::MetaMalformed)
     }
 
     fn definition(&self) -> ToolDefinition {
@@ -200,6 +205,10 @@ impl ToolKind {
                 "Give yourself another turn after this reply — use it to say something to the user across multiple steps. Put the first part in this reply's message, call this tool, and you'll be prompted again to continue with the next part. Pointless to call with no message (nothing is sent to the user), and pointless to call alongside other tools (a tool call already earns you another turn).",
                 json!({ "type": "object", "properties": {}, "required": [] }),
             ),
+            ToolKind::MetaMalformed => (
+                "Internal — not callable. Synthesized when one of your tool calls could not be parsed, to hand the error back to you.",
+                json!({ "type": "object", "properties": {}, "required": [] }),
+            ),
         };
         ToolDefinition {
             kind: "function",
@@ -214,7 +223,10 @@ impl ToolKind {
 
 impl ToolType {
     pub fn tool_definitions() -> Vec<ToolDefinition> {
-        ToolKind::iter().map(|k| k.definition()).collect()
+        ToolKind::iter()
+            .filter(ToolKind::advertised)
+            .map(|k| k.definition())
+            .collect()
     }
 
     pub fn wire_name(&self) -> &'static str {
@@ -273,6 +285,7 @@ impl ToolType {
             .into_iter()
             .collect(),
             ToolType::MetaNoOpExtraTurn => Map::new(),
+            ToolType::MetaMalformed { .. } => Map::new(),
         }
     }
 
@@ -320,6 +333,10 @@ impl ToolType {
                 })
             }
             ToolKind::MetaNoOpExtraTurn => Ok(ToolType::MetaNoOpExtraTurn),
+            ToolKind::MetaMalformed => Ok(ToolType::MetaMalformed {
+                report: "meta_malformed_tool_call is internal and cannot be called directly."
+                    .to_string(),
+            }),
         }
     }
 }
@@ -327,6 +344,24 @@ impl ToolType {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn meta_malformed_is_internal_not_advertised() {
+        let names: Vec<&str> = ToolType::tool_definitions()
+            .iter()
+            .map(|d| d.function.name)
+            .collect();
+        assert!(
+            !names.contains(&"meta_malformed_tool_call"),
+            "internal tool must not be advertised to the model"
+        );
+        assert!(names.contains(&"set_reminder"));
+        assert_eq!(ToolType::MetaMalformed { report: String::new() }.announcement(), None);
+        assert!(
+            ToolType::bind("attach_file", r#"{"path":"/x"}"#).is_err(),
+            "unknown tool must error at bind (the llm layer turns this into MetaMalformed)"
+        );
+    }
 
     #[test]
     fn read_file_accepts_stringified_numbers() {

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -115,11 +115,7 @@ impl ToolKind {
         }
     }
 
-    fn advertised(&self) -> bool {
-        !matches!(self, ToolKind::MetaMalformed)
-    }
-
-    fn definition(&self) -> ToolDefinition {
+    fn definition(&self) -> Option<ToolDefinition> {
         let (description, parameters): (&'static str, Value) = match self {
             ToolKind::WebSearch => (
                 "Search the web — ONE focused topic per query; search one fact at a time, never pile attributes into a single query. Snippets only, usually not enough for specifics (dates, numbers, names, quotes) — open the best result with visit_url and read it before answering. For several facts, fire several single-topic searches in the same turn (parallel is fine).",
@@ -205,28 +201,22 @@ impl ToolKind {
                 "Give yourself another turn after this reply — use it to say something to the user across multiple steps. Put the first part in this reply's message, call this tool, and you'll be prompted again to continue with the next part. Pointless to call with no message (nothing is sent to the user), and pointless to call alongside other tools (a tool call already earns you another turn).",
                 json!({ "type": "object", "properties": {}, "required": [] }),
             ),
-            ToolKind::MetaMalformed => (
-                "Internal — not callable. Synthesized when one of your tool calls could not be parsed, to hand the error back to you.",
-                json!({ "type": "object", "properties": {}, "required": [] }),
-            ),
+            ToolKind::MetaMalformed => return None,
         };
-        ToolDefinition {
+        Some(ToolDefinition {
             kind: "function",
             function: ToolDefFunction {
                 name: self.wire_name(),
                 description,
                 parameters,
             },
-        }
+        })
     }
 }
 
 impl ToolType {
     pub fn tool_definitions() -> Vec<ToolDefinition> {
-        ToolKind::iter()
-            .filter(ToolKind::advertised)
-            .map(|k| k.definition())
-            .collect()
+        ToolKind::iter().filter_map(|k| k.definition()).collect()
     }
 
     pub fn wire_name(&self) -> &'static str {

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -339,6 +339,9 @@ pub enum ToolType {
         addressee: String,
     },
     MetaNoOpExtraTurn,
+    MetaMalformed {
+        report: String,
+    },
 }
 
 impl ToolType {
@@ -351,7 +354,8 @@ impl ToolType {
             | ToolType::ReadFile { .. }
             | ToolType::EditFile { .. }
             | ToolType::SetReminder { .. }
-            | ToolType::MetaNoOpExtraTurn => 30_000,
+            | ToolType::MetaNoOpExtraTurn
+            | ToolType::MetaMalformed { .. } => 30_000,
         };
         Duration::milliseconds(ms)
     }


### PR DESCRIPTION
Implements the malformed-tool handling from #208, via the meta-tool + runtime/self-action pattern.

## Problem (confirmed from live logs)

A tool call that failed to `bind` errored the whole LLM decision (`InterruptionReason::MalformedToolCall` propagated by the atomic `collect::<Result<_>>()?`). That path threw away, in one shot:
1. the model's message and every **valid** sibling tool call;
2. the **triggering input** — the Err branch pushes only the interrupted marker and never records `current_input` the way the Ok branch does, so the user's message (moved out of `pending` when the turn started) is lost entirely;
3. any useful feedback — the model got a vague, **assistant-role** marker (`[… could not be parsed …]`), only on its *next* turn, with no re-prompt.

Recent logs showed exactly this: `attach_file` called as a tool, `set_reminder` with a param the parser dropped — each silently killed the turn, and the model spent the conversation guessing "probably an infrastructure issue" because it had lost the context and never saw the real error.

## Fix

On bind failure, synthesize a `ToolType::MetaMalformed { report }` instead of erroring. It rides the **same runtime/self-action path as `set_reminder`** (no external, no construct): `apply_post_send` self-delivers a `tool`-role `ToolResult` carrying the report, and it flows through `RunningTools` like any tool. So:

- the turn is **preserved** — the model's message + valid calls proceed normally;
- the model receives a **specific, `tool`-role error** naming the tool and the bind failure, in the same flow, and can correct against it;
- no dropped input, no Idle stall, no wrong-role marker.

### Details
- `MetaMalformed` is **internal**: filtered out of `tool_definitions()` (model never sees it) and never announced (`announcement() == None`, using the per-tool control from #206). If the model somehow names it, `bind` returns a note rather than erroring.
- The report names the tool + the bind error; for `attach*` names it appends the *"put the `[[attach_file:PATH]]` / `[[attach_image:PATH]]` marker in your reply instead"* hint — directly fixing the recurring `attach_file`-as-tool drop.
- `run_tool` keeps an unreachable `MetaMalformed` arm for match exhaustiveness (same as `set_reminder`).
- `InterruptionReason::MalformedToolCall` is now unused; left in place (its orphaned marker text can be removed in a follow-up).

### Tests
- `meta_malformed_is_internal_not_advertised` — excluded from the advertised list, not announced, unknown-tool still errors at bind.
- `malformed_report_names_the_error_and_adds_attach_hint`.
- Builds clean; all non-network tests pass (`fetch_web_search` / `fetch_url_content_real` fail on network, unrelated).

## Scope / follow-ups
- This is the "handle it gracefully when it happens" half. The complementary half — **relaxing the subtle parser rules** so it happens less (e.g. the `PARAM_RE` that dropped an inline `<parameter=x> 10` value, stringified-number edge cases) — is separate and still open.
- Capturing the *raw* pre-parse tool-call block (not just the reconstructed args) in the report would make some errors even clearer; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)