### PR TITLE
chatbot: tesseract OCR in sandbox, tool rounds 10->30

### DIFF
--- a/chatbot/Dockerfile.worker
+++ b/chatbot/Dockerfile.worker
@@ -11,12 +11,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash coreutils ca-certificates curl wget git jq file unzip zip procps \
     python3 python3-pip python3-venv \
     imagemagick fonts-dejavu fonts-liberation \
-    pandoc \
+    pandoc tesseract-ocr tesseract-ocr-eng \
     nodejs npm \
     libgbm1 libnss3 libatk-bridge2.0-0 libxcomposite1 libcups2 libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc
+RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc pytesseract
 
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet \

--- a/chatbot/src/types/conversation.rs
+++ b/chatbot/src/types/conversation.rs
@@ -9,7 +9,7 @@ use strum::{EnumDiscriminants, EnumIter};
 
 pub const MAX_SEARCH_DESCRIPTION_LENGTH: usize = 2000;
 
-pub const MAX_TOOL_ROUNDS: usize = 10;
+pub const MAX_TOOL_ROUNDS: usize = 30;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Platform {


### PR DESCRIPTION
Two small tweaks.

1. **Sandbox gets Tesseract OCR** — `tesseract-ocr` + `tesseract-ocr-eng` (apt) and `pytesseract` (pip) added to `Dockerfile.worker`. Verified in the worker image first: `tesseract 5.5.0`, `pytesseract` OCRs a generated test image.
2. **`MAX_TOOL_ROUNDS` 10 → 30** — more tool turns per reply.

`cargo build` clean.

> Note: the `bot-worker` image must be rebuilt to pick up tesseract (next deploy, or `docker rmi bot-worker:latest`). The tool-rounds change needs a bot redeploy.