### PR TITLE
chatbot: expand skill library (download, large_tasks, form_filling)

### DIFF
--- a/chatbot/skills/download.md
+++ b/chatbot/skills/download.md
@@ -1,0 +1,39 @@
+# Downloading
+
+Pick by what you're fetching: **media → yt-dlp**, **a plain file you can identify → curl/wget**, **genuinely unsure → yt-dlp is the safe first guess**. `yt-dlp`, `ffmpeg`, `curl` and `wget` are all already installed.
+
+## Media (video, audio, anything streamable) — use yt-dlp
+
+**`yt-dlp` is your default for any media URL. Just throw the URL at it.** It handles a huge range of sites and formats implicitly — YouTube, Twitter/X, TikTok, Instagram, SoundCloud, Reddit, direct `.mp4`/`.m3u8`/`.mpd` links, and thousands more — figuring out the right extractor, resolving playlists, and merging video+audio for you.
+
+```bash
+yt-dlp "URL"                          # best quality, auto format
+yt-dlp -f "bestvideo+bestaudio/best" "URL"
+yt-dlp -x --audio-format mp3 "URL"    # audio only, extract to mp3
+yt-dlp -o "%(title)s.%(ext)s" "URL"   # clean output filename
+```
+
+Useful flags:
+- `--list-formats` (`-F`) — see what's available before picking.
+- `-f "b[height<=720]"` — cap resolution.
+- `--playlist-items 1-5` — grab part of a playlist.
+- `--cookies-from-browser firefox` — for content behind a login.
+- `--write-sub --sub-lang en` — subtitles.
+
+If a plain `yt-dlp URL` fails, update it first (`pip install -U yt-dlp`) — sites change and the newest version usually already has the fix — then retry with `-F` to inspect formats.
+
+## Plain files (documents, archives, images, anything non-media)
+
+If you already know it's a regular file — a PDF, image, zip, JSON, release binary, etc. — don't bother with yt-dlp; just grab it directly:
+
+```bash
+curl -L -o out.ext "URL"    # -L follows redirects
+wget -O out.ext "URL"
+```
+
+- `-L` / redirects matter — many download links bounce through redirects.
+- For large files, `wget -c` / `curl -C -` resume a partial download.
+
+## Not sure what the URL is?
+
+Then yt-dlp is the safe first shot — it covers far more than it looks like it should, and reports cleanly when a link has no extractable media. If it says there's nothing to extract, fall back to `curl -L`.

