### PR TITLE
chatbot: Rust toolchain in the bash sandbox (build the bot project)

### DIFF
--- a/chatbot/Dockerfile.worker
+++ b/chatbot/Dockerfile.worker
@@ -5,7 +5,8 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1 \
     DOTNET_ROOT=/usr/share/dotnet \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
     DOTNET_NOLOGO=1 \
-    PATH=/usr/share/dotnet:/root/.dotnet/tools:/usr/local/bin:/usr/bin:/bin
+    CARGO_BUILD_JOBS=4 \
+    PATH=/root/.cargo/bin:/usr/share/dotnet:/root/.dotnet/tools:/usr/local/bin:/usr/bin:/bin
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash coreutils ca-certificates curl wget git openssh-client jq file unzip zip procps \
@@ -15,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep sqlite3 p7zip-full xz-utils tree \
     nodejs npm \
     libgbm1 libnss3 libatk-bridge2.0-0 libxcomposite1 libcups2 libicu-dev \
+    pkg-config libssl-dev libclang-dev cmake build-essential libvulkan-dev glslc protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir numpy pandas matplotlib pillow requests pypandoc pytesseract yt-dlp \
@@ -26,6 +28,10 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly --profile minimal \
+    && rustup component add clippy rustfmt \
+    && rustup target add x86_64-unknown-linux-gnu
 
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && bash /tmp/dotnet-install.sh --channel 8.0 --install-dir /usr/share/dotnet \

--- a/chatbot/src/externals/bash_container_external.rs
+++ b/chatbot/src/externals/bash_container_external.rs
@@ -94,7 +94,7 @@ async fn spawn_worker(name: &str) -> Result<(), String> {
 
     let mut args: Vec<String> = [
         "run", "-d", "--name", name,
-        "--memory", "1g", "--cpus", "2", "--pids-limit", "512",
+        "--memory", "8g", "--cpus", "6", "--pids-limit", "512",
         "--security-opt", "no-new-privileges",
     ]
     .into_iter()


### PR DESCRIPTION
Lets the bot clone, edit, and **build the bot project itself** in its sandbox — the missing piece behind the earlier `cargo: command not found` wall during the jiff migration.

## Changes
**`Dockerfile.worker`**
- Rust **nightly** toolchain via rustup (cargo/rustc + **clippy** + **rustfmt**, `x86_64-unknown-linux-gnu` target).
- Native build deps matching the real builder image: `pkg-config`, `libssl-dev`, `libclang-dev` (libclang for bindgen), `cmake`, `build-essential`, `libvulkan-dev`, `glslc`, `protobuf-compiler`. (`git` already present.)
- `CARGO_BUILD_JOBS=4` + cargo on `PATH`.

**`bash_container_external.rs`**
- Per-sandbox limit `1g/2cpu` → **`8g/6cpu`** (your call) so a real build fits. `pids-limit` unchanged. `CARGO_BUILD_JOBS=4` caps parallelism (and, via `NUM_JOBS`, `llama-cpp-sys`'s cmake build) so a build can't exceed 8g on the 30g host shared with the model.

## Why these deps
`chatbot` depends on `llama-cpp-2` with `vulkan`+`mtmd` → building it compiles llama.cpp in C++ (needs cmake/clang/vulkan/glslc) and runs bindgen (needs libclang). The lighter members (`re_framework`, etc.) don't.

## Verified
Built the worker image and ran a full `cargo build -p chatbot` in a container **at the exact prod limits (8g/6cpu/jobs=4)**, source mounted:
- exit 0, `Finished dev profile in 4m 02s`, produced a **639 MB** binary (llama.cpp statically linked) — no OOM.
- Confirmed present: nightly cargo/rustc/clippy, cmake, `libprotoc`, shaderc/glslc, libclang (llvm-19), openssl + vulkan `.pc`.

## Deploy note
This changes `Dockerfile.worker`, so CD will rebuild the worker image and drop existing `botwork-*` containers (per `cd-deploy.sh`) — the toolchain lands on the next sandbox spawn.