### PR TITLE
ci: CD workflow — deploy on merge to main (self-hosted runner)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,16 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - name: deploy on merge to main
+        run: /home/zireael9797/deploy/cd-deploy.sh


### PR DESCRIPTION
Adds `.github/workflows/deploy.yml` — the CD half of a self-hosted-runner pipeline.

- **Trigger:** `push` to `main` only (a merge). **No `pull_request`** — critical because this is a public repo and the runner is self-hosted; a fork-PR trigger would let untrusted code execute on the deploy machine.
- **Runs on:** `self-hosted` (this box).
- **Action:** runs `/home/zireael9797/deploy/cd-deploy.sh`, which pulls `~/deploy/bot` to `origin/main`, force-rebuilds `bot-worker` only if `Dockerfile.worker` changed, and runs `just deploy_local`. No `actions/checkout` — the gitignored `configuration.rs` secrets live only in the on-box clone.
- **`concurrency: deploy`** serializes overlapping deploys.

On-box pieces already in place: `~/deploy/bot` (dedicated deploy clone + secrets) and `~/deploy/cd-deploy.sh`.

**Remaining (needs your GitHub token + sudo):** register the self-hosted runner (Settings → Actions → Runners → New self-hosted runner) and `sudo ./svc.sh install && ./svc.sh start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)