### PR TITLE
chatbot: expand bash sandbox (ffmpeg, yt-dlp, PDF/Office, HTML parsing, shell tools)

### DIFF
--- a/chatbot/Dockerfile.worker
+++ b/chatbot/Dockerfile.worker
@@ -10,13 +10,13 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1 \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash coreutils ca-certificates curl wget git jq file unzip zip procps \
     python3 python3-pip python3-venv \
-    imagemagick fonts-dejavu fonts-liberation \
+    imagemagick ffmpeg fonts-dejavu fonts-liberation \
     pandoc tesseract-ocr tesseract-ocr-eng \
     nodejs npm \
     libgbm1 libnss3 libatk-bridge2.0-0 libxcomposite1 libcups2 libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc pytesseract
+RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc pytesseract yt-dlp
 
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet \

--- a/chatbot/Dockerfile.worker
+++ b/chatbot/Dockerfile.worker
@@ -11,12 +11,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash coreutils ca-certificates curl wget git jq file unzip zip procps \
     python3 python3-pip python3-venv \
     imagemagick ffmpeg fonts-dejavu fonts-liberation \
-    pandoc tesseract-ocr tesseract-ocr-eng \
+    pandoc poppler-utils tesseract-ocr tesseract-ocr-eng \
+    ripgrep sqlite3 p7zip-full xz-utils tree \
     nodejs npm \
     libgbm1 libnss3 libatk-bridge2.0-0 libxcomposite1 libcups2 libicu-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc pytesseract yt-dlp
+RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc pytesseract yt-dlp \
+    PyMuPDF pdfplumber python-docx openpyxl python-pptx beautifulsoup4 lxml
 
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet \


### PR DESCRIPTION
Expands the bash sandbox's default toolset. All verified to install + import in the worker image before committing.

**apt:** ffmpeg, poppler-utils, ripgrep, sqlite3, p7zip-full, xz-utils, tree
**pip:** yt-dlp, PyMuPDF, pdfplumber, python-docx, openpyxl, python-pptx, beautifulsoup4, lxml

Audited against the already-installed tools to avoid duplicates/alternatives:
- **Dropped `bc`** — Python already covers arithmetic.
- Kept with intentional overlap: `ripgrep` (recursive/gitignore/fast vs base `grep`), `sqlite3` CLI (vs Python's `sqlite3` module), and the layered PDF trio `poppler-utils` / `PyMuPDF` / `pdfplumber` (CLI / general / tables) matching the `document_conversion` skill.

`Dockerfile.worker`-only change — on merge, CD detects it and force-rebuilds `bot-worker`.