### PR TITLE
re_framework: sweeper look-ahead timer lane (#217)

### DIFF
--- a/re_framework/src/sweep.rs
+++ b/re_framework/src/sweep.rs
@@ -7,9 +7,10 @@ use std::time::{Duration, Instant};
 const BATCH: i64 = 50;
 const MAX_PAGES: i64 = 20;
 const OUTBOX_GRACE_MS: i64 = 60_000;
-const TIMER_GRACE_MS: i64 = 120_000;
 const MIN_INTERVAL: Duration = Duration::from_secs(10);
-const MAX_INTERVAL: Duration = Duration::from_secs(240);
+const MAX_INTERVAL: Duration = Duration::from_secs(30);
+const LOOK_AHEAD_MARGIN: Duration = Duration::from_secs(30);
+const TIMER_LOOK_AHEAD_MS: i64 = (MAX_INTERVAL.as_secs() + LOOK_AHEAD_MARGIN.as_secs()) as i64 * 1000;
 const REWAKE_SUPPRESS: Duration = Duration::from_secs(60);
 const WAKE_STAGGER: Duration = Duration::from_millis(25);
 
@@ -19,10 +20,10 @@ pub fn start() {
 
 async fn sweeper_loop() {
     let mut recently_woken: HashMap<(String, String), Instant> = HashMap::new();
-    sweep_once((0, 0), &mut recently_woken).await;
+    sweep_once((0, TIMER_LOOK_AHEAD_MS), &mut recently_woken).await;
     let mut interval = MIN_INTERVAL;
     loop {
-        let woke = sweep_once((OUTBOX_GRACE_MS, TIMER_GRACE_MS), &mut recently_woken).await;
+        let woke = sweep_once((OUTBOX_GRACE_MS, TIMER_LOOK_AHEAD_MS), &mut recently_woken).await;
         interval = if woke == 0 { (interval * 2).min(MAX_INTERVAL) } else { MIN_INTERVAL };
         tokio::time::sleep(interval).await;
     }
@@ -57,7 +58,7 @@ where
 }
 
 async fn sweep_once(
-    (outbox_grace_ms, timer_grace_ms): (i64, i64),
+    (outbox_grace_ms, timer_look_ahead_ms): (i64, i64),
     recently_woken: &mut HashMap<(String, String), Instant>,
 ) -> usize {
     let now_ms = chrono::Utc::now().timestamp_millis();
@@ -65,8 +66,8 @@ async fn sweep_once(
         store().stalled_outbox_senders(now_ms - outbox_grace_ms, BATCH, offset)
     })
     .await;
-    let due = paged("due-timers", |offset| {
-        store().due_timers(now_ms - timer_grace_ms, BATCH, offset)
+    let due = paged("coming-due-timers", |offset| {
+        store().due_timers(now_ms + timer_look_ahead_ms, BATCH, offset)
     })
     .await;
 
@@ -95,7 +96,7 @@ async fn sweep_once(
         }
     }
     if woke > 0 {
-        println!("[sweep] woke {woke} entities with stalled outbox rows or due timers");
+        println!("[sweep] woke {woke} entities with stalled outbox rows or coming-due timers");
     }
     woke
 }


### PR DESCRIPTION
Closes #217. Sub-task 1 of #215.

## What
The sweeper's **timer lane** now queries *coming-due* timers (`next_tick_on < now + L`, `L = 60s`) instead of *overdue* ones (`next_tick_on < now − 120s`). A non-resident entity is woken **before** its deadline, loads, and re-arms its own in-process `tokio::timeout` — firing **exactly on time** — instead of being rescued up to ~6 min late by the overdue backstop. This is the reminder lateness observed after a restart.

## Why one lane is enough
A look-ahead query (`<= now + L`) is a **strict superset** of the overdue query, so it also sweeps up genuine misses (crash between persist and fire, clock skew) in the same pass. The old 120s grace was never a correctness device — `wake` on a resident actor is an idempotent `Drain`, and sole-mailbox + `recently_woken` handle dedup. (Rationale, incl. why re_framework pokes rather than adopting subject's central reminder-service, is in #215.)

## Changes (`sweep.rs` only — store `due_timers` is already `next_tick_on < cutoff`, unchanged)
- `TIMER_GRACE_MS` (subtracted) → `TIMER_LOOK_AHEAD_MS = 60_000` (added).
- Boot sweep passes look-ahead too; outbox lane keeps its own `OUTBOX_GRACE_MS`.
- `TIMER_LOOK_AHEAD_MS` is **derived** as `MAX_INTERVAL + LOOK_AHEAD_MARGIN`, so `L ≥ max_scan_interval` holds *by construction* — no assert, unrepresentable to violate. `MAX_INTERVAL` is lowered 240s → 30s to keep `L` a sane 60s.

## Scope
No eviction — entities are still resident-forever, so this fixes the **absent** case only (post-restart today; post-eviction once #218 lands). The entity still fires via its own timer; the sweep only guarantees it's loaded in time.

## Testing
`cargo test -p re_framework` green (6/6, incl. `timer_deadlines` + both smoke runs); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