--- a/chatbot/skills/form_filling.md
+++ b/chatbot/skills/form_filling.md
@@ -1,0 +1,63 @@
+# Form Filling
+
+For filling a **flat** PDF (or image) form — one with no interactive form fields, just a printed layout — by stamping text onto it at coordinates. The tool is **PyMuPDF** (`import fitz`), already installed. (If a PDF *does* have real interactive fields, use those instead: `page.widgets()` / `widget.field_value`. This skill is for the common case where it doesn't.)
+
+The entire job is finding the right `(x, y)` for each field. Do it **empirically** with a render-and-look loop — never guess all coordinates blind and fill in one shot.
+
+## Process
+
+### 1. Look at the form first
+Rasterize the page to a PNG and actually view it before doing anything:
+```python
+import fitz
+doc = fitz.open("form.pdf")
+doc[0].get_pixmap(dpi=150).save("page.png")   # then open and look at page.png
+```
+Coordinates you'll write are in **PDF points** (72 per inch), not image pixels. Handy trick: also render one at `dpi=72` — then 1 image pixel ≈ 1 PDF point, so an `(x, y)` you eyeball in that PNG maps almost directly to the number you pass to `insert_text`. (Read small text off the 150-dpi render; estimate coordinates off the 72-dpi one.)
+
+### 2. List the fields
+Enumerate every spot that needs input — give each a short `field_id`, its human label, and roughly where it sits. Write this list down first. You're **mapping** the form here, not filling it.
+
+### 3. Locate each field by trial and error
+For each field, stamp a **placeholder value** (e.g. the field's own name) at a best-guess `(x, y)`, render, and look. Nudge `x`/`y`/`fontsize` until it lands cleanly inside the right box.
+```python
+page.insert_text((x, y), "SAMPLE", fontsize=9.5, fontname="helv", color=(0, 0, 0))
+```
+`insert_text` anchors at the text **baseline**; the page origin is top-left with `y` growing downward. Don't overthink the coordinate math — the look-and-adjust loop converges in a couple of tries.
+
+### 4. Build a coordinates JSON as you go
+Persist each solved field the moment it's right, so progress survives a context reset. Keep it in your workspace (`/work/coordinates.json`):
+```json
+{
+  "page_index": 0,
+  "fields": [
+    { "field_id": "full_name", "label": "Full name", "x": 214, "y": 225, "fontsize": 9.5, "fontname": "helv" }
+  ]
+}
+```
+Note this holds only **locations**, not values yet.
+
+### 5. Verify each field before moving to the next
+After placing a field, re-render and confirm **that** field sits correctly before starting the next one. Strictly one at a time — a pile of unverified coordinates is a pile of mistakes you'll have to untangle later.
+
+### 6. Ask the user for the real values LAST
+Only once **every** field's location is nailed down, ask the user for the actual values — all at once, as a checklist of the labels you discovered. Drop the values into the JSON, render each into place (still verifying), and save the final PDF:
+```python
+doc.save("/work/filled.pdf")
+```
+
+## Checkboxes and marks
+No text — draw the mark inside the box:
+```python
+r = fitz.Rect(x0, y0, x1, y1)              # the checkbox bounds
+page.draw_line((r.x0, r.y0), (r.x1, r.y1))  # an X
+page.draw_line((r.x1, r.y0), (r.x0, r.y1))
+```
+Or just `insert_text` an `"X"` / `"✓"` at the box.
+
+## Tips
+- `fontname`: `"helv"` (Helvetica), `"helvB"` (bold), `"cour"` (mono).
+- `color`: `(0,0,0)` black; many forms are filled in blue `(0,0,1)`.
+- Text colliding with the pre-printed label → nudge `y` or lower `fontsize`.
+- Long values overflowing a field → shrink `fontsize`, or split across lines with a second `insert_text`.
+- Multi-page forms → repeat per page via `doc[page_index]`.

--- a/chatbot/skills/large_tasks.md
+++ b/chatbot/skills/large_tasks.md
@@ -1,0 +1,42 @@
+# Large Tasks
+
+For any task big enough that you can't hold the whole thing in your head at once — a multi-file feature, a refactor, a migration, an involved bug hunt. Don't dive straight into editing. Work the loop below.
+
+## 1. Decompose and write the plan down
+
+Before touching anything, break the work into a short sequence of small, individually verifiable steps. Then **write that plan to a file** so it survives — your context can get compacted mid-task and an in-your-head plan is lost when it does.
+
+Write it to **`/work/PLAN.md`** (your workspace is `/work`). Keep it a living document:
+
+```markdown
+# <task in one line>
+
+## Goal
+<what "done" looks like, concretely>
+
+## Steps
+- [ ] 1. <small step> — verify: <how you'll know it worked>
+- [ ] 2. ...
+
+## Open questions
+- <anything you're unsure about>
+
+## Notes
+- <decisions made, dead ends, things learned>
+```
+
+Re-read `/work/PLAN.md` whenever you resume or feel lost. Tick boxes as you finish steps and add notes as you learn — future-you (possibly after a context reset) relies on it.
+
+## 2. Verify as you go
+
+Do **one step at a time** and confirm it worked before starting the next — build it, run it, test it, print the output. Don't batch a pile of unverified edits and hope they compose; a regression caught at step 2 is cheap, the same regression discovered at step 9 is not. If a step's verification fails, fix it before moving on, and note what went wrong in the plan.
+
+## 3. Know when to stop and ask
+
+Plans meet reality. Stop and check in with the user — rather than guessing — when:
+- a genuine ambiguity or design fork appears that changes the outcome,
+- the work turns out much larger or different than expected,
+- you'd have to make an irreversible or hard-to-undo change,
+- or you're blocked and your fixes aren't landing.
+
+A short "here's what I found, here's the fork, which way?" beats charging ahead on a wrong assumption and redoing it. Surfacing uncertainty early is the sign of doing this well, not badly.

--- a/chatbot/src/tools.rs
+++ b/chatbot/src/tools.rs
@@ -233,7 +233,7 @@ impl ToolKind {
                 }),
             ),
             ToolKind::UseSkill => (
-                "Consult your skill library — short reference guides for specific tasks. Available skills: `document_conversion` (converting between document/ebook formats — MOBI, EPUB, PDF, DOCX and more, with the right tool for each). Call it with a skill's name to read that skill in full and follow it, or with NO arguments to list every skill. Use the relevant skill before attempting a task it covers.",
+                "Consult your skill library — short reference guides for specific tasks. Skills cover things like document processing (pdf, ebook, md, docx), downloading (media, documents, other), and large tasks (programming, multi-step flows), among others. Call it with NO arguments to list every available skill, or with a skill's name to read that one in full and follow it. Check here before attempting a task a skill might cover.",
                 json!({
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Adds three skills to the bot's skill library and reworks the `use_skill` catalog blurb.

## New skills

**`download`** — `yt-dlp` as the default for any media URL or genuinely-unknown link (it handles thousands of sites/formats implicitly, resolves playlists, merges video+audio). `curl`/`wget` for files you can already identify (PDF, zip, image, release binary). Deliberately *not* pushed at every download — only media and the unknown.

**`large_tasks`** — for work too big to hold in your head (multi-file features, refactors, migrations, involved bug hunts). Decompose first and **write the plan to `/work/PLAN.md`** as a living document that survives context compaction; verify each step before the next; stop and ask the user on a genuine design fork or scope blow-up.

**`form_filling`** — generalized from a one-off PDF-filling toolkit into a reusable process for flat (non-interactive) PDF forms via PyMuPDF: rasterize and look, list the fields, trial-and-error each coordinate with placeholder values, build `coordinates.json` as you go, verify each field, and ask the user for the real values only once every location is nailed down.

## Catalog blurb

The `use_skill` description now lists **concepts** (document processing, downloading, large tasks) rather than one hard-coded per-skill entry. The no-arg listing is the source of truth, so adding a skill no longer means hand-syncing a blurb here.

## Deps

Everything the skills invoke — `yt-dlp`, `ffmpeg`, `curl`, `wget`, `PyMuPDF` — is already baked into `Dockerfile.worker`. No worker-image rebuild required.

## Verification

- `cargo test -p chatbot` — 23/23 relevant pass (incl. `use_skill_parses_leniently`, `use_skill_lists_when_no_argument`). The one failure, `test_fetch_url_content_real`, is a pre-existing network test (fetches real example.com) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)