### PR TITLE
chatbot: explicit mobi skill, static skill list, pandoc in sandbox

### DIFF
--- a/chatbot/Dockerfile.worker
+++ b/chatbot/Dockerfile.worker
@@ -11,11 +11,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash coreutils ca-certificates curl wget git jq file unzip zip procps \
     python3 python3-pip python3-venv \
     imagemagick fonts-dejavu fonts-liberation \
+    pandoc \
     nodejs npm \
     libgbm1 libnss3 libatk-bridge2.0-0 libxcomposite1 libcups2 libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests
+RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc
 
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet \

--- a/chatbot/skills/document_conversion.md
+++ b/chatbot/skills/document_conversion.md
@@ -1,7 +1,14 @@
 # Document Conversion
 
 ## MOBI to EPUB
-Use `mobi` library: `pip install mobi` then `mobi.extract("file.mobi")`. Handles conversion in one step. More reliable than calibre's `ebook-convert`.
+Use the `mobi` library's `extract()` function — one step, more reliable than calibre's `ebook-convert`. `pip install mobi`, then:
+```python
+import mobi
+tempdir, filepath = mobi.extract("book.mobi")
+# extract() returns (tempdir, filepath); filepath is the unpacked EPUB inside tempdir
+import shutil
+shutil.copy(filepath, "book.epub")
+```
 
 ## PDF to Text
 `pip install PyMuPDF` (fast, general) or `pip install pdfplumber` (better for tables).

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -208,7 +208,7 @@ impl ToolKind {
                 }),
             ),
             ToolKind::UseSkill => (
-                "Consult your skill library — short reference guides for specific tasks (e.g. converting document formats). Call it with NO arguments to list the available skills by name; call it with a skill's name to read that skill in full and follow it. You can't tell what's there without looking, so before a non-trivial or specialized task it's worth a quick listing to see if a skill applies.",
+                "Consult your skill library — short reference guides for specific tasks. Available skills: `document_conversion` (converting between document/ebook formats — MOBI, EPUB, PDF, DOCX and more, with the right tool for each). Call it with a skill's name to read that skill in full and follow it, or with NO arguments to list every skill. Use the relevant skill before attempting a task it covers.",
                 json!({
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Three small changes (one PR as requested).

1. **`document_conversion` skill** — MOBI→EPUB now spells out `mobi.extract()` with a concrete `tempdir, filepath = mobi.extract("book.mobi")` example (returns a tuple; `filepath` is the unpacked EPUB), instead of a one-line mention the model glossed over.

2. **`use_skill` description** — statically lists the available skill (`document_conversion`, with its format coverage) so the model can see a relevant skill exists *without* having to list first. Static by design (update the string when skills are added).

3. **Sandbox gets pandoc + pypandoc by default** — added `pandoc` (apt) and `pypandoc` (pip) to `Dockerfile.worker`. Tested first in the live worker container: `pandoc 3.1.11.1`, `pypandoc.get_pandoc_version()` matches, `md→rst` conversion works.

`cargo build` clean.

> Note: the `bot-worker` image must be rebuilt to pick up pandoc — happens on the next deploy, or `docker rmi bot-worker:latest` to force a rebuild on next sandbox use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)