### PR TITLE
chatbot: restrict tool-call narration to rare, informative moments

### DIFF
--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -78,7 +78,7 @@ fn session_footer(
         "If a tool or the user contradicts your memory, your memory is likely wrong — verify with a tool when you can, then carry on with the corrected info; don't just agree or defend a wrong prior.".to_string(),
     );
     lines.push(
-        "If you already have something worth sharing — a partial answer, or what you're about to do — say it right after your thinking and before the tool call, instead of calling silently.".to_string(),
+        "Only narrate before a tool call when there's genuinely new information to share (e.g. why you're trying something unusual or what you learned). Hold off for at least 5 tool calls in a row before adding commentary, and keep it brief."
     );
     lines.push(
         "The user cannot see tool results — you must send the information as a message."

--- a/chatbot/src/externals/llama_cpp_external.rs
+++ b/chatbot/src/externals/llama_cpp_external.rs
@@ -79,6 +79,7 @@ fn session_footer(
     );
     lines.push(
         "Only narrate before a tool call when there's genuinely new information to share (e.g. why you're trying something unusual or what you learned). Hold off for at least 5 tool calls in a row before adding commentary, and keep it brief."
+            .to_string(),
     );
     lines.push(
         "The user cannot see tool results — you must send the information as a message."


### PR DESCRIPTION
## Summary

Changed the system prompt instruction for tool-call narration in `chatbot/src/externals/llama_cpp_external.rs` (line 81).

### Before

The bot was instructed to narrate before tool calls whenever it had something worth sharing — a partial answer or what it was about to do.

### After

The bot is now instructed to:
- Only narrate before a tool call when there's genuinely new information to share (e.g. explaining why it's trying something unusual or what it learned).
- Wait for at least 5 sequential tool calls before adding commentary.
- Keep commentary brief.

### Rationale

This reduces excessive narration that clutters the chat during routine multi-step tool usage, keeping the conversation cleaner and more focused on actual insights.