### PR TITLE
Use Timestamp's Add/Sub for infallible deadline math

### DIFF
--- a/chatbot/src/state_machines/conversation_state_machine.rs
+++ b/chatbot/src/state_machines/conversation_state_machine.rs
@@ -711,17 +711,11 @@ fn conversation_schedule(conversation: &Conversation) -> Option<Scheduled<Conver
     match &conversation.state {
         ConversationState::Idle { .. } => None,
         ConversationState::AwaitingLLMDecision { .. } => Some(Scheduled {
-            at: conversation
-                .last_transition
-                .checked_add(SignedDuration::from_millis(LLM_TIMEOUT_MS))
-                .expect("millis should not overflow"),
+            at: conversation.last_transition + SignedDuration::from_millis(LLM_TIMEOUT_MS),
             action: ConversationAction::LLMDecisionResult(Err(InterruptionReason::TimedOut)),
         }),
         ConversationState::SendingMessage { .. } => Some(Scheduled {
-            at: conversation
-                .last_transition
-                .checked_add(SignedDuration::from_millis(SEND_TIMEOUT_MS))
-                .expect("millis should not overflow"),
+            at: conversation.last_transition + SignedDuration::from_millis(SEND_TIMEOUT_MS),
             action: ConversationAction::MessageSent(Err("timed out".to_string())),
         }),
         ConversationState::RunningTools { pending_tools, .. } => pending_tools

--- a/chatbot/src/state_machines/memory_manager_state_machine.rs
+++ b/chatbot/src/state_machines/memory_manager_state_machine.rs
@@ -67,10 +67,7 @@ impl StateMachine for MemoryManagerMachine {
         match &state.state {
             MemoryManagerState::Idle => None,
             MemoryManagerState::Compacting => Some(Scheduled {
-                at: state
-                    .last_transition
-                    .checked_add(SignedDuration::from_millis(COMPACT_TIMEOUT_MS))
-                    .expect("millis should not overflow"),
+                at: state.last_transition + SignedDuration::from_millis(COMPACT_TIMEOUT_MS),
                 action: MemoryManagerAction::CompactionDone(Err(InterruptionReason::TimedOut)),
             }),
         }

--- a/re_framework/src/smoke.rs
+++ b/re_framework/src/smoke.rs
@@ -70,11 +70,7 @@ impl StateMachine for CounterMachine {
     fn construct(init: CounterInit, _effects: &mut Effects<Self>) -> CounterState {
         CounterState {
             total: init.start,
-            tick_at: Some(
-                Timestamp::now()
-                    .checked_add(SignedDuration::from_millis(50))
-                    .expect("50 ms should be ok"),
-            ),
+            tick_at: Some(Timestamp::now() + SignedDuration::from_millis(50)),
         }
     }
 
@@ -207,11 +203,7 @@ impl StateMachine for PastDueMachine {
 
     fn construct(_init: PastDueInit, _effects: &mut Effects<Self>) -> PastDueState {
         PastDueState {
-            fire_at: Some(
-                Timestamp::now()
-                    .checked_sub(SignedDuration::from_secs(10))
-                    .expect("10 s in the past is representable"),
-            ),
+            fire_at: Some(Timestamp::now() - SignedDuration::from_secs(10)),
         }
     }
 

--- a/sample_framework_project/src/conversation.rs
+++ b/sample_framework_project/src/conversation.rs
@@ -106,10 +106,7 @@ impl StateMachine for ConversationMachine {
             Phase::Idle { reset_at: None } => None,
             Phase::AwaitingDecision | Phase::RunningTool { .. } | Phase::SendingReply => {
                 Some(Scheduled {
-                    at: state
-                        .phase_since
-                        .checked_add(SignedDuration::from_secs(RESCUE_SECS))
-                        .expect("secs should be fine"),
+                    at: state.phase_since + SignedDuration::from_secs(RESCUE_SECS),
                     action: ConversationAction::ForceReset,
                 })
             }
@@ -196,11 +193,7 @@ fn conversation_transition(
             turns: state.turns,
             history: state.history.clone(),
             phase: Phase::Idle {
-                reset_at: Some(
-                    Timestamp::now()
-                        .checked_add(SignedDuration::from_secs(IDLE_RESET_SECS))
-                        .expect("secs should be fine"),
-                ),
+                reset_at: Some(Timestamp::now() + SignedDuration::from_secs(IDLE_RESET_SECS)),
             },
             phase_since: Timestamp::now(),
         }),


### PR DESCRIPTION
Follow-up tidy from reviewing #232.

The jiff port spelled every deadline computation as `checked_add(..).expect(..)`, which reads as if it were guarding something. It isn't — jiff implements `Add`/`Sub<SignedDuration>` for `Timestamp` with exactly the same panic-on-overflow behaviour, so the `expect` buys nothing over the operator. chrono's `+` panicked on overflow too, so this also matches what the pre-jiff code did.

It was inconsistent as well: `conversation_schedule` had three sibling arms computing a deadline, two via `checked_add().expect()` and one via a bare `+`.

```rust
// before
at: conversation
    .last_transition
    .checked_add(SignedDuration::from_millis(LLM_TIMEOUT_MS))
    .expect("millis should not overflow"),

// after
at: conversation.last_transition + SignedDuration::from_millis(LLM_TIMEOUT_MS),
```

Seven sites across `chatbot`, `re_framework` and `sample_framework_project`. Net **-24 lines**, no behaviour change.

### Deliberately left alone

`validate_delay`'s `checked_add` stays. That one is a real guard — it turns overflow into a user-facing error string instead of a panic, and it's the one place a caller-supplied delay reaches the arithmetic.

### Verification

- `cargo test -p re_framework` — 7/7 pass, including `overdue_timer_fires_promptly`
- `cargo test -p sample_framework_project` — 6/6 pass
- `cargo check -p chatbot` — clean (4 pre-existing dead-code warnings in `configuration.rs`, untouched)
- New lines confirmed rustfmt-stable under `--edition 2024`

🤖 Generated with [Claude Code](https://claude.com/claude-code)