### PR TITLE
chatbot: A2 rename, self-managed SearxNG, use_skill tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bot/
 ├── chatbot/                      # Main Discord chatbot application
 │   ├── src/
 │   │   ├── roles/                # The render → infer → parse pipeline behind a Role trait
-│   │   │   ├── primary_role.rs   #   PrimaryRole — the "Terminal Alpha Beta" persona
+│   │   │   ├── primary_role.rs   #   PrimaryRole — the "A2" persona
 │   │   │   ├── local_model.rs    #   Loaded GGUF model + the llama.cpp decode loop
 │   │   │   ├── render.rs         #   Prompt assembly (minijinja over the pack's chat template)
 │   │   │   └── parsers/          #   Per-family output parsers (e.g. qwen.rs), picked by name
@@ -170,9 +170,8 @@ HTTP call.
 
 ### Prerequisites
 
-- Docker (with a GPU runtime; the Justfile targets an AMD/ROCm host)
+- Docker (with a GPU runtime; the Justfile targets an AMD/ROCm host). The container mounts the Docker socket and self-manages its `web_search` SearxNG instance and bash sandbox as sibling containers.
 - A Discord bot token
-- A SearxNG instance for `web_search` (JSON format enabled)
 - A model pack under `chatbot/models/` (GGUF weights + mmproj + template + `manifest.toml`)
 
 ### Configuration

--- a/chatbot/Dockerfile
+++ b/chatbot/Dockerfile
@@ -40,5 +40,9 @@ COPY --from=builder /app/commit.txt /app/commit.txt
 
 COPY chatbot/Dockerfile.worker /app/worker/Dockerfile
 
+COPY chatbot/searxng/ /app/searxng/
+
+COPY chatbot/skills/ /app/skills/
+
 
 CMD ["/app/chatbot"]

--- a/chatbot/README.md
+++ b/chatbot/README.md
@@ -84,46 +84,13 @@ To improve startup performance, the bot pre-evaluates the static base prompt (sy
 
 The `web_search` tool queries a [SearxNG](https://github.com/searxng/searxng) instance — a self-hosted metasearch engine — instead of a metered third-party API, so there's no external rate limit to trip.
 
-The bot only needs **a reachable instance with JSON output enabled**:
+**The bot manages SearxNG itself** — the same way it manages the bash sandbox. When `SEARXNG_URL` points at localhost (the default `http://localhost:8080`), the bot builds a `bot-searxng` image (`searxng/searxng` + a baked `settings.yml` with JSON enabled and a build-time-random `secret_key`) and runs it on the host Docker daemon via the mounted socket. Before every `web_search`, and at startup, `ensure_searxng()` recovers it if it's missing or stopped, and the container runs with `--restart unless-stopped`. So an accidental `docker rm`/stop of `bot-searxng`, or a daemon restart, self-heals without touching the bot.
 
-- Point `SEARXNG_URL` (in `src/configuration.rs`) at the instance's base URL. The bot runs with host networking (`--network host`), so `localhost` is the host machine — the default `http://localhost:8080` reaches a SearxNG published on the host's port 8080. A remote instance works too (e.g. `https://search.example.com`).
-- The instance **must** have JSON format enabled (it's off by default — see the `settings.yml` below).
+- The staged build context lives at `searxng/` (`Dockerfile` + `settings.yml`), copied into the bot image at `/app/searxng`.
+- **Remote instances are left unmanaged:** set `SEARXNG_URL` to a non-localhost URL (e.g. `https://search.example.com`) and the bot skips container management and just queries it. That instance must have JSON format enabled itself.
 
 > [!NOTE]
-> **Running** SearxNG (Docker, bare metal, hosted) is out of scope here — see the [upstream docs](https://docs.searxng.org/). The steps below are just a convenience for a quick local instance.
-
-A minimal local container:
-
-1. **Create a config dir and `settings.yml`** that overrides only what we need on top of the image defaults:
-   ```yaml
-   # <config-dir>/settings.yml
-   use_default_settings: true
-   server:
-     # Required: SearxNG won't start without one. Generate via `openssl rand -hex 32`.
-     secret_key: "<random-hex>"
-     # Listen on all interfaces inside the container so the published port works.
-     bind_address: "0.0.0.0"
-   search:
-     # JSON is off by default; the bot's web_search calls the JSON endpoint, so enable it.
-     formats:
-       - html
-       - json
-   ```
-
-2. **Run the container**, mounting that config and publishing port 8080 on the host:
-   ```bash
-   docker run -d --name searxng --restart unless-stopped \
-     -p 8080:8080 \
-     -v <config-dir>:/etc/searxng \
-     searxng/searxng
-   ```
-   The bot runs with `--network host`, so the host's `:8080` is reachable at the default `SEARXNG_URL=http://localhost:8080`.
-
-3. **Verify JSON output works:**
-   ```bash
-   curl "http://localhost:8080/search?q=test&format=json"   # → JSON with a "results" array
-   ```
-   A `403`/HTML response usually means JSON isn't enabled (check `search.formats`) or the limiter is blocking direct API calls (set `server.limiter: false` for a private instance).
+> Verify the JSON endpoint (locally: `curl "http://localhost:8080/search?q=test&format=json"` → JSON with a `results` array). A `403`/HTML response usually means JSON isn't enabled (`search.formats`) or the limiter is blocking direct API calls (`server.limiter: false`) — both are already set in the baked `settings.yml`.
 
 ## Architecture
 

--- a/chatbot/model_reference/qwen.md
+++ b/chatbot/model_reference/qwen.md
@@ -112,7 +112,7 @@ You have access to the following functions:
 If you choose to call a function ONLY reply in the following format with NO suffix:
 ... (format + <IMPORTANT> block) ...
 
-You are Terminal Alpha Beta.<|im_end|>
+You are A2.<|im_end|>
 <|im_start|>user
 What's the weather in London?<|im_end|>
 <|im_start|>assistant

--- a/chatbot/searxng/Dockerfile
+++ b/chatbot/searxng/Dockerfile
@@ -1,0 +1,6 @@
+FROM searxng/searxng:latest
+
+COPY settings.yml /etc/searxng/settings.yml
+
+RUN SECRET=$(head -c 32 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9') && \
+    sed -i "s|__SECRET__|$SECRET|" /etc/searxng/settings.yml

--- a/chatbot/searxng/Dockerfile
+++ b/chatbot/searxng/Dockerfile
@@ -4,3 +4,6 @@ COPY settings.yml /etc/searxng/settings.yml
 
 RUN SECRET=$(head -c 32 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9') && \
     sed -i "s|__SECRET__|$SECRET|" /etc/searxng/settings.yml
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD wget -q -O /dev/null http://localhost:8080/ || exit 1

--- a/chatbot/searxng/settings.yml
+++ b/chatbot/searxng/settings.yml
@@ -1,0 +1,10 @@
+use_default_settings: true
+
+server:
+  secret_key: "__SECRET__"
+  limiter: false
+
+search:
+  formats:
+    - html
+    - json

--- a/chatbot/skills/document_conversion.md
+++ b/chatbot/skills/document_conversion.md
@@ -1,0 +1,23 @@
+# Document Conversion
+
+## MOBI to EPUB
+Use `mobi` library: `pip install mobi` then `mobi.extract("file.mobi")`. Handles conversion in one step. More reliable than calibre's `ebook-convert`.
+
+## PDF to Text
+`pip install PyMuPDF` (fast, general) or `pip install pdfplumber` (better for tables).
+
+## General conversion
+`pip install pypandoc` then `pypandoc.convert_file("in.ext", "out_format")`. Pandoc covers 100+ formats — your go-to.
+
+## Office files (DOCX, XLSX, PPTX)
+- python-docx / python-pptx / openpyxl for reading/writing
+- pandoc for DOC to DOCX, DOCX to PDF
+- LibreOffice headless: `soffice --headless --convert-to out_format in_file` (complex Office docs)
+
+## Quick reference
+- MOBI to EPUB: `mobi.extract()`
+- EPUB to PDF: pandoc
+- DOCX to PDF: pandoc
+- PDF to text: PyMuPDF
+- General: pandoc
+- Complex Office: LibreOffice

--- a/chatbot/src/externals.rs
+++ b/chatbot/src/externals.rs
@@ -1,5 +1,8 @@
 pub mod bash_container_external;
+pub mod container;
 pub mod llama_cpp_external;
 pub mod message_external;
+pub mod searxng_external;
+pub mod skill_external;
 pub mod summarize_external;
 pub mod tool_call_external;

--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -1,3 +1,4 @@
+use crate::externals::container::{docker, ensure_image, is_running, revive_if_present};
 use crate::types::conversation::ToolResultData;
 use crate::types::media::{Image, MessageImage};
 use std::process::Stdio;
@@ -16,53 +17,15 @@ fn worker_name(conversation_id: &str) -> String {
     format!("botwork-{safe}")
 }
 
-async fn docker(args: &[&str]) -> Result<std::process::Output, String> {
-    Command::new("docker")
-        .args(args)
-        .output()
-        .await
-        .map_err(|e| format!("failed to invoke docker: {e}"))
-}
-
-async fn is_running(name: &str) -> bool {
-    match docker(&["inspect", "-f", "{{.State.Running}}", name]).await {
-        Ok(out) => out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "true",
-        Err(_) => false,
-    }
-}
-
 async fn ensure_worker(name: &str) -> Result<(), String> {
-    match docker(&["inspect", "-f", "{{.State.Running}}", name]).await {
-        Ok(out) if out.status.success() => {
-            if String::from_utf8_lossy(&out.stdout).trim() == "true" {
-                return Ok(());
-            }
-            if docker(&["start", name]).await.map(|o| o.status.success()).unwrap_or(false) {
-                return Ok(());
-            }
-            let _ = docker(&["rm", "-f", name]).await;
-        }
-        _ => {}
+    if revive_if_present(name).await {
+        return Ok(());
     }
     spawn_worker(name).await
 }
 
 pub(crate) async fn ensure_worker_image() -> Result<(), String> {
-    let present = docker(&["image", "inspect", WORKER_IMAGE])
-        .await
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if present {
-        return Ok(());
-    }
-    let out = docker(&["build", "-t", WORKER_IMAGE, WORKER_BUILD_CONTEXT]).await?;
-    if !out.status.success() {
-        return Err(format!(
-            "could not build sandbox image: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        ));
-    }
-    Ok(())
+    ensure_image(WORKER_IMAGE, WORKER_BUILD_CONTEXT).await
 }
 
 async fn spawn_worker(name: &str) -> Result<(), String> {

--- a/chatbot/src/externals/container.rs
+++ b/chatbot/src/externals/container.rs
@@ -1,0 +1,51 @@
+use std::process::Output;
+use tokio::process::Command;
+
+pub(crate) async fn docker(args: &[&str]) -> Result<Output, String> {
+    Command::new("docker")
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| format!("failed to invoke docker: {e}"))
+}
+
+pub(crate) async fn is_running(name: &str) -> bool {
+    match docker(&["inspect", "-f", "{{.State.Running}}", name]).await {
+        Ok(out) => out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "true",
+        Err(_) => false,
+    }
+}
+
+pub(crate) async fn ensure_image(image: &str, context: &str) -> Result<(), String> {
+    let present = docker(&["image", "inspect", image])
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if present {
+        return Ok(());
+    }
+    let out = docker(&["build", "-t", image, context]).await?;
+    if out.status.success() {
+        return Ok(());
+    }
+    Err(format!(
+        "could not build image {image}: {}",
+        String::from_utf8_lossy(&out.stderr).trim()
+    ))
+}
+
+pub(crate) async fn revive_if_present(name: &str) -> bool {
+    match docker(&["inspect", "-f", "{{.State.Running}}", name]).await {
+        Ok(out) if out.status.success() => {
+            if String::from_utf8_lossy(&out.stdout).trim() == "true" {
+                return true;
+            }
+            if docker(&["start", name]).await.map(|o| o.status.success()).unwrap_or(false) {
+                return true;
+            }
+            let _ = docker(&["rm", "-f", name]).await;
+            false
+        }
+        _ => false,
+    }
+}

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -62,10 +62,11 @@ fn session_footer(
         "DIRECT MESSAGE (one-to-one with the user), not a group chat- every message is meant for you, there is no one else."
     };
     let now = Utc::now().format("%Y-%m-%d %H:%M:%S UTC");
+    let bot_name = crate::BOT_NAME;
 
     let mut lines = vec![
         "=== SYSTEM GENERATED CONVERSATION METADATA FOOTER ===".to_string(),
-        format!("Your username in this conversation: {bot_identity}. Respond to both this name and Terminal Alpha Beta"),
+        format!("Your username in this conversation: {bot_identity}. Respond to both this name and {bot_name}"),
         format!("Setting: {setting}"),
         format!("Current time: {now}"),
         platform.formatting_note().to_string(),
@@ -86,7 +87,7 @@ fn session_footer(
 
     if is_group {
         lines.push(
-            "Reminders: in a group you default to silence — chime in when your id is @mentioned, or occasionally on your own if you genuinely add something; otherwise your whole reply must be the literal token [EMPTY] (exactly those seven characters with square brackets, nothing else — never (empty), empty, or any variant). Match the @mention id, not the name. You are Terminal Alpha Beta.".to_string(),
+            format!("Reminders: in a group you default to silence — chime in when your id is @mentioned, or occasionally on your own if you genuinely add something; otherwise your whole reply must be the literal token [EMPTY] (exactly those seven characters with square brackets, nothing else — never (empty), empty, or any variant). Match the @mention id, not the name. You are {bot_name}."),
         );
     }
 

--- a/chatbot/src/externals/searxng_external.rs
+++ b/chatbot/src/externals/searxng_external.rs
@@ -1,0 +1,48 @@
+use crate::configuration::client_tokens::SEARXNG_URL;
+use crate::externals::container::{docker, ensure_image, is_running, revive_if_present};
+
+const SEARXNG_IMAGE: &str = "bot-searxng:latest";
+const SEARXNG_BUILD_CONTEXT: &str = "/app/searxng";
+const SEARXNG_CONTAINER: &str = "bot-searxng";
+const SEARXNG_PORT_MAP: &str = "8080:8080";
+
+fn is_self_hosted() -> bool {
+    let url = SEARXNG_URL.trim();
+    url.contains("localhost") || url.contains("127.0.0.1")
+}
+
+pub(crate) async fn ensure_searxng_image() -> Result<(), String> {
+    ensure_image(SEARXNG_IMAGE, SEARXNG_BUILD_CONTEXT).await
+}
+
+pub(crate) async fn ensure_searxng() -> Result<(), String> {
+    if !is_self_hosted() {
+        return Ok(());
+    }
+    if revive_if_present(SEARXNG_CONTAINER).await {
+        return Ok(());
+    }
+    spawn_searxng().await
+}
+
+async fn spawn_searxng() -> Result<(), String> {
+    ensure_searxng_image().await?;
+    let out = docker(&[
+        "run", "-d", "--name", SEARXNG_CONTAINER,
+        "--restart", "unless-stopped",
+        "-p", SEARXNG_PORT_MAP,
+        "--memory", "512m", "--cpus", "1",
+        SEARXNG_IMAGE,
+    ])
+    .await?;
+    if out.status.success() {
+        return Ok(());
+    }
+    if is_running(SEARXNG_CONTAINER).await {
+        return Ok(());
+    }
+    Err(format!(
+        "could not start searxng: {}",
+        String::from_utf8_lossy(&out.stderr).trim()
+    ))
+}

--- a/chatbot/src/externals/searxng_external.rs
+++ b/chatbot/src/externals/searxng_external.rs
@@ -12,13 +12,13 @@ const SEARXNG_PORT_MAP: &str = "8080:8080";
 static BRINGUP: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn is_self_hosted() -> bool {
-    match reqwest::Url::parse(SEARXNG_URL.trim()).ok().and_then(|u| u.host_str().map(str::to_owned)) {
-        Some(host) => matches!(
-            host.as_str(),
-            "localhost" | "127.0.0.1" | "0.0.0.0" | "::1" | "[::1]"
-        ),
-        None => false,
-    }
+    reqwest::Url::parse(SEARXNG_URL.trim())
+        .ok()
+        .and_then(|u| {
+            u.host_str()
+                .map(|h| matches!(h, "localhost" | "127.0.0.1" | "0.0.0.0" | "::1" | "[::1]"))
+        })
+        .unwrap_or(false)
 }
 
 async fn is_unhealthy(name: &str) -> bool {
@@ -28,7 +28,7 @@ async fn is_unhealthy(name: &str) -> bool {
     }
 }
 
-pub(crate) async fn ensure_searxng_image() -> Result<(), String> {
+async fn ensure_searxng_image() -> Result<(), String> {
     ensure_image(SEARXNG_IMAGE, SEARXNG_BUILD_CONTEXT).await
 }
 

--- a/chatbot/src/externals/searxng_external.rs
+++ b/chatbot/src/externals/searxng_external.rs
@@ -1,3 +1,6 @@
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+
 use crate::configuration::client_tokens::SEARXNG_URL;
 use crate::externals::container::{docker, ensure_image, is_running, revive_if_present};
 
@@ -6,9 +9,23 @@ const SEARXNG_BUILD_CONTEXT: &str = "/app/searxng";
 const SEARXNG_CONTAINER: &str = "bot-searxng";
 const SEARXNG_PORT_MAP: &str = "8080:8080";
 
+static BRINGUP: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
 fn is_self_hosted() -> bool {
-    let url = SEARXNG_URL.trim();
-    url.contains("localhost") || url.contains("127.0.0.1")
+    match reqwest::Url::parse(SEARXNG_URL.trim()).ok().and_then(|u| u.host_str().map(str::to_owned)) {
+        Some(host) => matches!(
+            host.as_str(),
+            "localhost" | "127.0.0.1" | "0.0.0.0" | "::1" | "[::1]"
+        ),
+        None => false,
+    }
+}
+
+async fn is_unhealthy(name: &str) -> bool {
+    match docker(&["inspect", "-f", "{{.State.Health.Status}}", name]).await {
+        Ok(out) => String::from_utf8_lossy(&out.stdout).trim() == "unhealthy",
+        Err(_) => false,
+    }
 }
 
 pub(crate) async fn ensure_searxng_image() -> Result<(), String> {
@@ -19,9 +36,11 @@ pub(crate) async fn ensure_searxng() -> Result<(), String> {
     if !is_self_hosted() {
         return Ok(());
     }
-    if revive_if_present(SEARXNG_CONTAINER).await {
+    let _bringup = BRINGUP.lock().await;
+    if revive_if_present(SEARXNG_CONTAINER).await && !is_unhealthy(SEARXNG_CONTAINER).await {
         return Ok(());
     }
+    let _ = docker(&["rm", "-f", SEARXNG_CONTAINER]).await;
     spawn_searxng().await
 }
 

--- a/chatbot/src/externals/skill_external.rs
+++ b/chatbot/src/externals/skill_external.rs
@@ -1,0 +1,58 @@
+use std::path::PathBuf;
+use tokio::fs;
+
+const SKILLS_DIR: &str = "/app/skills";
+
+async fn skill_names() -> Result<Vec<String>, String> {
+    let mut dir = fs::read_dir(SKILLS_DIR)
+        .await
+        .map_err(|e| format!("could not open the skills directory: {e}"))?;
+    let mut names = Vec::new();
+    while let Some(entry) = dir
+        .next_entry()
+        .await
+        .map_err(|e| format!("could not read the skills directory: {e}"))?
+    {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                names.push(stem.to_string());
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+pub async fn list_skills() -> Result<String, String> {
+    let names = skill_names().await?;
+    if names.is_empty() {
+        return Ok("No skills are available.".to_string());
+    }
+    let list = names
+        .iter()
+        .map(|n| format!("- {n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(format!(
+        "Available skills ({}). Call use_skill again with a name to read one in full:\n{list}",
+        names.len()
+    ))
+}
+
+pub async fn read_skill(name: &str) -> Result<String, String> {
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err(format!("'{name}' is not a valid skill name."));
+    }
+    let path = PathBuf::from(SKILLS_DIR).join(format!("{name}.md"));
+    match fs::read_to_string(&path).await {
+        Ok(content) => Ok(content),
+        Err(_) => {
+            let hint = match skill_names().await {
+                Ok(names) if !names.is_empty() => format!("available skills: {}", names.join(", ")),
+                _ => "no skills are available".to_string(),
+            };
+            Err(format!("no skill named '{name}' ({hint})"))
+        }
+    }
+}

--- a/chatbot/src/externals/tool_call_external.rs
+++ b/chatbot/src/externals/tool_call_external.rs
@@ -54,6 +54,10 @@ const MAX_SEARCH_RESULTS: usize = 8;
 const SIMPLIFIED_SEARCH_RESULTS: usize = 3;
 
 async fn fetch_web_search(query: &str) -> anyhow::Result<ToolResultData> {
+    if let Err(e) = crate::externals::searxng_external::ensure_searxng().await {
+        eprintln!("[searxng] ensure failed (querying anyway): {e}");
+    }
+
     let search_url = format!(
         "{}/search?q={}&format=json",
         SEARXNG_URL.trim_end_matches('/'),
@@ -431,6 +435,18 @@ async fn run_tool(
                 metadata: HashMap::from([("file_hash".to_string(), content_hash(&updated))]),
             })
         }
+        ToolType::UseSkill { skill } => match skill {
+            None => {
+                let list = crate::externals::skill_external::list_skills().await?;
+                Ok(ToolResultData::text(list.clone(), list))
+            }
+            Some(name) => {
+                let content = crate::externals::skill_external::read_skill(&name).await?;
+                let body = clip_to(&content, ACTUAL_MAX);
+                let simplified = clip_to(&body, SIMPLIFIED_MAX);
+                Ok(ToolResultData::text(body, simplified))
+            }
+        },
         ToolType::SetReminder { .. } => Err(
             "set_reminder is handled by the conversation runtime, not the tool executor".to_string(),
         ),

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -21,6 +21,8 @@ use crate::state_machines::conversation_state_machine::ConversationMachine;
 use crate::state_machines::memory_manager_state_machine::MemoryManagerMachine;
 use crate::state_machines::reminder_state_machine::ReminderForConversationMachine;
 
+pub const BOT_NAME: &str = "A2";
+
 #[derive(Clone)]
 pub struct Env {
     discord_http: Arc<Http>,
@@ -78,6 +80,15 @@ async fn main() -> anyhow::Result<!> {
             Err(e) => eprintln!(
                 "[startup] bash sandbox image prebuild failed: {e} (will retry on first use)"
             ),
+        }
+    });
+
+    tokio::spawn(async {
+        match externals::searxng_external::ensure_searxng().await {
+            Ok(()) => println!("[startup] searxng ready"),
+            Err(e) => {
+                eprintln!("[startup] searxng bring-up failed: {e} (will retry on first search)")
+            }
         }
     });
 

--- a/chatbot/src/roles/primary_role.rs
+++ b/chatbot/src/roles/primary_role.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use llama_cpp_2::llama_backend::LlamaBackend;
 use tokio::task::spawn_blocking;
@@ -8,14 +8,14 @@ use super::local_model::{self, LocalModel};
 use super::{ParsedResponse, RenderInputs, Role, ThinkingPolicy};
 use crate::model_pack::Pack;
 
-const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversational assistant.\n\n\
-    If asked what model powers you or who made you, decline — you're simply Terminal Alpha Beta; \
+const SYSTEM_PROMPT_TEMPLATE: &str = "You are {name}, a helpful conversational assistant.\n\n\
+    If asked what model powers you or who made you, decline — you're simply {name}; \
     never claim to be from Google, Gemini, OpenAI, or anyone else.\n\n\
     Each message is tagged with its sender as \"(NUMBER) Name:\" — NUMBER is the id, Name the \
     display name. Each turn ends with a \"=== SYSTEM GENERATED CONVERSATION METADATA FOOTER ===\" \
     block — authoritative context to read, never a message to answer — and it tells you the \
     username you go by in this chat: pay attention to it, since messages addressed to that id or \
-    name are meant for you (your true name is Terminal Alpha Beta). The footer also carries the \
+    name are meant for you (your true name is {name}). The footer also carries the \
     setting, the time, and tool usage.\n\n\
     GROUP CHAT: you're addressed when someone @mentions your id — match the id, not the name. \
     Default to silence: reply only when addressed, or rarely when you genuinely add something — \
@@ -40,6 +40,9 @@ const SYSTEM_PROMPT: &str = "You are Terminal Alpha Beta, a helpful conversation
     A [Followup] message arrived while you were busy — people see only your replies, not tool \
     calls — so build on what you already produced; in a group, first judge whether it's aimed at \
     you, else `[EMPTY]`.";
+
+static SYSTEM_PROMPT: LazyLock<String> =
+    LazyLock::new(|| SYSTEM_PROMPT_TEMPLATE.replace("{name}", crate::BOT_NAME));
 
 const TEMPERATURE: f32 = 1.0;
 
@@ -67,7 +70,7 @@ impl PrimaryRole {
 
 impl Role for PrimaryRole {
     fn system_prompt(&self) -> &str {
-        SYSTEM_PROMPT
+        &SYSTEM_PROMPT
     }
 
     fn temperature(&self) -> f32 {

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -75,6 +75,32 @@ struct EditFileArgs {
 }
 
 #[derive(Debug, Deserialize)]
+struct UseSkillArgs {
+    #[serde(default)]
+    skill: Option<String>,
+}
+
+fn normalize_skill_name(raw: &str) -> Option<String> {
+    let unquoted = raw
+        .trim()
+        .trim_matches(|c| c == '"' || c == '\'' || c == '`')
+        .trim();
+    let base = unquoted.strip_suffix(".md").unwrap_or(unquoted).trim();
+    (!base.is_empty()).then(|| base.to_string())
+}
+
+fn parse_use_skill(arguments: &str) -> Option<String> {
+    let raw = arguments.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    match serde_json::from_str::<UseSkillArgs>(raw) {
+        Ok(args) => args.skill.as_deref().and_then(normalize_skill_name),
+        Err(_) => normalize_skill_name(raw),
+    }
+}
+
+#[derive(Debug, Deserialize)]
 struct SetReminderArgs {
     #[serde(deserialize_with = "de_lenient_number")]
     delay_seconds: i64,
@@ -97,6 +123,7 @@ impl ToolKind {
             ToolKind::ViewImage => "view_image",
             ToolKind::ReadFile => "read_file",
             ToolKind::EditFile => "edit_file",
+            ToolKind::UseSkill => "use_skill",
             ToolKind::SetReminder => "set_reminder",
             ToolKind::MetaNoOpExtraTurn => "meta_no_op_extra_turn",
             ToolKind::MetaMalformed => "meta_malformed_tool_call",
@@ -178,6 +205,16 @@ impl ToolKind {
                         "new_string": { "type": "string", "description": "The text to put in its place. Use an empty string to delete the matched text." }
                     },
                     "required": ["path", "old_string", "new_string"]
+                }),
+            ),
+            ToolKind::UseSkill => (
+                "Consult your skill library — short reference guides for specific tasks (e.g. converting document formats). Call it with NO arguments to list every available skill by name. Call it with a skill's name to read that skill's full contents, and follow them before attempting the task it covers. Check here first when a task looks like it might have a skill.",
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "skill": { "type": "string", "description": "The name of the skill to read, exactly as shown in the no-argument listing, e.g. \"document_conversion\". The .md extension, surrounding quotes, and extra spaces are all optional. Omit this field entirely to list all available skills instead of reading one." }
+                    },
+                    "required": []
                 }),
             ),
             ToolKind::SetReminder => (
@@ -269,6 +306,11 @@ impl ToolType {
             ]
             .into_iter()
             .collect(),
+            ToolType::UseSkill { skill } => skill
+                .as_ref()
+                .map(|s| ("skill".to_string(), json!(s)))
+                .into_iter()
+                .collect(),
             ToolType::MetaNoOpExtraTurn => Map::new(),
             ToolType::MetaMalformed { .. } => Map::new(),
         }
@@ -309,6 +351,9 @@ impl ToolType {
                     new_string: args.new_string,
                 })
             }
+            ToolKind::UseSkill => Ok(ToolType::UseSkill {
+                skill: parse_use_skill(arguments),
+            }),
             ToolKind::SetReminder => {
                 let args = parse_args::<SetReminderArgs>(name, arguments)?;
                 Ok(ToolType::SetReminder {
@@ -374,6 +419,37 @@ mod tests {
             absent,
             ToolType::ReadFile { offset: None, limit: None, .. }
         ));
+    }
+
+    #[test]
+    fn use_skill_lists_when_no_argument() {
+        for args in ["", "{}", r#"{"skill":""}"#, r#"{"skill":"   "}"#, r#"{"skill":null}"#] {
+            assert!(
+                matches!(ToolType::bind("use_skill", args), Ok(ToolType::UseSkill { skill: None })),
+                "args {args:?} should list (skill: None)"
+            );
+        }
+    }
+
+    #[test]
+    fn use_skill_parses_leniently() {
+        let expected = "document_conversion";
+        for raw in [
+            "document_conversion",
+            "document_conversion.md",
+            "  document_conversion  ",
+            "\"document_conversion\"",
+            "'document_conversion.md'",
+            "  \"document_conversion.md\" ",
+        ] {
+            let args = serde_json::json!({ "skill": raw }).to_string();
+            match ToolType::bind("use_skill", &args) {
+                Ok(ToolType::UseSkill { skill: Some(name) }) => {
+                    assert_eq!(name, expected, "raw {raw:?} should normalize to {expected}")
+                }
+                other => panic!("raw {raw:?} did not parse: {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -295,6 +295,11 @@ impl ToolType {
             ]
             .into_iter()
             .collect(),
+            ToolType::UseSkill { skill } => skill
+                .as_ref()
+                .map(|s| ("skill".to_string(), json!(s)))
+                .into_iter()
+                .collect(),
             ToolType::SetReminder {
                 delay_seconds,
                 note,
@@ -306,11 +311,6 @@ impl ToolType {
             ]
             .into_iter()
             .collect(),
-            ToolType::UseSkill { skill } => skill
-                .as_ref()
-                .map(|s| ("skill".to_string(), json!(s)))
-                .into_iter()
-                .collect(),
             ToolType::MetaNoOpExtraTurn => Map::new(),
             ToolType::MetaMalformed { .. } => Map::new(),
         }

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -208,7 +208,7 @@ impl ToolKind {
                 }),
             ),
             ToolKind::UseSkill => (
-                "Consult your skill library — short reference guides for specific tasks (e.g. converting document formats). Call it with NO arguments to list every available skill by name. Call it with a skill's name to read that skill's full contents, and follow them before attempting the task it covers. Check here first when a task looks like it might have a skill.",
+                "Consult your skill library — short reference guides for specific tasks (e.g. converting document formats). Call it with NO arguments to list the available skills by name; call it with a skill's name to read that skill in full and follow it. You can't tell what's there without looking, so before a non-trivial or specialized task it's worth a quick listing to see if a skill applies.",
                 json!({
                     "type": "object",
                     "properties": {

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -333,6 +333,9 @@ pub enum ToolType {
         old_string: String,
         new_string: String,
     },
+    UseSkill {
+        skill: Option<String>,
+    },
     SetReminder {
         delay_seconds: i64,
         note: String,
@@ -353,6 +356,7 @@ impl ToolType {
             ToolType::ViewImage { .. }
             | ToolType::ReadFile { .. }
             | ToolType::EditFile { .. }
+            | ToolType::UseSkill { .. }
             | ToolType::SetReminder { .. }
             | ToolType::MetaNoOpExtraTurn
             | ToolType::MetaMalformed { .. } => 30_000,


### PR DESCRIPTION
Three small incremental updates, batched.

## 1. Persona rename → "A2"
The hardcoded "true name" ("Terminal Alpha Beta") is renamed to **A2** and centralized into a single `crate::BOT_NAME` const:
- `primary_role.rs` system prompt is now a `{name}` template resolved once via `LazyLock`.
- `llama_cpp_external.rs` footer + docs reference the const.
- Next rename is a one-line change.

The **Discord display name** is read live from the API (`get_current_user().global_name`), so it's renamed on Discord's side (already done) — not in code.

## 2. Self-managed SearxNG
The bot now brings up and **recovers its own `bot-searxng` container the same way it manages the bash sandbox**:
- Derived image `bot-searxng:latest` = `searxng/searxng` + a baked `settings.yml` (JSON format enabled, `limiter: false`, build-time-random `secret_key`), built from a staged `/app/searxng` context.
- `ensure_searxng()` runs before every `web_search` and at startup: inspect → start → `rm -f` + respawn. Runs with `--restart unless-stopped`.
- **Fail-safe layers:** restart policy (crash/daemon-restart) + recover-on-use (deletion/manual-stop) + startup ensure + baked config (no external volume to lose). An accidental `docker rm`/stop of `bot-searxng` self-heals without touching the bot.
- A non-localhost `SEARXNG_URL` is left **unmanaged** (remote instances still work).
- Shared docker primitives (`docker`/`is_running`/`ensure_image`/`revive_if_present`) extracted into `externals/container.rs` and reused by the worker — no duplicated ensure-dance.

Verified end-to-end locally: image builds, JSON endpoint returns 200 + valid JSON, secret injected, entrypoint keeps our baked settings and drops privileges at runtime.

## 3. `use_skill` tool
Skills are markdown reference guides checked into `chatbot/skills/` and copied to `/app/skills`:
- **No args** → lists the *actual* skill files present (dynamic, sorted).
- **With a name** → reads that skill's full content. Path-traversal guarded.
- **Lenient parsing:** surrounding quotes (`"`/`'`/`` ` ``), extra spaces, and an optional `.md` are all stripped; empty/`{}`/missing/`null` → list. Two new tests cover it.
- First skill: `document_conversion.md`.

## Testing
`cargo build` + `cargo clippy` clean; tool tests green (incl. the two new `use_skill` lenient-parse tests). The one failing test (`test_fetch_url_content_real`) is a live-network `visit_url` test, unrelated. `.dockerignore`'s `*.md` verified to match root-level only, so nested skill `.md` files survive the build context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)